### PR TITLE
Make large transcript restoration near-instant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
  "png",
  "pulldown-cmark",
  "ratatui",
+ "rayon",
  "reqwest 0.12.28",
  "rstest",
  "self-replace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rayon = "1.12.0"
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"] }
 self-replace = "1.5.0"
 semver = { version = "1.0.28", features = ["serde"] }
-serde = { version = "1.0.229", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive", "rc"] }
 serde_json = { version = "1.0.151", features = ["raw_value"] }
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nanocodex-core = { version = "0.1.1", git = "https://github.com/gakonst/nanocode
 pulldown-cmark = { version = "0.13.4", default-features = false }
 png = "0.18.1"
 ratatui = "0.30.2"
+rayon = "1.12.0"
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"] }
 self-replace = "1.5.0"
 semver = { version = "1.0.28", features = ["serde"] }

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -148,6 +148,10 @@ impl PersistenceFixture {
     fn load_transcript_parallel(&self) -> Vec<Arc<TranscriptRecord>> {
         session::load_transcript_parallel(&self.config_path, &self.session_id).unwrap()
     }
+
+    fn list_parallel(&self) -> Vec<session::SessionSummary> {
+        session::list_parallel(&self.config_path, &self.workspace).unwrap()
+    }
 }
 
 fn mixed_projection_records(turns: u64) -> Vec<Arc<TranscriptRecord>> {
@@ -651,6 +655,10 @@ fn benchmarks(criterion: &mut Criterion) {
         bencher.iter(|| {
             black_box(session::list(&fixture.config_path, &fixture.workspace).unwrap());
         });
+    });
+
+    sessions.bench_function("catalog_api_heavy_archive_parallel", |bencher| {
+        bencher.iter(|| black_box(fixture.list_parallel()));
     });
 
     sessions.bench_function("load_known_api_heavy_transcript", |bencher| {

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -685,7 +685,6 @@ fn benchmarks(criterion: &mut Criterion) {
             BatchSize::LargeInput,
         );
     });
-
     sessions.bench_function("project_api_heavy_transcript", |bencher| {
         bencher.iter_batched(
             || {

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -145,6 +145,9 @@ impl PersistenceFixture {
             Err(error) => panic!("failed to clear projection cache: {error}"),
         }
     }
+    fn load_transcript_parallel(&self) -> Vec<Arc<TranscriptRecord>> {
+        session::load_transcript_parallel(&self.config_path, &self.session_id).unwrap()
+    }
 }
 
 fn mixed_projection_records(turns: u64) -> Vec<Arc<TranscriptRecord>> {
@@ -664,6 +667,10 @@ fn benchmarks(criterion: &mut Criterion) {
 
     sessions.bench_function("load_known_multi_segment_transcript", |bencher| {
         bencher.iter(|| black_box(multi_segment_fixture.load_transcript()));
+    });
+
+    sessions.bench_function("load_known_multi_segment_transcript_parallel", |bencher| {
+        bencher.iter(|| black_box(multi_segment_fixture.load_transcript_parallel()));
     });
 
     sessions.bench_function("load_known_multi_segment_transcript_cold", |bencher| {

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -635,7 +635,6 @@ fn benchmarks(criterion: &mut Criterion) {
             BatchSize::SmallInput,
         );
     });
-
     let fixture = PersistenceFixture::api_heavy_archive();
     let multi_segment_fixture = PersistenceFixture::multi_segment_archive();
     let mixed_fixture = PersistenceFixture::mixed_archive();

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -690,6 +690,17 @@ fn benchmarks(criterion: &mut Criterion) {
         );
     });
 
+    sessions.bench_function(
+        "load_known_multi_segment_transcript_parallel_cold",
+        |bencher| {
+            bencher.iter_batched(
+                || multi_segment_fixture.clear_projection_cache(),
+                |()| black_box(multi_segment_fixture.load_transcript_parallel()),
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
     sessions.bench_function("load_mixed_transcript", |bencher| {
         bencher.iter(|| black_box(mixed_fixture.load_transcript()));
     });
@@ -701,6 +712,7 @@ fn benchmarks(criterion: &mut Criterion) {
             BatchSize::LargeInput,
         );
     });
+
     sessions.bench_function("project_api_heavy_transcript", |bencher| {
         bencher.iter_batched(
             || {

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -145,6 +145,7 @@ impl PersistenceFixture {
             Err(error) => panic!("failed to clear projection cache: {error}"),
         }
     }
+
     fn load_transcript_parallel(&self) -> Vec<Arc<TranscriptRecord>> {
         session::load_transcript_parallel(&self.config_path, &self.session_id).unwrap()
     }
@@ -761,7 +762,6 @@ fn benchmarks(criterion: &mut Criterion) {
             black_box(root);
         });
     });
-
     sessions.bench_function("resume_api_heavy_transcript_cold", |bencher| {
         bencher.iter_batched(
             || fixture.clear_projection_cache(),

--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -3,13 +3,11 @@
 use arboard::Clipboard;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use png::{BitDepth, ColorType, Encoder, EncodingError};
-
 #[cfg(target_os = "macos")]
 use std::{
     io::{self, Write},
     process::{Command, ExitStatus, Stdio},
 };
-
 #[cfg(target_os = "macos")]
 use thiserror::Error;
 
@@ -119,10 +117,9 @@ fn encode_png(width: usize, height: usize, pixels: &[u8]) -> Result<Vec<u8>, Enc
 
 #[cfg(test)]
 mod tests {
-    use super::encode_png;
-
     #[cfg(target_os = "macos")]
     use super::copy_with_pbcopy;
+    use super::encode_png;
 
     #[test]
     fn clipboard_pixels_are_encoded_as_png() {

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -9,7 +9,6 @@ use crate::{
     config::{ReasoningEffort, ReasoningMode},
     subagents::AgentUpdate,
     tui::{
-        context::completed_transcript_tokens,
         pane::PaneId,
         session::SessionSummary,
         theme::{ColorScheme, Theme, ThemeMode},
@@ -161,14 +160,7 @@ impl AppNode {
                 self.update_root(self.focus, RootEvent::PasteImage(data_url))
             }
             AppEvent::Transcript { pane, record } => {
-                let tokens = completed_transcript_tokens(&record);
-                let mut update = self.update_root(pane, RootEvent::Transcript(record));
-                if let Some(tokens) = tokens {
-                    let context = self.update_root(pane, RootEvent::ContextTokens(tokens));
-                    update.effects.extend(context.effects);
-                    update.render = update.render.max(context.render);
-                }
-                update
+                self.update_root(pane, RootEvent::Transcript(record))
             }
             AppEvent::AgentStreamClosed(pane) => {
                 self.update_root(pane, RootEvent::AgentStreamClosed)

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -3,7 +3,7 @@
 use super::{
     node::{ComponentUpdate, Node, RenderRequest},
     queue::QueueId,
-    root::{RootEffect, RootEvent, RootNode},
+    root::{RestoredSessionProjection, RootEffect, RootEvent, RootNode},
 };
 use crate::{
     config::{ReasoningEffort, ReasoningMode},
@@ -90,7 +90,7 @@ pub(crate) enum AppEvent {
     },
     SessionRestored {
         pane: PaneId,
-        records: Vec<Arc<TranscriptRecord>>,
+        projection: RestoredSessionProjection,
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
@@ -231,7 +231,7 @@ impl AppNode {
             }
             AppEvent::SessionRestored {
                 pane,
-                records,
+                projection,
                 effort,
                 reasoning_mode,
                 preferred_reasoning_mode,
@@ -239,7 +239,7 @@ impl AppNode {
             } => self.update_root(
                 pane,
                 RootEvent::SessionRestored {
-                    records,
+                    projection,
                     effort,
                     reasoning_mode,
                     preferred_reasoning_mode,

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -90,7 +90,7 @@ pub(crate) enum AppEvent {
     },
     SessionRestored {
         pane: PaneId,
-        projection: RestoredSessionProjection,
+        projection: Box<RestoredSessionProjection>,
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -21,4 +21,4 @@ mod waved_text;
 pub(crate) use app::{AppEffect, AppEvent, AppNode};
 pub(crate) use node::{ComponentUpdate, RenderRequest};
 pub(crate) use queue::QueueId;
-pub(crate) use root::{RootEffect, RootNode};
+pub(crate) use root::{RestoredSessionProjection, RootEffect, RootNode};

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -101,7 +101,7 @@ pub(crate) enum RootEvent {
     SessionsLoaded(Vec<SessionSummary>),
     SessionLoadFailed(String),
     SessionRestored {
-        projection: RestoredSessionProjection,
+        projection: Box<RestoredSessionProjection>,
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
@@ -1468,7 +1468,7 @@ impl Component for RootNode {
                     reasoning_mode,
                     preferred_reasoning_mode,
                     fast_mode,
-                    projection,
+                    *projection,
                 );
                 ComponentUpdate::render(RenderRequest::Immediate)
             }

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -22,7 +22,7 @@ use crate::{
     config::{ReasoningEffort, ReasoningMode},
     subagents::AgentUpdate,
     tui::{
-        context::{ContextDiagnostics, completed_transcript_tokens},
+        context::ContextDiagnostics,
         prompt::Submission,
         session::SessionSummary,
         theme::{Theme, ThemeMode},
@@ -83,6 +83,7 @@ impl Notification {
 pub(crate) enum RootEvent {
     Terminal(Event),
     PasteImage(String),
+    #[cfg(test)]
     ContextTokens(u64),
     Transcript(Arc<TranscriptRecord>),
     AgentStreamClosed,
@@ -323,8 +324,8 @@ impl RootNode {
         );
         self.set_fast_mode(fast_mode);
         for record in records {
-            self.context_diagnostics.observe(&record);
-            if let Some(tokens) = completed_transcript_tokens(&record) {
+            let observation = self.context_diagnostics.observe(&record);
+            if let Some(tokens) = observation.completed_tokens {
                 let _ = self
                     .composer
                     .component_mut()
@@ -1363,19 +1364,28 @@ impl Component for RootNode {
                     )
                 }
             }
+            #[cfg(test)]
             RootEvent::ContextTokens(tokens) => self.update_composer(
                 ComposerEvent::ContextTokens(tokens),
                 RenderRequest::Streaming,
             ),
             RootEvent::Transcript(record) => {
                 let steer_applied = record.kind() == "run.steered";
-                self.context_diagnostics.observe(&record);
+                let observation = self.context_diagnostics.observe(&record);
                 if let Some(Overlay::ContextDiagnostics(panel)) = &mut self.overlay {
                     panel
                         .component_mut()
                         .replace(self.context_diagnostics.clone());
                 }
                 let mut update = self.update_transcript(TranscriptEvent::Record(record));
+                if let Some(tokens) = observation.completed_tokens {
+                    let context = self.update_composer(
+                        ComposerEvent::ContextTokens(tokens),
+                        RenderRequest::Streaming,
+                    );
+                    update.effects.extend(context.effects);
+                    update.render = update.render.max(context.render);
+                }
                 if steer_applied {
                     let applied = self.steer_applied();
                     update.effects.extend(applied.effects);

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -101,7 +101,7 @@ pub(crate) enum RootEvent {
     SessionsLoaded(Vec<SessionSummary>),
     SessionLoadFailed(String),
     SessionRestored {
-        records: Vec<Arc<TranscriptRecord>>,
+        projection: RestoredSessionProjection,
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
@@ -116,6 +116,12 @@ pub(crate) enum RootEvent {
         id: QueueId,
     },
     AnimationFrame(Instant),
+}
+
+pub(crate) struct RestoredSessionProjection {
+    transcript: Transcript,
+    context_diagnostics: ContextDiagnostics,
+    context_tokens: Option<u64>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -307,6 +313,7 @@ impl RootNode {
         self.set_max_subagents(max_subagents);
     }
 
+    #[allow(dead_code, reason = "used by restoration benchmarks and focused tests")]
     pub(crate) fn restore_session(
         &mut self,
         workspace: &Path,
@@ -316,6 +323,47 @@ impl RootNode {
         fast_mode: bool,
         records: Vec<Arc<TranscriptRecord>>,
     ) {
+        let projection = Self::project_session(thinking, records);
+        self.install_session_projection(
+            workspace,
+            thinking,
+            reasoning_mode,
+            preferred_reasoning_mode,
+            fast_mode,
+            projection,
+        );
+    }
+
+    pub(crate) fn project_session(
+        thinking: ReasoningEffort,
+        records: Vec<Arc<TranscriptRecord>>,
+    ) -> RestoredSessionProjection {
+        let mut transcript = Transcript::with_effort(thinking);
+        let mut context_diagnostics = ContextDiagnostics::default();
+        let mut context_tokens = None;
+        for record in records {
+            let observation = context_diagnostics.observe(&record);
+            if observation.completed_tokens.is_some() {
+                context_tokens = observation.completed_tokens;
+            }
+            let _ = transcript.update(TranscriptEvent::Record(record));
+        }
+        RestoredSessionProjection {
+            transcript,
+            context_diagnostics,
+            context_tokens,
+        }
+    }
+
+    pub(crate) fn install_session_projection(
+        &mut self,
+        workspace: &Path,
+        thinking: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        preferred_reasoning_mode: ReasoningMode,
+        fast_mode: bool,
+        projection: RestoredSessionProjection,
+    ) {
         self.reset_session(
             workspace,
             thinking,
@@ -323,18 +371,13 @@ impl RootNode {
             preferred_reasoning_mode,
         );
         self.set_fast_mode(fast_mode);
-        for record in records {
-            let observation = self.context_diagnostics.observe(&record);
-            if let Some(tokens) = observation.completed_tokens {
-                let _ = self
-                    .composer
-                    .component_mut()
-                    .update(ComposerEvent::ContextTokens(tokens));
-            }
+        self.transcript = Node::new(projection.transcript);
+        self.context_diagnostics = projection.context_diagnostics;
+        if let Some(tokens) = projection.context_tokens {
             let _ = self
-                .transcript
+                .composer
                 .component_mut()
-                .update(TranscriptEvent::Record(record));
+                .update(ComposerEvent::ContextTokens(tokens));
         }
         self.thread = ThreadState::Started;
     }
@@ -1412,20 +1455,20 @@ impl Component for RootNode {
             RootEvent::SessionsLoaded(sessions) => self.sessions_loaded(sessions),
             RootEvent::SessionLoadFailed(message) => self.session_load_failed(message),
             RootEvent::SessionRestored {
-                records,
+                projection,
                 effort,
                 reasoning_mode,
                 preferred_reasoning_mode,
                 fast_mode,
             } => {
                 let workspace = self.workspace.clone();
-                self.restore_session(
+                self.install_session_projection(
                     &workspace,
                     effort,
                     reasoning_mode,
                     preferred_reasoning_mode,
                     fast_mode,
-                    records,
+                    projection,
                 );
                 ComponentUpdate::render(RenderRequest::Immediate)
             }

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -55,6 +55,13 @@ pub(crate) struct ContextObservation {
     pub(crate) completed_tokens: Option<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ApiEventProjection {
+    Discard,
+    Retain,
+    LatestOutbound,
+}
+
 impl Default for ContextDiagnostics {
     fn default() -> Self {
         Self {
@@ -273,6 +280,31 @@ struct InputTokenDetails {
 
 fn raw_value_is_string(value: &RawValue) -> bool {
     value.get().trim_start().starts_with('"')
+}
+
+pub(crate) fn api_event_projection(record: &TranscriptRecord) -> ApiEventProjection {
+    if record.source() != "agent" || record.kind() != "api.event" {
+        return ApiEventProjection::Retain;
+    }
+    let Ok(payload) = record.decode_payload::<ApiEvent>() else {
+        return ApiEventProjection::Retain;
+    };
+    if payload.phase != "generation" {
+        return ApiEventProjection::Discard;
+    }
+    match payload.direction {
+        "outbound" => ApiEventProjection::LatestOutbound,
+        "inbound" => {
+            let completed = serde_json::from_str::<ResponseEvent>(payload.event.get())
+                .is_ok_and(|event| event.kind == "response.completed");
+            if completed {
+                ApiEventProjection::Retain
+            } else {
+                ApiEventProjection::Discard
+            }
+        }
+        _ => ApiEventProjection::Discard,
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -103,6 +103,10 @@ impl ContextDiagnostics {
                 self.observe_compaction_completed(record);
                 ContextObservation::default()
             }
+            ("tact", "context.observed") => {
+                self.observe_context_snapshot(record);
+                ContextObservation::default()
+            }
             _ => ContextObservation::default(),
         }
     }
@@ -162,6 +166,18 @@ impl ContextDiagnostics {
             return;
         };
         self.set_usage(payload.usage.map(Usage::into_tokens));
+    }
+
+    fn observe_context_snapshot(&mut self, record: &TranscriptRecord) {
+        let Ok(snapshot) = record.decode_payload::<ContextSnapshot>() else {
+            return;
+        };
+        self.prompt_cache = Some(snapshot.prompt_cache);
+        self.continuation = Some(if snapshot.previous_response {
+            ContinuationMode::PreviousResponse
+        } else {
+            ContinuationMode::FullContext
+        });
     }
 
     fn set_usage(&mut self, usage: Option<TokenUsage>) {
@@ -231,6 +247,12 @@ struct ResponseEvent<'a> {
 #[derive(Deserialize)]
 struct Response {
     usage: Option<Usage>,
+}
+
+#[derive(Deserialize)]
+struct ContextSnapshot {
+    prompt_cache: bool,
+    previous_response: bool,
 }
 
 #[derive(Deserialize)]
@@ -305,6 +327,20 @@ pub(crate) fn api_event_projection(record: &TranscriptRecord) -> ApiEventProject
         }
         _ => ApiEventProjection::Discard,
     }
+}
+
+pub(crate) fn outbound_context_snapshot(record: &TranscriptRecord) -> Option<(bool, bool)> {
+    let payload = record.decode_payload::<ApiEvent>().ok()?;
+    if payload.direction != "outbound" || payload.phase != "generation" {
+        return None;
+    }
+    let request = serde_json::from_str::<ApiRequest>(payload.event.get()).ok()?;
+    Some((
+        request.prompt_cache_key.is_some_and(raw_value_is_string),
+        request
+            .previous_response_id
+            .is_some_and(raw_value_is_string),
+    ))
 }
 
 #[cfg(test)]

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -2,7 +2,7 @@
 
 use crate::tui::transcript::TranscriptRecord;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::value::RawValue;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ContinuationMode {
@@ -50,6 +50,11 @@ pub(crate) struct ContextDiagnostics {
     awaiting_post_compaction_usage: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ContextObservation {
+    pub(crate) completed_tokens: Option<u64>,
+}
+
 impl Default for ContextDiagnostics {
     fn default() -> Self {
         Self {
@@ -76,40 +81,51 @@ impl ContextDiagnostics {
         diagnostics
     }
 
-    pub(crate) fn observe(&mut self, record: &TranscriptRecord) {
+    pub(crate) fn observe(&mut self, record: &TranscriptRecord) -> ContextObservation {
         match (record.source(), record.kind()) {
             ("agent", "api.event") => self.observe_api_event(record),
-            ("agent", "model.call.completed") => self.observe_model_call_completed(record),
-            ("agent", "model.compaction.started") => self.observe_compaction_started(record),
-            ("agent", "model.compaction.completed") => self.observe_compaction_completed(record),
-            _ => {}
+            ("agent", "model.call.completed") => {
+                self.observe_model_call_completed(record);
+                ContextObservation::default()
+            }
+            ("agent", "model.compaction.started") => {
+                self.observe_compaction_started(record);
+                ContextObservation::default()
+            }
+            ("agent", "model.compaction.completed") => {
+                self.observe_compaction_completed(record);
+                ContextObservation::default()
+            }
+            _ => ContextObservation::default(),
         }
     }
 
-    fn observe_api_event(&mut self, record: &TranscriptRecord) {
+    fn observe_api_event(&mut self, record: &TranscriptRecord) -> ContextObservation {
         let Ok(payload) = record.decode_payload::<ApiEvent>() else {
-            return;
+            return ContextObservation::default();
         };
         if payload.phase != "generation" {
-            return;
+            return ContextObservation::default();
         }
-        match payload.direction.as_str() {
-            "outbound" => self.observe_request(&payload.event),
-            "inbound" => self.observe_response_event(&payload.event),
-            _ => {}
+        match payload.direction {
+            "outbound" => {
+                self.observe_request(payload.event);
+                ContextObservation::default()
+            }
+            "inbound" => self.observe_response_event(payload.event),
+            _ => ContextObservation::default(),
         }
     }
 
-    fn observe_request(&mut self, request: &Value) {
-        self.prompt_cache = Some(
-            request
-                .get("prompt_cache_key")
-                .is_some_and(Value::is_string),
-        );
+    fn observe_request(&mut self, request: &RawValue) {
+        let Ok(request) = serde_json::from_str::<ApiRequest>(request.get()) else {
+            return;
+        };
+        self.prompt_cache = Some(request.prompt_cache_key.is_some_and(raw_value_is_string));
         self.continuation = Some(
             if request
-                .get("previous_response_id")
-                .is_some_and(Value::is_string)
+                .previous_response_id
+                .is_some_and(raw_value_is_string)
             {
                 ContinuationMode::PreviousResponse
             } else {
@@ -118,15 +134,20 @@ impl ContextDiagnostics {
         );
     }
 
-    fn observe_response_event(&mut self, event: &Value) {
-        if event.get("type").and_then(Value::as_str) != Some("response.completed") {
-            return;
+    fn observe_response_event(&mut self, event: &RawValue) -> ContextObservation {
+        let Ok(event) = serde_json::from_str::<ResponseEvent>(event.get()) else {
+            return ContextObservation::default();
+        };
+        if event.kind != "response.completed" {
+            return ContextObservation::default();
         }
         let usage = event
-            .get("response")
-            .and_then(|response| response.get("usage"))
-            .and_then(usage_from_value);
+            .response
+            .and_then(|response| response.usage)
+            .map(Usage::into_tokens);
+        let completed_tokens = usage.map(|usage| usage.total);
         self.set_usage(usage);
+        ContextObservation { completed_tokens }
     }
 
     fn observe_model_call_completed(&mut self, record: &TranscriptRecord) {
@@ -178,10 +199,31 @@ impl ContextDiagnostics {
 }
 
 #[derive(Deserialize)]
-struct ApiEvent {
-    direction: String,
-    phase: String,
-    event: Value,
+struct ApiEvent<'a> {
+    direction: &'a str,
+    phase: &'a str,
+    #[serde(borrow)]
+    event: &'a RawValue,
+}
+
+#[derive(Deserialize)]
+struct ApiRequest<'a> {
+    #[serde(borrow)]
+    prompt_cache_key: Option<&'a RawValue>,
+    #[serde(borrow)]
+    previous_response_id: Option<&'a RawValue>,
+}
+
+#[derive(Deserialize)]
+struct ResponseEvent<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    response: Option<Response>,
+}
+
+#[derive(Deserialize)]
+struct Response {
+    usage: Option<Usage>,
 }
 
 #[derive(Deserialize)]
@@ -229,31 +271,13 @@ struct InputTokenDetails {
     cached_tokens: u64,
 }
 
-pub(crate) fn completed_transcript_tokens(record: &TranscriptRecord) -> Option<u64> {
-    if record.source() != "agent" || record.kind() != "api.event" {
-        return None;
-    }
-    let payload = record.decode_payload::<ApiEvent>().ok()?;
-    if payload.direction != "inbound" || payload.phase != "generation" {
-        return None;
-    }
-    let response = payload.event.get("response")?;
-    (payload.event.get("type")?.as_str()? == "response.completed")
-        .then(|| response.get("usage"))
-        .flatten()?
-        .get("total_tokens")?
-        .as_u64()
-}
-
-fn usage_from_value(value: &Value) -> Option<TokenUsage> {
-    serde_json::from_value::<Usage>(value.clone())
-        .ok()
-        .map(Usage::into_tokens)
+fn raw_value_is_string(value: &RawValue) -> bool {
+    value.get().trim_start().starts_with('"')
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ContextDiagnostics, ContinuationMode, completed_transcript_tokens};
+    use super::{ContextDiagnostics, ContinuationMode};
     use crate::tui::transcript::TranscriptRecord;
     use nanocodex::{AgentEvent, AgentEventKind};
     use serde_json::{Value, json, value::to_raw_value};
@@ -408,6 +432,10 @@ mod tests {
                 }),
             ),
         );
-        assert_eq!(completed_transcript_tokens(&record), Some(136_000));
+        let mut diagnostics = ContextDiagnostics::default();
+        let observation = diagnostics.observe(&record);
+
+        assert_eq!(observation.completed_tokens, Some(136_000));
+        assert_eq!(diagnostics.usage.unwrap().total, 136_000);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -996,7 +996,7 @@ pub(crate) async fn run(
                         schedule(
                             app.update(AppEvent::SessionRestored {
                                 pane,
-                                projection,
+                                projection: Box::new(projection),
                                 effort,
                                 reasoning_mode,
                                 preferred_reasoning_mode,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -258,9 +258,19 @@ pub(crate) async fn run(
     let (configured, restored_projection, reasoning_mode) =
         if let Some(session_id) = resume_session_id {
             let restored_config = config.clone();
+            let config_path = restored_config.path().to_path_buf();
+            let checkpoint_session_id = session_id.clone();
+            let checkpoint = tokio::task::spawn_blocking(move || {
+                session::load_checkpoint(&config_path, &checkpoint_session_id)
+            });
+            let transcript = session::load_transcript_async(
+                restored_config.path().to_path_buf(),
+                session_id.clone(),
+            );
+            let (snapshot, records) = tokio::join!(checkpoint, transcript);
+            let snapshot = snapshot.map_err(RuntimeError::SessionTask)??;
+            let records = records?;
             tokio::task::spawn_blocking(move || -> Result<_> {
-                let snapshot = session::load_checkpoint(restored_config.path(), &session_id)?;
-                let records = session::load_transcript(restored_config.path(), &session_id)?;
                 let reasoning_mode = session::reasoning_mode(&records);
                 let projection = RootNode::project_session(initial_effort, records);
                 let configured = ConfiguredAgent::from_config_with_session(
@@ -1451,10 +1461,19 @@ fn apply_pane_effect(
             let preferred_reasoning_mode = context.config.agent().reasoning_mode();
             let fast_mode = context.config.agent().fast_mode();
             let config = context.config.clone();
-            *context.resume_session_task = Some(tokio::task::spawn_blocking(move || {
-                let restored = (|| {
-                    let snapshot = session::load_checkpoint(config.path(), &session_id)?;
-                    let records = session::load_transcript(config.path(), &session_id)?;
+            *context.resume_session_task = Some(tokio::spawn(async move {
+                let config_path = config.path().to_path_buf();
+                let checkpoint_session_id = session_id.clone();
+                let checkpoint = tokio::task::spawn_blocking(move || {
+                    session::load_checkpoint(&config_path, &checkpoint_session_id)
+                });
+                let transcript =
+                    session::load_transcript_async(config.path().to_path_buf(), session_id.clone());
+                let restored = async {
+                    let (snapshot, records) = tokio::join!(checkpoint, transcript);
+                    let snapshot = snapshot.map_err(RuntimeError::SessionTask)??;
+                    let records = records?;
+                    tokio::task::spawn_blocking(move || -> Result<_> {
                     let reasoning_mode = session::reasoning_mode(&records);
                     let projection = RootNode::project_session(effort, records);
                     let configured = ConfiguredAgent::from_config_with_session(
@@ -1469,7 +1488,11 @@ fn apply_pane_effect(
                         projection,
                         reasoning_mode,
                     })
-                })();
+                    })
+                    .await
+                    .map_err(RuntimeError::SessionTask)?
+                }
+                .await;
                 (
                     pane,
                     effort,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1447,8 +1447,10 @@ fn apply_pane_effect(
                 .expect("session-list pane must exist")
                 .session_id
                 .clone();
-            *context.session_list_task = Some(tokio::task::spawn_blocking(move || {
-                let sessions = session::list(&config_path, &workspace).map(|mut sessions| {
+            *context.session_list_task = Some(tokio::spawn(async move {
+                let sessions = session::list_async(config_path, workspace)
+                    .await
+                    .map(|mut sessions| {
                     sessions.retain(|session| session.session_id != active_session_id);
                     sessions
                 });

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -25,7 +25,10 @@ use crate::{
     subagents::SubagentControl,
     tui::{
         agent_events::ForwardedAgentEvent,
-        components::{AppEffect, AppEvent, AppNode, ComponentUpdate, RenderRequest, RootNode},
+        components::{
+            AppEffect, AppEvent, AppNode, ComponentUpdate, RenderRequest,
+            RestoredSessionProjection, RootNode,
+        },
         editor::EditorOutcome,
         pane::PaneId,
         prompt::Submission,
@@ -95,7 +98,7 @@ fn spawn_update_check(config_path: &Path) -> Option<UpdateCheckTask> {
 
 struct RestoredSession {
     configured: ConfiguredAgent,
-    records: Vec<std::sync::Arc<transcript::TranscriptRecord>>,
+    projection: RestoredSessionProjection,
     reasoning_mode: ReasoningMode,
 }
 
@@ -247,28 +250,37 @@ pub(crate) async fn run(
 ) -> Result<Option<String>> {
     ensure_interactive()?;
 
-    let restored_records;
-    let preferred_reasoning_mode = config.agent().reasoning_mode();
-    let reasoning_mode;
-    let configured = if let Some(session_id) = resume_session_id.as_deref() {
-        let snapshot = session::load_checkpoint(config.path(), session_id)?;
-        restored_records = session::load_transcript(config.path(), session_id)?;
-        reasoning_mode = session::reasoning_mode(&restored_records);
-        ConfiguredAgent::from_config_with_session(
-            &config,
-            config.agent().thinking(),
-            reasoning_mode,
-            Some(session_id),
-            Some(snapshot),
-        )?
-    } else {
-        restored_records = Vec::new();
-        reasoning_mode = preferred_reasoning_mode;
-        ConfiguredAgent::from_config(&config)?
-    };
     let initial_effort = config.agent().thinking();
     let initial_fast_mode = config.agent().fast_mode();
     let initial_max_subagents = config.agent().max_subagents();
+    let preferred_reasoning_mode = config.agent().reasoning_mode();
+    let resuming = resume_session_id.is_some();
+    let (configured, restored_projection, reasoning_mode) =
+        if let Some(session_id) = resume_session_id {
+            let restored_config = config.clone();
+            tokio::task::spawn_blocking(move || -> Result<_> {
+                let snapshot = session::load_checkpoint(restored_config.path(), &session_id)?;
+                let records = session::load_transcript(restored_config.path(), &session_id)?;
+                let reasoning_mode = session::reasoning_mode(&records);
+                let projection = RootNode::project_session(initial_effort, records);
+                let configured = ConfiguredAgent::from_config_with_session(
+                    &restored_config,
+                    initial_effort,
+                    reasoning_mode,
+                    Some(&session_id),
+                    Some(snapshot),
+                )?;
+                Ok((configured, Some(projection), reasoning_mode))
+            })
+            .await
+            .map_err(RuntimeError::SessionTask)??
+        } else {
+            (
+                ConfiguredAgent::from_config(&config)?,
+                None,
+                preferred_reasoning_mode,
+            )
+        };
     let mut terminal = TerminalSession::enter().map_err(RuntimeError::Terminal)?;
     let ConfiguredAgent {
         agent,
@@ -287,7 +299,7 @@ pub(crate) async fn run(
                 pane: PaneId::Main,
                 generation: 0,
             },
-            if resume_session_id.is_some() {
+            if resuming {
                 PaneSession::persisted(&main_session_id)
             } else {
                 PaneSession::new(&main_session_id, None)
@@ -313,14 +325,14 @@ pub(crate) async fn run(
     root.set_reasoning_modes(reasoning_mode, preferred_reasoning_mode);
     root.set_fast_mode(initial_fast_mode);
     root.set_max_subagents(initial_max_subagents);
-    if !restored_records.is_empty() {
-        root.restore_session(
+    if let Some(projection) = restored_projection {
+        root.install_session_projection(
             &workspace,
             initial_effort,
             reasoning_mode,
             preferred_reasoning_mode,
             initial_fast_mode,
-            restored_records,
+            projection,
         );
     }
     let mut theme = config.theme().clone();
@@ -919,7 +931,7 @@ pub(crate) async fn run(
                 match restored {
                     Ok(RestoredSession {
                         configured,
-                        records,
+                        projection,
                         reasoning_mode,
                     }) => {
                         let ConfiguredAgent {
@@ -974,7 +986,7 @@ pub(crate) async fn run(
                         schedule(
                             app.update(AppEvent::SessionRestored {
                                 pane,
-                                records,
+                                projection,
                                 effort,
                                 reasoning_mode,
                                 preferred_reasoning_mode,
@@ -1444,6 +1456,7 @@ fn apply_pane_effect(
                     let snapshot = session::load_checkpoint(config.path(), &session_id)?;
                     let records = session::load_transcript(config.path(), &session_id)?;
                     let reasoning_mode = session::reasoning_mode(&records);
+                    let projection = RootNode::project_session(effort, records);
                     let configured = ConfiguredAgent::from_config_with_session(
                         &config,
                         effort,
@@ -1453,7 +1466,7 @@ fn apply_pane_effect(
                     )?;
                     Ok(RestoredSession {
                         configured,
-                        records,
+                        projection,
                         reasoning_mode,
                     })
                 })();

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -5,17 +5,19 @@ use crate::{
     tui::transcript::{self, SessionStarted, TranscriptRecord},
 };
 use nanocodex::SessionSnapshot;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs::{self, File},
     io::{self, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempfile::NamedTempFile;
 use thiserror::Error;
+use tokio::sync::oneshot;
 use zstd::stream::{read::Decoder, write::Encoder};
 
 const COMPRESSION_LEVEL: i32 = 3;
@@ -136,6 +138,8 @@ pub(crate) enum SessionError {
     InvalidCheckpoint { path: PathBuf },
     #[error(transparent)]
     Transcript(#[from] transcript::TranscriptError),
+    #[error("the transcript loading worker stopped unexpectedly")]
+    TranscriptLoaderStopped,
 }
 
 pub(crate) fn save_checkpoint(
@@ -301,6 +305,10 @@ pub(crate) fn list(
     Ok(sessions)
 }
 
+#[allow(
+    dead_code,
+    reason = "used by compatibility tests and restoration benchmarks"
+)]
 pub(crate) fn load_transcript(
     config_path: &Path,
     session_id: &str,
@@ -318,6 +326,63 @@ pub(crate) fn load_transcript(
         }
     }
     Ok(records)
+}
+
+pub(crate) async fn load_transcript_async(
+    config_path: PathBuf,
+    session_id: String,
+) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
+    let (sender, receiver) = oneshot::channel();
+    transcript_loader().spawn(move || {
+        drop(sender.send(load_transcript_parallel_inner(&config_path, &session_id)));
+    });
+    receiver
+        .await
+        .map_err(|_| SessionError::TranscriptLoaderStopped)?
+}
+
+#[allow(dead_code, reason = "used by restoration benchmarks")]
+pub(crate) fn load_transcript_parallel(
+    config_path: &Path,
+    session_id: &str,
+) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
+    transcript_loader().install(|| load_transcript_parallel_inner(config_path, session_id))
+}
+
+fn load_transcript_parallel_inner(
+    config_path: &Path,
+    session_id: &str,
+) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
+    let segments = transcript_paths(config_path)?
+        .into_par_iter()
+        .map(|path| {
+            transcript::load_matching(&path, |first| {
+                session_started_record(first).is_none_or(|started| started.session_id == session_id)
+            })
+            .map_err(SessionError::from)
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .collect::<Result<Vec<_>, SessionError>>()?;
+    let mut records = Vec::new();
+    for segment in segments.into_iter().flatten() {
+        if session_started(&segment).is_some_and(|started| started.session_id == session_id) {
+            records.extend(segment);
+        }
+    }
+    Ok(records)
+}
+
+fn transcript_loader() -> &'static rayon::ThreadPool {
+    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        let available = std::thread::available_parallelism().map_or(1, usize::from);
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(available.min(4))
+            .thread_name(|index| format!("tact-transcript-loader-{index}"))
+            .build()
+            .expect("the transcript loading thread pool should initialize")
+    })
 }
 
 pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
@@ -521,7 +586,7 @@ fn create_private_directory(path: &Path) -> Result<(), SessionError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        encode_filename, format_age, list, load_checkpoint, load_transcript,
+        encode_filename, format_age, list, load_checkpoint, load_transcript, load_transcript_async,
         obsolete_checkpoint_path, save_checkpoint,
     };
     use crate::{
@@ -667,5 +732,11 @@ mod tests {
         assert_eq!(sessions[0].effort, ReasoningEffort::Low);
         assert_eq!(sessions[0].reasoning_mode, ReasoningMode::Pro);
         assert_eq!(load_transcript(&config, "session/one").unwrap().len(), 3);
+        let loaded = load_transcript_async(config.clone(), "session/one".to_owned())
+            .await
+            .unwrap();
+        assert_eq!(loaded.len(), 3);
+        assert_eq!(loaded[0].kind(), "session.started");
+        assert_eq!(loaded[2].kind(), "effort.changed");
     }
 }

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -344,9 +344,17 @@ fn load_catalog_segment(
     if let Some(summary) = read_segment_summary(path) {
         return Ok((summary.workspace == workspace).then_some(summary));
     }
-    let segment = transcript::load_matching_segment(path, |first| {
-        session_started_record(first).is_none_or(|started| started.workspace == workspace)
-    })?;
+    let segment = transcript::load_matching_segment_filtered(
+        path,
+        |first| session_started_record(first).is_none_or(|started| started.workspace == workspace),
+        |record| {
+            record.source() == "tact"
+                && matches!(
+                    record.kind(),
+                    "session.started" | "user.submitted" | "effort.changed"
+                )
+        },
+    )?;
     let Some(segment) = segment else {
         return Ok(None);
     };
@@ -477,9 +485,13 @@ fn load_session_segment(
     {
         return Ok(None);
     }
-    let segment = transcript::load_matching_segment(path, |first| {
-        session_started_record(first).is_none_or(|started| started.session_id == session_id)
-    })?;
+    let segment = transcript::load_matching_segment_filtered(
+        path,
+        |first| {
+            session_started_record(first).is_none_or(|started| started.session_id == session_id)
+        },
+        |record| api_event_projection(record) != ApiEventProjection::Discard,
+    )?;
     let Some(segment) = segment else {
         return Ok(None);
     };

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -77,6 +77,7 @@ struct TranscriptProjectionEnvelope<'a> {
 struct LoadedSessionSegment {
     records: Vec<Arc<TranscriptRecord>>,
     complete: bool,
+    observed_records: usize,
 }
 
 #[derive(Serialize)]
@@ -420,16 +421,20 @@ pub(crate) fn load_transcript(
     let source_fingerprint = transcript_fingerprint(config_path)?;
     let mut records = Vec::new();
     let mut complete = true;
+    let mut observed_records = 0;
     for path in transcript_paths(config_path)? {
         let Some(segment) = load_session_segment(&path, session_id)? else {
             continue;
         };
         complete &= segment.complete;
+        observed_records += segment.observed_records;
         records.extend(segment.records);
     }
-    if complete {
+    if complete && observed_records > records.len() {
         records = compact_projection_records(records);
-        write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
+        if projection_cache_worthwhile(observed_records, records.len()) {
+            write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
+        }
     }
     Ok(records)
 }
@@ -471,13 +476,17 @@ fn load_transcript_parallel_inner(
         .collect::<Result<Vec<_>, SessionError>>()?;
     let mut records = Vec::new();
     let mut complete = true;
+    let mut observed_records = 0;
     for segment in segments.into_iter().flatten() {
         complete &= segment.complete;
+        observed_records += segment.observed_records;
         records.extend(segment.records);
     }
-    if complete {
+    if complete && observed_records > records.len() {
         records = compact_projection_records(records);
-        write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
+        if projection_cache_worthwhile(observed_records, records.len()) {
+            write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
+        }
     }
     Ok(records)
 }
@@ -511,6 +520,7 @@ fn load_session_segment(
     Ok(matches.then_some(LoadedSessionSegment {
         records: segment.records,
         complete: segment.complete,
+        observed_records: segment.observed_records,
     }))
 }
 
@@ -700,6 +710,10 @@ fn compact_projection_records(records: Vec<Arc<TranscriptRecord>>) -> Vec<Arc<Tr
             ApiEventProjection::LatestOutbound => None,
         })
         .collect()
+}
+
+fn projection_cache_worthwhile(observed_records: usize, projected_records: usize) -> bool {
+    observed_records > 0 && projected_records.saturating_mul(2) <= observed_records
 }
 
 fn discard_completed_assistant_deltas(
@@ -1022,6 +1036,12 @@ mod tests {
         writer.into_task().await.unwrap().unwrap();
     }
 
+    fn write_projection_cache(config: &Path, session_id: &str) {
+        let records = load_transcript(config, session_id).unwrap();
+        let source_fingerprint = transcript_fingerprint(config).unwrap();
+        write_transcript_projection(config, session_id, &source_fingerprint, &records);
+    }
+
     #[test]
     fn checkpoint_filenames_are_distinct_and_path_safe() {
         assert_eq!(encode_filename("a/b"), "612f62");
@@ -1293,13 +1313,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn visible_transcript_does_not_create_projection_cache() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal
+            .append_local(LocalEvent::SessionStarted(SessionStarted {
+                session_id: "session".to_owned(),
+                parent_session_id: None,
+                model: "model".to_owned(),
+                effort: ReasoningEffort::Medium,
+                reasoning_mode: ReasoningMode::Standard,
+                fast_mode: false,
+                workspace: "/work".into(),
+                application_version: "test".to_owned(),
+            }))
+            .unwrap();
+        journal
+            .append_local(LocalEvent::UserSubmitted {
+                id: TurnId::new(1),
+                text: "inspect the workspace".to_owned(),
+            })
+            .unwrap();
+        for (sequence, kind, payload) in [
+            (0, AgentEventKind::RunStarted, json!({})),
+            (
+                1,
+                AgentEventKind::AssistantDelta,
+                json!({
+                    "model_call_index": 1,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": "partial response"
+                }),
+            ),
+            (
+                2,
+                AgentEventKind::AssistantMessage,
+                json!({
+                    "model_call_index": 1,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": "complete response"
+                }),
+            ),
+            (3, AgentEventKind::RunCompleted, json!({})),
+        ] {
+            journal
+                .append_agent(AgentEvent {
+                    protocol_version: 1,
+                    request_id: Arc::from("request"),
+                    seq: sequence,
+                    kind,
+                    payload: to_raw_value(&payload).unwrap(),
+                })
+                .unwrap();
+        }
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
+
+        let projected = load_transcript(&config, "session").unwrap();
+
+        assert_eq!(
+            projected
+                .iter()
+                .filter(|record| record.kind() == "assistant.delta")
+                .count(),
+            1
+        );
+        assert!(!transcript_projection_path(&config, "session").exists());
+    }
+
+    #[tokio::test]
     async fn projection_cache_is_bound_to_its_session() {
         let directory = tempdir().unwrap();
         let config = directory.path().join("config.toml");
         write_minimal_session(&config, "session-one").await;
         write_minimal_session(&config, "session-two").await;
-        load_transcript(&config, "session-one").unwrap();
-        load_transcript(&config, "session-two").unwrap();
+        write_projection_cache(&config, "session-one");
+        write_projection_cache(&config, "session-two");
         let first = transcript_projection_path(&config, "session-one");
         let second = transcript_projection_path(&config, "session-two");
         let first_bytes = fs::read(&first).unwrap();
@@ -1320,7 +1412,7 @@ mod tests {
         let records = load_transcript(&config, "session-one").unwrap();
         let source_fingerprint = transcript_fingerprint(&config).unwrap();
         let cache = transcript_projection_path(&config, "session-one");
-        fs::remove_file(&cache).unwrap();
+        assert!(!cache.exists());
 
         let transcript = transcript_paths(&config).unwrap().remove(0);
         std::fs::OpenOptions::new()
@@ -1341,7 +1433,7 @@ mod tests {
         let config = directory.path().join("config.toml");
         write_minimal_session(&config, "session-one").await;
         load_transcript(&config, "session-one").unwrap();
-        fs::remove_dir_all(directory.path().join("transcript-projections")).unwrap();
+        assert!(!directory.path().join("transcript-projections").exists());
         let summaries = fs::read_dir(directory.path().join("transcripts/v1"))
             .unwrap()
             .filter_map(Result::ok)

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -22,11 +22,12 @@ use zstd::stream::{read::Decoder, write::Encoder};
 
 const COMPRESSION_LEVEL: i32 = 3;
 const CHECKPOINT_FORMAT_VERSION: u32 = 1;
+const SEGMENT_SUMMARY_FORMAT_VERSION: u32 = 1;
 
 #[cfg(unix)]
 use std::os::unix::fs::DirBuilderExt;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct SessionSummary {
     pub(crate) session_id: String,
     pub(crate) started_at_unix_ms: u64,
@@ -35,6 +36,13 @@ pub(crate) struct SessionSummary {
     pub(crate) reasoning_mode: ReasoningMode,
     pub(crate) workspace: PathBuf,
     pub(crate) preview: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredSegmentSummary {
+    format_version: u32,
+    transcript_bytes: u64,
+    summary: SessionSummary,
 }
 
 #[derive(Serialize)]
@@ -302,47 +310,43 @@ fn list_parallel_inner(
 fn load_catalog_segment(
     path: &Path,
     workspace: &Path,
-) -> Result<Option<Vec<Arc<TranscriptRecord>>>, SessionError> {
-    transcript::load_matching(path, |first| {
+) -> Result<Option<SessionSummary>, SessionError> {
+    if let Some(summary) = read_segment_summary(path) {
+        return Ok((summary.workspace == workspace).then_some(summary));
+    }
+    let segment = transcript::load_matching_segment(path, |first| {
         session_started_record(first).is_none_or(|started| started.workspace == workspace)
-    })
-    .map_err(Into::into)
+    })?;
+    let Some(segment) = segment else {
+        return Ok(None);
+    };
+    let summary = summarize_segment(&segment.records);
+    if segment.complete
+        && let Some(summary) = &summary
+    {
+        write_segment_summary(path, summary);
+    }
+    Ok(summary.filter(|summary| summary.workspace == workspace))
 }
 
 fn collect_catalog(
     config_path: &Path,
     workspace: &Path,
-    segments: impl IntoIterator<Item = Result<Option<Vec<Arc<TranscriptRecord>>>, SessionError>>,
+    segments: impl IntoIterator<Item = Result<Option<SessionSummary>, SessionError>>,
 ) -> Result<Vec<SessionSummary>, SessionError> {
     let mut sessions = HashMap::<String, SessionSummary>::new();
     for segment in segments {
-        let Some(records) = segment? else {
+        let Some(summary) = segment? else {
             continue;
         };
-        let Some(started) = session_started(&records) else {
-            continue;
-        };
-        if started.workspace != workspace {
+        if summary.workspace != workspace {
             continue;
         }
-        if !has_checkpoint(config_path, &started.session_id)? {
+        if !has_checkpoint(config_path, &summary.session_id)? {
             continue;
         }
-        let started_at_unix_ms = records
-            .first()
-            .map_or(0, |record| record.recorded_at_unix_ms());
-        let preview = first_user_message(&records).unwrap_or_else(|| "No user prompt".to_owned());
-        let summary = SessionSummary {
-            session_id: started.session_id.clone(),
-            started_at_unix_ms,
-            model: started.model,
-            effort: latest_effort(&records, started.effort),
-            reasoning_mode: started.reasoning_mode,
-            workspace: started.workspace,
-            preview,
-        };
         sessions
-            .entry(started.session_id)
+            .entry(summary.session_id.clone())
             .and_modify(|existing| {
                 if summary.started_at_unix_ms > existing.started_at_unix_ms {
                     existing.started_at_unix_ms = summary.started_at_unix_ms;
@@ -370,15 +374,10 @@ pub(crate) fn load_transcript(
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
     let mut records = Vec::new();
     for path in transcript_paths(config_path)? {
-        let Some(segment) = transcript::load_matching(&path, |first| {
-            session_started_record(first).is_none_or(|started| started.session_id == session_id)
-        })?
-        else {
+        let Some(segment) = load_session_segment(&path, session_id)? else {
             continue;
         };
-        if session_started(&segment).is_some_and(|started| started.session_id == session_id) {
-            records.extend(segment);
-        }
+        records.extend(segment);
     }
     Ok(records)
 }
@@ -410,22 +409,40 @@ fn load_transcript_parallel_inner(
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
     let segments = transcript_paths(config_path)?
         .into_par_iter()
-        .map(|path| {
-            transcript::load_matching(&path, |first| {
-                session_started_record(first).is_none_or(|started| started.session_id == session_id)
-            })
-            .map_err(SessionError::from)
-        })
+        .map(|path| load_session_segment(&path, session_id))
         .collect::<Vec<_>>()
         .into_iter()
         .collect::<Result<Vec<_>, SessionError>>()?;
     let mut records = Vec::new();
     for segment in segments.into_iter().flatten() {
-        if session_started(&segment).is_some_and(|started| started.session_id == session_id) {
-            records.extend(segment);
-        }
+        records.extend(segment);
     }
     Ok(records)
+}
+
+fn load_session_segment(
+    path: &Path,
+    session_id: &str,
+) -> Result<Option<Vec<Arc<TranscriptRecord>>>, SessionError> {
+    if let Some(summary) = read_segment_summary(path)
+        && summary.session_id != session_id
+    {
+        return Ok(None);
+    }
+    let segment = transcript::load_matching_segment(path, |first| {
+        session_started_record(first).is_none_or(|started| started.session_id == session_id)
+    })?;
+    let Some(segment) = segment else {
+        return Ok(None);
+    };
+    let matches =
+        session_started(&segment.records).is_some_and(|started| started.session_id == session_id);
+    if segment.complete
+        && let Some(summary) = summarize_segment(&segment.records)
+    {
+        write_segment_summary(path, &summary);
+    }
+    Ok(matches.then_some(segment.records))
 }
 
 fn transcript_loader() -> &'static rayon::ThreadPool {
@@ -523,6 +540,60 @@ fn first_user_message(records: &[Arc<TranscriptRecord>]) -> Option<String> {
                 .join(" ")
         })
         .filter(|preview| !preview.is_empty())
+}
+
+fn summarize_segment(records: &[Arc<TranscriptRecord>]) -> Option<SessionSummary> {
+    let started = session_started(records)?;
+    Some(SessionSummary {
+        session_id: started.session_id,
+        started_at_unix_ms: records
+            .first()
+            .map_or(0, |record| record.recorded_at_unix_ms()),
+        model: started.model,
+        effort: latest_effort(records, started.effort),
+        reasoning_mode: started.reasoning_mode,
+        workspace: started.workspace,
+        preview: first_user_message(records).unwrap_or_else(|| "No user prompt".to_owned()),
+    })
+}
+
+fn read_segment_summary(transcript_path: &Path) -> Option<SessionSummary> {
+    let transcript_bytes = fs::metadata(transcript_path).ok()?.len();
+    let stored = serde_json::from_slice::<StoredSegmentSummary>(
+        &fs::read(segment_summary_path(transcript_path)).ok()?,
+    )
+    .ok()?;
+    (stored.format_version == SEGMENT_SUMMARY_FORMAT_VERSION
+        && stored.transcript_bytes == transcript_bytes)
+        .then_some(stored.summary)
+}
+
+fn write_segment_summary(transcript_path: &Path, summary: &SessionSummary) {
+    let Some(directory) = transcript_path.parent() else {
+        return;
+    };
+    let Ok(transcript_bytes) = fs::metadata(transcript_path).map(|metadata| metadata.len()) else {
+        return;
+    };
+    let stored = StoredSegmentSummary {
+        format_version: SEGMENT_SUMMARY_FORMAT_VERSION,
+        transcript_bytes,
+        summary: summary.clone(),
+    };
+    let Ok(encoded) = serde_json::to_vec(&stored) else {
+        return;
+    };
+    let Ok(mut temporary) = NamedTempFile::new_in(directory) else {
+        return;
+    };
+    if temporary.write_all(&encoded).is_err() {
+        return;
+    }
+    drop(temporary.persist(segment_summary_path(transcript_path)));
+}
+
+fn segment_summary_path(transcript_path: &Path) -> PathBuf {
+    transcript_path.with_extension("summary.json")
 }
 
 fn checkpoint_directory(config_path: &Path) -> PathBuf {
@@ -650,7 +721,7 @@ mod tests {
     };
     use nanocodex::SessionSnapshot;
     use serde_json::{Value, json};
-    use std::path::Path;
+    use std::{fs, path::Path};
     use tempfile::tempdir;
 
     fn snapshot(lineage: &str) -> SessionSnapshot {
@@ -786,6 +857,14 @@ mod tests {
         assert_eq!(sessions[0].preview, "inspect the workspace");
         assert_eq!(sessions[0].effort, ReasoningEffort::Low);
         assert_eq!(sessions[0].reasoning_mode, ReasoningMode::Pro);
+        let summaries = fs::read_dir(directory.path().join("transcripts/v1"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.to_string_lossy().ends_with(".summary.json"))
+            .collect::<Vec<_>>();
+        assert_eq!(summaries.len(), 1);
+        fs::write(&summaries[0], b"invalid cache").unwrap();
         let async_sessions = list_async(config.clone(), Path::new("/work").to_path_buf())
             .await
             .unwrap();

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -3,8 +3,8 @@
 use crate::{
     config::{ReasoningEffort, ReasoningMode},
     tui::{
-        context::{ApiEventProjection, api_event_projection},
-        transcript::{self, SessionStarted, TranscriptRecord},
+        context::{ApiEventProjection, api_event_projection, outbound_context_snapshot},
+        transcript::{self, LocalEvent, SessionStarted, TranscriptRecord},
     },
 };
 use nanocodex::SessionSnapshot;
@@ -45,7 +45,9 @@ pub(crate) struct SessionSummary {
 #[derive(Deserialize, Serialize)]
 struct StoredSegmentSummary {
     format_version: u32,
+    transcript_filename: String,
     transcript_bytes: u64,
+    transcript_modified_unix_ns: u128,
     summary: SessionSummary,
 }
 
@@ -59,6 +61,7 @@ struct TranscriptFingerprint {
 #[derive(Deserialize, Serialize)]
 struct StoredTranscriptProjection {
     format_version: u32,
+    session_id: String,
     transcript_fingerprint: Vec<TranscriptFingerprint>,
     records: Vec<Arc<TranscriptRecord>>,
 }
@@ -66,7 +69,8 @@ struct StoredTranscriptProjection {
 #[derive(Serialize)]
 struct TranscriptProjectionEnvelope<'a> {
     format_version: u32,
-    transcript_fingerprint: Vec<TranscriptFingerprint>,
+    session_id: &'a str,
+    transcript_fingerprint: &'a [TranscriptFingerprint],
     records: &'a [Arc<TranscriptRecord>],
 }
 
@@ -413,6 +417,7 @@ pub(crate) fn load_transcript(
     if let Some(records) = read_transcript_projection(config_path, session_id) {
         return Ok(records);
     }
+    let source_fingerprint = transcript_fingerprint(config_path)?;
     let mut records = Vec::new();
     let mut complete = true;
     for path in transcript_paths(config_path)? {
@@ -424,7 +429,7 @@ pub(crate) fn load_transcript(
     }
     if complete {
         records = compact_projection_records(records);
-        write_transcript_projection(config_path, session_id, &records);
+        write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
     }
     Ok(records)
 }
@@ -457,6 +462,7 @@ fn load_transcript_parallel_inner(
     if let Some(records) = read_transcript_projection(config_path, session_id) {
         return Ok(records);
     }
+    let source_fingerprint = transcript_fingerprint(config_path)?;
     let segments = transcript_paths(config_path)?
         .into_par_iter()
         .map(|path| load_session_segment(&path, session_id))
@@ -471,7 +477,7 @@ fn load_transcript_parallel_inner(
     }
     if complete {
         records = compact_projection_records(records);
-        write_transcript_projection(config_path, session_id, &records);
+        write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
     }
     Ok(records)
 }
@@ -621,26 +627,34 @@ fn summarize_segment(records: &[Arc<TranscriptRecord>]) -> Option<SessionSummary
 }
 
 fn read_segment_summary(transcript_path: &Path) -> Option<SessionSummary> {
-    let transcript_bytes = fs::metadata(transcript_path).ok()?.len();
+    let metadata = fs::metadata(transcript_path).ok()?;
     let stored = serde_json::from_slice::<StoredSegmentSummary>(
         &fs::read(segment_summary_path(transcript_path)).ok()?,
     )
     .ok()?;
     (stored.format_version == SEGMENT_SUMMARY_FORMAT_VERSION
-        && stored.transcript_bytes == transcript_bytes)
-        .then_some(stored.summary)
+        && stored.transcript_filename == transcript_path.file_name()?.to_string_lossy().as_ref()
+        && stored.transcript_bytes == metadata.len()
+        && stored.transcript_modified_unix_ns == modified_unix_ns(&metadata))
+    .then_some(stored.summary)
 }
 
 fn write_segment_summary(transcript_path: &Path, summary: &SessionSummary) {
     let Some(directory) = transcript_path.parent() else {
         return;
     };
-    let Ok(transcript_bytes) = fs::metadata(transcript_path).map(|metadata| metadata.len()) else {
+    let Ok(metadata) = fs::metadata(transcript_path) else {
         return;
     };
     let stored = StoredSegmentSummary {
         format_version: SEGMENT_SUMMARY_FORMAT_VERSION,
-        transcript_bytes,
+        transcript_filename: transcript_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+        transcript_bytes: metadata.len(),
+        transcript_modified_unix_ns: modified_unix_ns(&metadata),
         summary: summary.clone(),
     };
     let Ok(encoded) = serde_json::to_vec(&stored) else {
@@ -669,7 +683,19 @@ fn compact_projection_records(records: Vec<Arc<TranscriptRecord>>) -> Vec<Arc<Tr
         .filter_map(|(index, record)| match api_event_projection(&record) {
             ApiEventProjection::Discard => None,
             ApiEventProjection::Retain => Some(record),
-            ApiEventProjection::LatestOutbound if Some(index) == latest_outbound => Some(record),
+            ApiEventProjection::LatestOutbound if Some(index) == latest_outbound => {
+                let (prompt_cache, previous_response) = outbound_context_snapshot(&record)?;
+                TranscriptRecord::from_local(
+                    record.sequence(),
+                    record.recorded_at_unix_ms(),
+                    LocalEvent::ContextObserved {
+                        prompt_cache,
+                        previous_response,
+                    },
+                )
+                .ok()
+                .map(Arc::new)
+            }
             ApiEventProjection::LatestOutbound => None,
         })
         .collect()
@@ -686,6 +712,9 @@ fn read_transcript_projection(
     if stored.format_version != PROJECTION_FORMAT_VERSION {
         return None;
     }
+    if stored.session_id != session_id {
+        return None;
+    }
     let fingerprint = transcript_fingerprint(config_path).ok()?;
     (stored.transcript_fingerprint == fingerprint).then_some(stored.records)
 }
@@ -693,17 +722,18 @@ fn read_transcript_projection(
 fn write_transcript_projection(
     config_path: &Path,
     session_id: &str,
+    source_fingerprint: &[TranscriptFingerprint],
     records: &[Arc<TranscriptRecord>],
 ) {
-    let _ = try_write_transcript_projection(config_path, session_id, records);
+    let _ = try_write_transcript_projection(config_path, session_id, source_fingerprint, records);
 }
 
 fn try_write_transcript_projection(
     config_path: &Path,
     session_id: &str,
+    source_fingerprint: &[TranscriptFingerprint],
     records: &[Arc<TranscriptRecord>],
 ) -> Option<()> {
-    let fingerprint = transcript_fingerprint(config_path).ok()?;
     let directory = transcript_projection_directory(config_path);
     create_private_directory(&directory).ok()?;
     let path = transcript_projection_path(config_path, session_id);
@@ -714,7 +744,8 @@ fn try_write_transcript_projection(
             &mut output,
             &TranscriptProjectionEnvelope {
                 format_version: PROJECTION_FORMAT_VERSION,
-                transcript_fingerprint: fingerprint,
+                session_id,
+                transcript_fingerprint: source_fingerprint,
                 records,
             },
         )
@@ -722,6 +753,9 @@ fn try_write_transcript_projection(
         output.finish().ok()?;
     }
     temporary.flush().ok()?;
+    if transcript_fingerprint(config_path).ok()?.as_slice() != source_fingerprint {
+        return None;
+    }
     temporary.persist(path).ok()?;
     Some(())
 }
@@ -734,12 +768,6 @@ fn transcript_fingerprint(config_path: &Path) -> Result<Vec<TranscriptFingerprin
                 path: path.clone(),
                 source,
             })?;
-            let modified_unix_ns = metadata
-                .modified()
-                .unwrap_or(UNIX_EPOCH)
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos();
             Ok(TranscriptFingerprint {
                 filename: path
                     .file_name()
@@ -747,10 +775,19 @@ fn transcript_fingerprint(config_path: &Path) -> Result<Vec<TranscriptFingerprin
                     .to_string_lossy()
                     .into_owned(),
                 bytes: metadata.len(),
-                modified_unix_ns,
+                modified_unix_ns: modified_unix_ns(&metadata),
             })
         })
         .collect()
+}
+
+fn modified_unix_ns(metadata: &fs::Metadata) -> u128 {
+    metadata
+        .modified()
+        .unwrap_or(UNIX_EPOCH)
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
 }
 
 fn transcript_projection_directory(config_path: &Path) -> PathBuf {
@@ -879,8 +916,8 @@ fn create_private_directory(path: &Path) -> Result<(), SessionError> {
 mod tests {
     use super::{
         encode_filename, format_age, list, list_async, load_checkpoint, load_transcript,
-        load_transcript_async, obsolete_checkpoint_path, save_checkpoint,
-        transcript_projection_path,
+        load_transcript_async, obsolete_checkpoint_path, save_checkpoint, transcript_fingerprint,
+        transcript_paths, transcript_projection_path, write_transcript_projection,
     };
     use crate::{
         config::{ReasoningEffort, ReasoningMode},
@@ -888,7 +925,7 @@ mod tests {
     };
     use nanocodex::{AgentEvent, AgentEventKind, SessionSnapshot};
     use serde_json::{Value, json, value::to_raw_value};
-    use std::{fs, path::Path, sync::Arc};
+    use std::{fs, io::Write, path::Path, sync::Arc};
     use tempfile::tempdir;
 
     fn snapshot(lineage: &str) -> SessionSnapshot {
@@ -914,6 +951,24 @@ mod tests {
             }]
         }))
         .unwrap()
+    }
+
+    async fn write_minimal_session(config: &Path, session_id: &str) {
+        let (mut journal, writer) = TranscriptJournal::open(config, session_id).unwrap();
+        journal
+            .append_local(LocalEvent::SessionStarted(SessionStarted {
+                session_id: session_id.to_owned(),
+                parent_session_id: None,
+                model: "model".to_owned(),
+                effort: ReasoningEffort::Medium,
+                reasoning_mode: ReasoningMode::Standard,
+                fast_mode: false,
+                workspace: "/work".into(),
+                application_version: "test".to_owned(),
+            }))
+            .unwrap();
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
     }
 
     #[test]
@@ -1077,7 +1132,10 @@ mod tests {
             json!({
                 "direction": "outbound",
                 "phase": "generation",
-                "event": {"prompt_cache_key": "latest", "previous_response_id": "response"}
+                "event": {
+                    "prompt_cache_key": "latest-secret-key",
+                    "previous_response_id": "secret-response-id"
+                }
             }),
             json!({
                 "direction": "inbound",
@@ -1111,17 +1169,87 @@ mod tests {
                 .iter()
                 .filter(|record| record.kind() == "api.event")
                 .count(),
-            2
+            1
         );
 
         let cache = transcript_projection_path(&config, "session");
         assert!(cache.is_file());
         let cached = load_transcript(&config, "session").unwrap();
         assert_eq!(cached.len(), projected.len());
+        assert!(!format!("{cached:?}").contains("latest-secret-key"));
+        assert!(!format!("{cached:?}").contains("secret-response-id"));
 
         fs::write(&cache, b"invalid cache").unwrap();
         let recovered = load_transcript(&config, "session").unwrap();
         assert_eq!(recovered.len(), projected.len());
         assert!(fs::metadata(cache).unwrap().len() > b"invalid cache".len() as u64);
+    }
+
+    #[tokio::test]
+    async fn projection_cache_is_bound_to_its_session() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        write_minimal_session(&config, "session-one").await;
+        write_minimal_session(&config, "session-two").await;
+        load_transcript(&config, "session-one").unwrap();
+        load_transcript(&config, "session-two").unwrap();
+        let first = transcript_projection_path(&config, "session-one");
+        let second = transcript_projection_path(&config, "session-two");
+        let first_bytes = fs::read(&first).unwrap();
+        fs::write(&first, fs::read(&second).unwrap()).unwrap();
+        fs::write(&second, first_bytes).unwrap();
+
+        let records = load_transcript(&config, "session-one").unwrap();
+        let started = super::session_started(&records).unwrap();
+
+        assert_eq!(started.session_id, "session-one");
+    }
+
+    #[tokio::test]
+    async fn projection_cache_is_not_written_for_changed_source() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        write_minimal_session(&config, "session-one").await;
+        let records = load_transcript(&config, "session-one").unwrap();
+        let source_fingerprint = transcript_fingerprint(&config).unwrap();
+        let cache = transcript_projection_path(&config, "session-one");
+        fs::remove_file(&cache).unwrap();
+
+        let transcript = transcript_paths(&config).unwrap().remove(0);
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(transcript)
+            .unwrap()
+            .write_all(b"changed")
+            .unwrap();
+
+        write_transcript_projection(&config, "session-one", &source_fingerprint, &records);
+
+        assert!(!cache.exists());
+    }
+
+    #[tokio::test]
+    async fn segment_summary_is_bound_to_its_transcript() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        write_minimal_session(&config, "session-one").await;
+        load_transcript(&config, "session-one").unwrap();
+        fs::remove_dir_all(directory.path().join("transcript-projections")).unwrap();
+        let summaries = fs::read_dir(directory.path().join("transcripts/v1"))
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.to_string_lossy().ends_with(".summary.json"))
+            .collect::<Vec<_>>();
+        assert_eq!(summaries.len(), 1);
+        let summary = fs::read_to_string(&summaries[0])
+            .unwrap()
+            .replace("session-one", "session-xxx");
+        fs::write(&summaries[0], summary).unwrap();
+
+        let records = load_transcript(&config, "session-one").unwrap();
+        let started = super::session_started(&records).unwrap();
+
+        assert_eq!(started.session_id, "session-one");
     }
 }

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -254,7 +254,12 @@ pub(crate) fn list(
     remove_obsolete_checkpoints(config_path)?;
     let mut sessions = HashMap::<String, SessionSummary>::new();
     for path in transcript_paths(config_path)? {
-        let records = transcript::load(&path)?;
+        let Some(records) = transcript::load_matching(&path, |first| {
+            session_started_record(first).is_none_or(|started| started.workspace == workspace)
+        })?
+        else {
+            continue;
+        };
         let Some(started) = session_started(&records) else {
             continue;
         };
@@ -302,7 +307,12 @@ pub(crate) fn load_transcript(
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
     let mut records = Vec::new();
     for path in transcript_paths(config_path)? {
-        let segment = transcript::load(&path)?;
+        let Some(segment) = transcript::load_matching(&path, |first| {
+            session_started_record(first).is_none_or(|started| started.session_id == session_id)
+        })?
+        else {
+            continue;
+        };
         if session_started(&segment).is_some_and(|started| started.session_id == session_id) {
             records.extend(segment);
         }
@@ -350,7 +360,12 @@ fn session_started(records: &[Arc<TranscriptRecord>]) -> Option<SessionStarted> 
     let record = records
         .iter()
         .find(|record| record.source() == "tact" && record.kind() == "session.started")?;
-    record.decode_payload().ok()
+    session_started_record(record)
+}
+
+fn session_started_record(record: &TranscriptRecord) -> Option<SessionStarted> {
+    (record.source() == "tact" && record.kind() == "session.started")
+        .then(|| record.decode_payload().ok())?
 }
 
 pub(crate) fn reasoning_mode(records: &[Arc<TranscriptRecord>]) -> ReasoningMode {

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -251,17 +251,72 @@ pub(crate) fn load_checkpoint(
     Ok(ResumeState::new(snapshot, instructions))
 }
 
+#[allow(
+    dead_code,
+    reason = "used by compatibility tests and catalog benchmarks"
+)]
 pub(crate) fn list(
     config_path: &Path,
     workspace: &Path,
 ) -> Result<Vec<SessionSummary>, SessionError> {
     remove_obsolete_checkpoints(config_path)?;
+    let segments = transcript_paths(config_path)?
+        .into_iter()
+        .map(|path| load_catalog_segment(&path, workspace));
+    collect_catalog(config_path, workspace, segments)
+}
+
+pub(crate) async fn list_async(
+    config_path: PathBuf,
+    workspace: PathBuf,
+) -> Result<Vec<SessionSummary>, SessionError> {
+    let (sender, receiver) = oneshot::channel();
+    transcript_loader().spawn(move || {
+        drop(sender.send(list_parallel_inner(&config_path, &workspace)));
+    });
+    receiver
+        .await
+        .map_err(|_| SessionError::TranscriptLoaderStopped)?
+}
+
+#[allow(dead_code, reason = "used by session catalog benchmarks")]
+pub(crate) fn list_parallel(
+    config_path: &Path,
+    workspace: &Path,
+) -> Result<Vec<SessionSummary>, SessionError> {
+    transcript_loader().install(|| list_parallel_inner(config_path, workspace))
+}
+
+fn list_parallel_inner(
+    config_path: &Path,
+    workspace: &Path,
+) -> Result<Vec<SessionSummary>, SessionError> {
+    remove_obsolete_checkpoints(config_path)?;
+    let segments = transcript_paths(config_path)?
+        .into_par_iter()
+        .map(|path| load_catalog_segment(&path, workspace))
+        .collect::<Vec<_>>();
+    collect_catalog(config_path, workspace, segments)
+}
+
+fn load_catalog_segment(
+    path: &Path,
+    workspace: &Path,
+) -> Result<Option<Vec<Arc<TranscriptRecord>>>, SessionError> {
+    transcript::load_matching(path, |first| {
+        session_started_record(first).is_none_or(|started| started.workspace == workspace)
+    })
+    .map_err(Into::into)
+}
+
+fn collect_catalog(
+    config_path: &Path,
+    workspace: &Path,
+    segments: impl IntoIterator<Item = Result<Option<Vec<Arc<TranscriptRecord>>>, SessionError>>,
+) -> Result<Vec<SessionSummary>, SessionError> {
     let mut sessions = HashMap::<String, SessionSummary>::new();
-    for path in transcript_paths(config_path)? {
-        let Some(records) = transcript::load_matching(&path, |first| {
-            session_started_record(first).is_none_or(|started| started.workspace == workspace)
-        })?
-        else {
+    for segment in segments {
+        let Some(records) = segment? else {
             continue;
         };
         let Some(started) = session_started(&records) else {
@@ -586,8 +641,8 @@ fn create_private_directory(path: &Path) -> Result<(), SessionError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        encode_filename, format_age, list, load_checkpoint, load_transcript, load_transcript_async,
-        obsolete_checkpoint_path, save_checkpoint,
+        encode_filename, format_age, list, list_async, load_checkpoint, load_transcript,
+        load_transcript_async, obsolete_checkpoint_path, save_checkpoint,
     };
     use crate::{
         config::{ReasoningEffort, ReasoningMode},
@@ -731,6 +786,11 @@ mod tests {
         assert_eq!(sessions[0].preview, "inspect the workspace");
         assert_eq!(sessions[0].effort, ReasoningEffort::Low);
         assert_eq!(sessions[0].reasoning_mode, ReasoningMode::Pro);
+        let async_sessions = list_async(config.clone(), Path::new("/work").to_path_buf())
+            .await
+            .unwrap();
+        assert_eq!(async_sessions.len(), 1);
+        assert_eq!(async_sessions[0].session_id, "session/one");
         assert_eq!(load_transcript(&config, "session/one").unwrap().len(), 3);
         let loaded = load_transcript_async(config.clone(), "session/one".to_owned())
             .await

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -11,7 +11,7 @@ use nanocodex::SessionSnapshot;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::{self, File},
     io::{self, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
@@ -674,6 +674,7 @@ fn segment_summary_path(transcript_path: &Path) -> PathBuf {
 }
 
 fn compact_projection_records(records: Vec<Arc<TranscriptRecord>>) -> Vec<Arc<TranscriptRecord>> {
+    let records = discard_completed_assistant_deltas(records);
     let latest_outbound = records
         .iter()
         .rposition(|record| api_event_projection(record) == ApiEventProjection::LatestOutbound);
@@ -699,6 +700,56 @@ fn compact_projection_records(records: Vec<Arc<TranscriptRecord>>) -> Vec<Arc<Tr
             ApiEventProjection::LatestOutbound => None,
         })
         .collect()
+}
+
+fn discard_completed_assistant_deltas(
+    records: Vec<Arc<TranscriptRecord>>,
+) -> Vec<Arc<TranscriptRecord>> {
+    let mut completed_messages = HashSet::new();
+    let mut compacted = Vec::with_capacity(records.len());
+    for record in records.into_iter().rev() {
+        match record.kind() {
+            "assistant.message" => {
+                if let Some(key) = assistant_message_key(&record) {
+                    completed_messages.insert(key);
+                }
+                compacted.push(record);
+            }
+            "assistant.delta" => {
+                let completed = assistant_message_key(&record)
+                    .is_some_and(|key| completed_messages.contains(&key));
+                if !completed {
+                    compacted.push(record);
+                }
+            }
+            _ => compacted.push(record),
+        }
+    }
+    compacted.reverse();
+    compacted
+}
+
+fn assistant_message_key(record: &TranscriptRecord) -> Option<AssistantMessageKey> {
+    let payload = record.decode_payload::<AssistantMessageIdentity>().ok()?;
+    Some(AssistantMessageKey {
+        model_call_index: payload.model_call_index,
+        item_id: payload.item_id,
+        commentary: payload.phase.as_deref() == Some("commentary"),
+    })
+}
+
+#[derive(Eq, Hash, PartialEq)]
+struct AssistantMessageKey {
+    model_call_index: u32,
+    item_id: Option<String>,
+    commentary: bool,
+}
+
+#[derive(Deserialize)]
+struct AssistantMessageIdentity {
+    model_call_index: u32,
+    item_id: Option<String>,
+    phase: Option<String>,
 }
 
 fn read_transcript_projection(
@@ -1159,15 +1210,71 @@ mod tests {
                 })
                 .unwrap();
         }
+        for (sequence, kind, payload) in [
+            (
+                4,
+                AgentEventKind::AssistantDelta,
+                json!({
+                    "model_call_index": 1,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": "partial"
+                }),
+            ),
+            (
+                5,
+                AgentEventKind::AssistantDelta,
+                json!({
+                    "model_call_index": 1,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": " response"
+                }),
+            ),
+            (
+                6,
+                AgentEventKind::AssistantMessage,
+                json!({
+                    "model_call_index": 1,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": "complete response"
+                }),
+            ),
+        ] {
+            journal
+                .append_agent(AgentEvent {
+                    protocol_version: 1,
+                    request_id: Arc::from("request"),
+                    seq: sequence,
+                    kind,
+                    payload: to_raw_value(&payload).unwrap(),
+                })
+                .unwrap();
+        }
         drop(journal);
         writer.into_task().await.unwrap().unwrap();
 
         let projected = load_transcript(&config, "session").unwrap();
-        assert_eq!(projected.len(), 3);
+        assert_eq!(projected.len(), 4);
         assert_eq!(
             projected
                 .iter()
                 .filter(|record| record.kind() == "api.event")
+                .count(),
+            1
+        );
+        assert_eq!(
+            projected
+                .iter()
+                .filter(|record| record.kind() == "assistant.delta")
+                .count(),
+            0
+        );
+        assert_eq!(
+            projected
+                .iter()
+                .filter(|record| record.kind() == "assistant.message")
                 .count(),
             1
         );

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     config::{ReasoningEffort, ReasoningMode},
-    tui::transcript::{self, SessionStarted, TranscriptRecord},
+    tui::{
+        context::{ApiEventProjection, api_event_projection},
+        transcript::{self, SessionStarted, TranscriptRecord},
+    },
 };
 use nanocodex::SessionSnapshot;
 use rayon::prelude::*;
@@ -23,6 +26,7 @@ use zstd::stream::{read::Decoder, write::Encoder};
 const COMPRESSION_LEVEL: i32 = 3;
 const CHECKPOINT_FORMAT_VERSION: u32 = 1;
 const SEGMENT_SUMMARY_FORMAT_VERSION: u32 = 1;
+const PROJECTION_FORMAT_VERSION: u32 = 1;
 
 #[cfg(unix)]
 use std::os::unix::fs::DirBuilderExt;
@@ -43,6 +47,32 @@ struct StoredSegmentSummary {
     format_version: u32,
     transcript_bytes: u64,
     summary: SessionSummary,
+}
+
+#[derive(Deserialize, Eq, PartialEq, Serialize)]
+struct TranscriptFingerprint {
+    filename: String,
+    bytes: u64,
+    modified_unix_ns: u128,
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredTranscriptProjection {
+    format_version: u32,
+    transcript_fingerprint: Vec<TranscriptFingerprint>,
+    records: Vec<Arc<TranscriptRecord>>,
+}
+
+#[derive(Serialize)]
+struct TranscriptProjectionEnvelope<'a> {
+    format_version: u32,
+    transcript_fingerprint: Vec<TranscriptFingerprint>,
+    records: &'a [Arc<TranscriptRecord>],
+}
+
+struct LoadedSessionSegment {
+    records: Vec<Arc<TranscriptRecord>>,
+    complete: bool,
 }
 
 #[derive(Serialize)]
@@ -372,12 +402,21 @@ pub(crate) fn load_transcript(
     config_path: &Path,
     session_id: &str,
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
+    if let Some(records) = read_transcript_projection(config_path, session_id) {
+        return Ok(records);
+    }
     let mut records = Vec::new();
+    let mut complete = true;
     for path in transcript_paths(config_path)? {
         let Some(segment) = load_session_segment(&path, session_id)? else {
             continue;
         };
-        records.extend(segment);
+        complete &= segment.complete;
+        records.extend(segment.records);
+    }
+    if complete {
+        records = compact_projection_records(records);
+        write_transcript_projection(config_path, session_id, &records);
     }
     Ok(records)
 }
@@ -407,6 +446,9 @@ fn load_transcript_parallel_inner(
     config_path: &Path,
     session_id: &str,
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
+    if let Some(records) = read_transcript_projection(config_path, session_id) {
+        return Ok(records);
+    }
     let segments = transcript_paths(config_path)?
         .into_par_iter()
         .map(|path| load_session_segment(&path, session_id))
@@ -414,8 +456,14 @@ fn load_transcript_parallel_inner(
         .into_iter()
         .collect::<Result<Vec<_>, SessionError>>()?;
     let mut records = Vec::new();
+    let mut complete = true;
     for segment in segments.into_iter().flatten() {
-        records.extend(segment);
+        complete &= segment.complete;
+        records.extend(segment.records);
+    }
+    if complete {
+        records = compact_projection_records(records);
+        write_transcript_projection(config_path, session_id, &records);
     }
     Ok(records)
 }
@@ -423,7 +471,7 @@ fn load_transcript_parallel_inner(
 fn load_session_segment(
     path: &Path,
     session_id: &str,
-) -> Result<Option<Vec<Arc<TranscriptRecord>>>, SessionError> {
+) -> Result<Option<LoadedSessionSegment>, SessionError> {
     if let Some(summary) = read_segment_summary(path)
         && summary.session_id != session_id
     {
@@ -442,7 +490,10 @@ fn load_session_segment(
     {
         write_segment_summary(path, &summary);
     }
-    Ok(matches.then_some(segment.records))
+    Ok(matches.then_some(LoadedSessionSegment {
+        records: segment.records,
+        complete: segment.complete,
+    }))
 }
 
 fn transcript_loader() -> &'static rayon::ThreadPool {
@@ -596,6 +647,109 @@ fn segment_summary_path(transcript_path: &Path) -> PathBuf {
     transcript_path.with_extension("summary.json")
 }
 
+fn compact_projection_records(records: Vec<Arc<TranscriptRecord>>) -> Vec<Arc<TranscriptRecord>> {
+    let latest_outbound = records
+        .iter()
+        .rposition(|record| api_event_projection(record) == ApiEventProjection::LatestOutbound);
+    records
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, record)| match api_event_projection(&record) {
+            ApiEventProjection::Discard => None,
+            ApiEventProjection::Retain => Some(record),
+            ApiEventProjection::LatestOutbound if Some(index) == latest_outbound => Some(record),
+            ApiEventProjection::LatestOutbound => None,
+        })
+        .collect()
+}
+
+fn read_transcript_projection(
+    config_path: &Path,
+    session_id: &str,
+) -> Option<Vec<Arc<TranscriptRecord>>> {
+    let path = transcript_projection_path(config_path, session_id);
+    let decoder = Decoder::new(File::open(path).ok()?).ok()?;
+    let stored =
+        serde_json::from_reader::<_, StoredTranscriptProjection>(BufReader::new(decoder)).ok()?;
+    if stored.format_version != PROJECTION_FORMAT_VERSION {
+        return None;
+    }
+    let fingerprint = transcript_fingerprint(config_path).ok()?;
+    (stored.transcript_fingerprint == fingerprint).then_some(stored.records)
+}
+
+fn write_transcript_projection(
+    config_path: &Path,
+    session_id: &str,
+    records: &[Arc<TranscriptRecord>],
+) {
+    let _ = try_write_transcript_projection(config_path, session_id, records);
+}
+
+fn try_write_transcript_projection(
+    config_path: &Path,
+    session_id: &str,
+    records: &[Arc<TranscriptRecord>],
+) -> Option<()> {
+    let fingerprint = transcript_fingerprint(config_path).ok()?;
+    let directory = transcript_projection_directory(config_path);
+    create_private_directory(&directory).ok()?;
+    let path = transcript_projection_path(config_path, session_id);
+    let mut temporary = NamedTempFile::new_in(&directory).ok()?;
+    {
+        let mut output = Encoder::new(&mut temporary, COMPRESSION_LEVEL).ok()?;
+        serde_json::to_writer(
+            &mut output,
+            &TranscriptProjectionEnvelope {
+                format_version: PROJECTION_FORMAT_VERSION,
+                transcript_fingerprint: fingerprint,
+                records,
+            },
+        )
+        .ok()?;
+        output.finish().ok()?;
+    }
+    temporary.flush().ok()?;
+    temporary.persist(path).ok()?;
+    Some(())
+}
+
+fn transcript_fingerprint(config_path: &Path) -> Result<Vec<TranscriptFingerprint>, SessionError> {
+    transcript_paths(config_path)?
+        .into_iter()
+        .map(|path| {
+            let metadata = fs::metadata(&path).map_err(|source| SessionError::ReadDirectory {
+                path: path.clone(),
+                source,
+            })?;
+            let modified_unix_ns = metadata
+                .modified()
+                .unwrap_or(UNIX_EPOCH)
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            Ok(TranscriptFingerprint {
+                filename: path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .into_owned(),
+                bytes: metadata.len(),
+                modified_unix_ns,
+            })
+        })
+        .collect()
+}
+
+fn transcript_projection_directory(config_path: &Path) -> PathBuf {
+    data_directory(config_path).join("transcript-projections/v1")
+}
+
+fn transcript_projection_path(config_path: &Path, session_id: &str) -> PathBuf {
+    transcript_projection_directory(config_path)
+        .join(format!("{}.json.zst", encode_filename(session_id)))
+}
+
 fn checkpoint_directory(config_path: &Path) -> PathBuf {
     checkpoint_root(config_path).join(format!("v{CHECKPOINT_FORMAT_VERSION}"))
 }
@@ -714,14 +868,15 @@ mod tests {
     use super::{
         encode_filename, format_age, list, list_async, load_checkpoint, load_transcript,
         load_transcript_async, obsolete_checkpoint_path, save_checkpoint,
+        transcript_projection_path,
     };
     use crate::{
         config::{ReasoningEffort, ReasoningMode},
         tui::transcript::{LocalEvent, SessionStarted, TranscriptJournal, TurnId},
     };
-    use nanocodex::SessionSnapshot;
-    use serde_json::{Value, json};
-    use std::{fs, path::Path};
+    use nanocodex::{AgentEvent, AgentEventKind, SessionSnapshot};
+    use serde_json::{Value, json, value::to_raw_value};
+    use std::{fs, path::Path, sync::Arc};
     use tempfile::tempdir;
 
     fn snapshot(lineage: &str) -> SessionSnapshot {
@@ -877,5 +1032,84 @@ mod tests {
         assert_eq!(loaded.len(), 3);
         assert_eq!(loaded[0].kind(), "session.started");
         assert_eq!(loaded[2].kind(), "effort.changed");
+    }
+
+    #[tokio::test]
+    async fn projection_cache_discards_streaming_api_events_and_recovers_from_corruption() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal
+            .append_local(LocalEvent::SessionStarted(SessionStarted {
+                session_id: "session".to_owned(),
+                parent_session_id: None,
+                model: "model".to_owned(),
+                effort: ReasoningEffort::Medium,
+                reasoning_mode: ReasoningMode::Standard,
+                fast_mode: false,
+                workspace: "/work".into(),
+                application_version: "test".to_owned(),
+            }))
+            .unwrap();
+        for (sequence, payload) in [
+            json!({
+                "direction": "outbound",
+                "phase": "generation",
+                "event": {"prompt_cache_key": "first"}
+            }),
+            json!({
+                "direction": "inbound",
+                "phase": "generation",
+                "event": {"type": "response.output_text.delta", "delta": "discard me"}
+            }),
+            json!({
+                "direction": "outbound",
+                "phase": "generation",
+                "event": {"prompt_cache_key": "latest", "previous_response_id": "response"}
+            }),
+            json!({
+                "direction": "inbound",
+                "phase": "generation",
+                "event": {
+                    "type": "response.completed",
+                    "response": {"usage": {"total_tokens": 42}}
+                }
+            }),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            journal
+                .append_agent(AgentEvent {
+                    protocol_version: 1,
+                    request_id: Arc::from("request"),
+                    seq: u64::try_from(sequence).unwrap(),
+                    kind: AgentEventKind::ApiEvent,
+                    payload: to_raw_value(&payload).unwrap(),
+                })
+                .unwrap();
+        }
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
+
+        let projected = load_transcript(&config, "session").unwrap();
+        assert_eq!(projected.len(), 3);
+        assert_eq!(
+            projected
+                .iter()
+                .filter(|record| record.kind() == "api.event")
+                .count(),
+            2
+        );
+
+        let cache = transcript_projection_path(&config, "session");
+        assert!(cache.is_file());
+        let cached = load_transcript(&config, "session").unwrap();
+        assert_eq!(cached.len(), projected.len());
+
+        fs::write(&cache, b"invalid cache").unwrap();
+        let recovered = load_transcript(&config, "session").unwrap();
+        assert_eq!(recovered.len(), projected.len());
+        assert!(fs::metadata(cache).unwrap().len() > b"invalid cache".len() as u64);
     }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -1,7 +1,7 @@
 //! Terminal lifecycle and synchronized Ratatui frames.
 
-use crossterm::clipboard::CopyToClipboard;
 use crossterm::{
+    clipboard::CopyToClipboard,
     cursor::{Hide, Show},
     event::{
         DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -248,9 +248,18 @@ pub(crate) fn load_matching(
     Ok(load_matching_segment(path, matches_first)?.map(|segment| segment.records))
 }
 
+#[cfg(test)]
 pub(crate) fn load_matching_segment(
     path: &Path,
     matches_first: impl FnOnce(&TranscriptRecord) -> bool,
+) -> Result<Option<LoadedSegment>, TranscriptError> {
+    load_matching_segment_filtered(path, matches_first, |_| true)
+}
+
+pub(crate) fn load_matching_segment_filtered(
+    path: &Path,
+    matches_first: impl FnOnce(&TranscriptRecord) -> bool,
+    mut retain: impl FnMut(&TranscriptRecord) -> bool,
 ) -> Result<Option<LoadedSegment>, TranscriptError> {
     let file = File::open(path).map_err(|source| TranscriptError::Read {
         path: path.to_path_buf(),
@@ -306,7 +315,7 @@ pub(crate) fn load_matching_segment(
                 supported: SCHEMA_VERSION,
             });
         }
-        let expected = u64::try_from(records.len()).unwrap_or(u64::MAX) + 1;
+        let expected = u64::try_from(line).unwrap_or(u64::MAX);
         if record.sequence() != expected {
             return Err(TranscriptError::Sequence {
                 path: path.to_path_buf(),
@@ -320,7 +329,9 @@ pub(crate) fn load_matching_segment(
         {
             return Ok(None);
         }
-        records.push(Arc::new(record));
+        if retain(&record) {
+            records.push(Arc::new(record));
+        }
     }
 
     Ok(Some(LoadedSegment { records, complete }))

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -230,7 +230,15 @@ impl TranscriptWriter {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn load(path: &Path) -> Result<Vec<Arc<TranscriptRecord>>, TranscriptError> {
+    Ok(load_matching(path, |_| true)?.unwrap_or_default())
+}
+
+pub(crate) fn load_matching(
+    path: &Path,
+    matches_first: impl FnOnce(&TranscriptRecord) -> bool,
+) -> Result<Option<Vec<Arc<TranscriptRecord>>>, TranscriptError> {
     let file = File::open(path).map_err(|source| TranscriptError::Read {
         path: path.to_path_buf(),
         source,
@@ -243,6 +251,7 @@ pub(crate) fn load(path: &Path) -> Result<Vec<Arc<TranscriptRecord>>, Transcript
     let mut records = Vec::new();
     let mut bytes = Vec::new();
     let mut line = 0_usize;
+    let mut matches_first = Some(matches_first);
 
     loop {
         bytes.clear();
@@ -291,10 +300,15 @@ pub(crate) fn load(path: &Path) -> Result<Vec<Arc<TranscriptRecord>>, Transcript
                 expected,
             });
         }
+        if let Some(matches_first) = matches_first.take()
+            && !matches_first(&record)
+        {
+            return Ok(None);
+        }
         records.push(Arc::new(record));
     }
 
-    Ok(records)
+    Ok(Some(records))
 }
 
 fn incomplete_zstd_frame(error: &io::Error) -> bool {
@@ -420,7 +434,7 @@ fn unix_milliseconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{DurableWrite, TranscriptJournal, load, write_records};
+    use super::{DurableWrite, TranscriptJournal, load, load_matching, write_records};
     use crate::{
         config::{ReasoningEffort, ReasoningMode},
         tui::transcript::{
@@ -558,6 +572,29 @@ mod tests {
 
         let error = load(&path).unwrap_err();
         assert!(matches!(error, TranscriptError::Decode { line: 1, .. }));
+    }
+
+    #[test]
+    fn rejected_segment_does_not_decode_later_records() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("transcript.jsonl.zst");
+        let first = super::super::record::TranscriptRecord::from_local(
+            1,
+            1,
+            LocalEvent::WorkerTurnAccepted { id: TurnId::new(1) },
+        )
+        .unwrap();
+        let mut contents = serde_json::to_vec(&first).unwrap();
+        contents.extend_from_slice(b"\nnot-json\n");
+        fs::write(&path, zstd::encode_all(contents.as_slice(), 1).unwrap()).unwrap();
+
+        let records = load_matching(&path, |_| false).unwrap();
+
+        assert!(records.is_none());
+        assert!(matches!(
+            load(&path).unwrap_err(),
+            TranscriptError::Decode { line: 2, .. }
+        ));
     }
 
     #[test]

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -35,6 +35,7 @@ pub(crate) struct TranscriptWriter {
 pub(crate) struct LoadedSegment {
     pub(crate) records: Vec<Arc<TranscriptRecord>>,
     pub(crate) complete: bool,
+    pub(crate) observed_records: usize,
 }
 
 trait DurableWrite: Write + Send + 'static {
@@ -334,7 +335,11 @@ pub(crate) fn load_matching_segment_filtered(
         }
     }
 
-    Ok(Some(LoadedSegment { records, complete }))
+    Ok(Some(LoadedSegment {
+        records,
+        complete,
+        observed_records: line,
+    }))
 }
 
 fn incomplete_zstd_frame(error: &io::Error) -> bool {

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -32,6 +32,11 @@ pub(crate) struct TranscriptWriter {
     task: JoinHandle<Result<(), TranscriptError>>,
 }
 
+pub(crate) struct LoadedSegment {
+    pub(crate) records: Vec<Arc<TranscriptRecord>>,
+    pub(crate) complete: bool,
+}
+
 trait DurableWrite: Write + Send + 'static {
     fn synchronize(&self) -> io::Result<()>;
 }
@@ -235,10 +240,18 @@ pub(crate) fn load(path: &Path) -> Result<Vec<Arc<TranscriptRecord>>, Transcript
     Ok(load_matching(path, |_| true)?.unwrap_or_default())
 }
 
+#[cfg(test)]
 pub(crate) fn load_matching(
     path: &Path,
     matches_first: impl FnOnce(&TranscriptRecord) -> bool,
 ) -> Result<Option<Vec<Arc<TranscriptRecord>>>, TranscriptError> {
+    Ok(load_matching_segment(path, matches_first)?.map(|segment| segment.records))
+}
+
+pub(crate) fn load_matching_segment(
+    path: &Path,
+    matches_first: impl FnOnce(&TranscriptRecord) -> bool,
+) -> Result<Option<LoadedSegment>, TranscriptError> {
     let file = File::open(path).map_err(|source| TranscriptError::Read {
         path: path.to_path_buf(),
         source,
@@ -252,6 +265,7 @@ pub(crate) fn load_matching(
     let mut bytes = Vec::new();
     let mut line = 0_usize;
     let mut matches_first = Some(matches_first);
+    let mut complete = false;
 
     loop {
         bytes.clear();
@@ -266,6 +280,7 @@ pub(crate) fn load_matching(
             }
         };
         if read == 0 {
+            complete = true;
             break;
         }
         line += 1;
@@ -308,7 +323,7 @@ pub(crate) fn load_matching(
         records.push(Arc::new(record));
     }
 
-    Ok(Some(records))
+    Ok(Some(LoadedSegment { records, complete }))
 }
 
 fn incomplete_zstd_frame(error: &io::Error) -> bool {
@@ -434,7 +449,9 @@ fn unix_milliseconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{DurableWrite, TranscriptJournal, load, load_matching, write_records};
+    use super::{
+        DurableWrite, TranscriptJournal, load, load_matching, load_matching_segment, write_records,
+    };
     use crate::{
         config::{ReasoningEffort, ReasoningMode},
         tui::transcript::{
@@ -497,6 +514,12 @@ mod tests {
             path.parent().unwrap(),
             directory.path().join("transcripts/v1")
         );
+        assert!(
+            load_matching_segment(&path, |_| true)
+                .unwrap()
+                .unwrap()
+                .complete
+        );
 
         let length = fs::metadata(&path).unwrap().len();
         fs::OpenOptions::new()
@@ -506,6 +529,12 @@ mod tests {
             .set_len(length - 3)
             .unwrap();
         assert_eq!(load(&path).unwrap().len(), 3);
+        assert!(
+            !load_matching_segment(&path, |_| true)
+                .unwrap()
+                .unwrap()
+                .complete
+        );
     }
 
     #[tokio::test]

--- a/src/tui/transcript/mod.rs
+++ b/src/tui/transcript/mod.rs
@@ -10,7 +10,9 @@ pub(crate) use entry::{
 };
 #[cfg(test)]
 pub(crate) use journal::load;
-pub(crate) use journal::{TranscriptJournal, load_matching, remove_obsolete, storage_directory};
+pub(crate) use journal::{
+    TranscriptJournal, load_matching_segment, remove_obsolete, storage_directory,
+};
 pub(crate) use model::TranscriptModel;
 pub(crate) use record::{
     LocalEvent, SessionEnded, SessionOutcome, SessionStarted, ShellId, TranscriptRecord, TurnId,

--- a/src/tui/transcript/mod.rs
+++ b/src/tui/transcript/mod.rs
@@ -8,7 +8,9 @@ mod record;
 pub(crate) use entry::{
     EntryId, EntryKind, MessagePhase, ToolEntry, ToolState, TranscriptEntry, TransientStatus,
 };
-pub(crate) use journal::{TranscriptJournal, load, remove_obsolete, storage_directory};
+#[cfg(test)]
+pub(crate) use journal::load;
+pub(crate) use journal::{TranscriptJournal, load_matching, remove_obsolete, storage_directory};
 pub(crate) use model::TranscriptModel;
 pub(crate) use record::{
     LocalEvent, SessionEnded, SessionOutcome, SessionStarted, ShellId, TranscriptRecord, TurnId,

--- a/src/tui/transcript/mod.rs
+++ b/src/tui/transcript/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use entry::{
 #[cfg(test)]
 pub(crate) use journal::load;
 pub(crate) use journal::{
-    TranscriptJournal, load_matching_segment, remove_obsolete, storage_directory,
+    TranscriptJournal, load_matching_segment_filtered, remove_obsolete, storage_directory,
 };
 pub(crate) use model::TranscriptModel;
 pub(crate) use record::{

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -255,9 +255,10 @@ impl TranscriptRecord {
         &self.source
     }
 
-    pub(crate) fn decode_payload<T: serde::de::DeserializeOwned>(
-        &self,
-    ) -> Result<T, serde_json::Error> {
+    pub(crate) fn decode_payload<'a, T>(&'a self) -> Result<T, serde_json::Error>
+    where
+        T: serde::Deserialize<'a>,
+    {
         serde_json::from_str(self.payload.get())
     }
 

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -89,6 +89,10 @@ pub(crate) enum LocalEvent {
         from: bool,
         to: bool,
     },
+    ContextObserved {
+        prompt_cache: bool,
+        previous_response: bool,
+    },
     WorkerTurnAccepted {
         id: TurnId,
     },
@@ -195,6 +199,16 @@ impl TranscriptRecord {
             LocalEvent::FastModeChanged { from, to } => (
                 "fast_mode.changed",
                 to_raw_value(&FastModeChanged { from, to })?,
+            ),
+            LocalEvent::ContextObserved {
+                prompt_cache,
+                previous_response,
+            } => (
+                "context.observed",
+                to_raw_value(&ContextObserved {
+                    prompt_cache,
+                    previous_response,
+                })?,
             ),
             LocalEvent::WorkerTurnAccepted { id } => {
                 ("worker.turn_accepted", to_raw_value(&WorkerTurn { id })?)
@@ -313,6 +327,12 @@ struct EffortChanged {
 struct FastModeChanged {
     from: bool,
     to: bool,
+}
+
+#[derive(Serialize)]
+struct ContextObserved {
+    prompt_cache: bool,
+    previous_response: bool,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

- reject unrelated transcript segments after reading only their first record and cache completed segment summaries for fast session discovery
- load catalogs and multi-segment transcripts concurrently on a bounded Rayon pool while Tokio awaits completion through channels
- move transcript loading and projection construction off Tokio worker threads
- cache compact, validated transcript projections and discard irrelevant API telemetry before allocation
- decode context telemetry once and omit completed assistant deltas superseded by final messages
- bind derived caches to their session and source metadata, recover from corrupt caches, and avoid retaining raw outbound request secrets

## Performance

Local Criterion measurements with filesystem pages warm:

| Workload | Before | After |
| --- | ---: | ---: |
| API-heavy warm resume | 37.0 ms | 53.5 µs |
| API-heavy projection-cache rebuild resume | 37.0 ms | 13.5 ms |
| Session catalog | 23.2 ms | 133 µs |
| Four-segment cache-cold load | 14.5 ms serial | 4.11 ms parallel |
| Realistic 1,000-turn mixed warm resume | 10.1 ms | 4.86 ms |
| Realistic 1,000-turn mixed cache-rebuild resume | 13.7 ms | 9.50 ms |

“Cache-cold” means the derived projection cache was removed while filesystem pages remained warm.

## Concurrency

Rayon work runs on a dedicated pool capped at four threads. Async callers receive completion through Tokio one-shot channels, so no Tokio worker blocks waiting for Rayon. Segment collection preserves transcript order.

## Validation

- `cargo test -q` — 419 passed
- `cargo check --all-targets --locked`
- `cargo codspeed build --locked`
- `cargo codspeed run` — all 28 benchmarks discovered and executed
