### PR TITLE
Upgrade nanocodex to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -387,6 +387,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "backtrace"
@@ -724,6 +747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codspeed"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,7 +831,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1185,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +1274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1393,6 +1431,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1980,7 +2024,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2301,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.1.1"
-source = "git+https://github.com/gakonst/nanocodex?rev=8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf#8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf"
+source = "git+https://github.com/gakonst/nanocodex?rev=4cef15d4c06f2a355de4347688a31c3fb28b07d2#4cef15d4c06f2a355de4347688a31c3fb28b07d2"
 dependencies = [
  "async-trait",
  "base64",
@@ -2315,7 +2359,7 @@ dependencies = [
  "nanocodex-mcp",
  "nanocodex-service",
  "nanocodex-tools",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "schemars",
  "serde",
  "serde_json",
@@ -2335,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-core"
 version = "0.1.1"
-source = "git+https://github.com/gakonst/nanocodex?rev=8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf#8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf"
+source = "git+https://github.com/gakonst/nanocodex?rev=4cef15d4c06f2a355de4347688a31c3fb28b07d2#4cef15d4c06f2a355de4347688a31c3fb28b07d2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2348,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-macros"
 version = "0.1.1"
-source = "git+https://github.com/gakonst/nanocodex?rev=8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf#8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf"
+source = "git+https://github.com/gakonst/nanocodex?rev=4cef15d4c06f2a355de4347688a31c3fb28b07d2#4cef15d4c06f2a355de4347688a31c3fb28b07d2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2359,13 +2403,14 @@ dependencies = [
 [[package]]
 name = "nanocodex-mcp"
 version = "0.1.1"
-source = "git+https://github.com/gakonst/nanocodex?rev=8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf#8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf"
+source = "git+https://github.com/gakonst/nanocodex?rev=4cef15d4c06f2a355de4347688a31c3fb28b07d2#4cef15d4c06f2a355de4347688a31c3fb28b07d2"
 dependencies = [
  "async-trait",
  "bm25",
  "http",
  "nanocodex-core",
  "nanocodex-tools",
+ "reqwest 0.13.4",
  "rmcp",
  "rustls",
  "serde",
@@ -2378,14 +2423,14 @@ dependencies = [
 [[package]]
 name = "nanocodex-service"
 version = "0.1.1"
-source = "git+https://github.com/gakonst/nanocodex?rev=8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf#8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf"
+source = "git+https://github.com/gakonst/nanocodex?rev=4cef15d4c06f2a355de4347688a31c3fb28b07d2#4cef15d4c06f2a355de4347688a31c3fb28b07d2"
 dependencies = [
  "base64",
  "futures-util",
  "http",
  "js-sys",
  "nanocodex-core",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
@@ -2403,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.1.1"
-source = "git+https://github.com/gakonst/nanocodex?rev=8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf#8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf"
+source = "git+https://github.com/gakonst/nanocodex?rev=4cef15d4c06f2a355de4347688a31c3fb28b07d2#4cef15d4c06f2a355de4347688a31c3fb28b07d2"
 dependencies = [
  "async-trait",
  "base64",
@@ -2413,7 +2458,7 @@ dependencies = [
  "nanocodex-core",
  "nix 0.30.1",
  "portable-pty",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "rquickjs",
  "schemars",
  "serde",
@@ -3070,6 +3115,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -3097,7 +3143,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3409,11 +3455,13 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3564,7 +3612,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3573,6 +3621,7 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3621,7 +3670,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3636,6 +3685,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3980,7 +4030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4219,7 +4269,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4232,7 +4282,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4242,7 +4292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4681,7 +4731,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5042,7 +5092,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ flate2 = "1.1.9"
 futures-util = "0.3.33"
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = { version = "0.1.1", git = "https://github.com/gakonst/nanocodex", rev = "8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf" }
-nanocodex-core = { version = "0.1.1", git = "https://github.com/gakonst/nanocodex", rev = "8b9af4e3b4d18bf8dd2f5cc67ae4d831a8682cdf" }
+nanocodex = { version = "0.1.1", git = "https://github.com/gakonst/nanocodex", rev = "4cef15d4c06f2a355de4347688a31c3fb28b07d2" }
+nanocodex-core = { version = "0.1.1", git = "https://github.com/gakonst/nanocodex", rev = "4cef15d4c06f2a355de4347688a31c3fb28b07d2" }
 pulldown-cmark = { version = "0.13.4", default-features = false }
 png = "0.18.1"
 ratatui = "0.30.2"


### PR DESCRIPTION
## Summary

- upgrade nanocodex and nanocodex-core from 8b9af4e3 to upstream master at 4cef15d4
- refresh the lockfile for the updated dependency graph
- retain source compatibility without tact code changes

## Validation

- cargo check --all-targets --locked
- cargo test --all-targets --locked (420 tests plus benchmark smoke checks)
- cargo +stable clippy --all-targets --locked -- -D warnings
- cargo +nightly fmt --all -- --check
- cargo codspeed build --locked
- Rust 1.90 all-target compatibility check

## Upstream behavior changes

- MCP providers begin prewarming during agent construction
- stable response-item IDs persist through checkpoints and compaction
- detailed reasoning summaries are no longer explicitly requested
- the dependency graph now includes the AWS-LC native build path