### PR TITLE
Select search menu results with Tab

### DIFF
--- a/src/tui/components/actions.rs
+++ b/src/tui/components/actions.rs
@@ -29,7 +29,7 @@ const ACTIONS: [Action; 11] = [
     Action::Subagents,
     Action::DebugContext,
 ];
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter open", "esc close"];
+const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab open", "esc close"];
 const SEARCH_LABEL: &str = "Search: ";
 const SELECTION_MARKER: &str = "› ";
 
@@ -93,7 +93,7 @@ impl ActionsMenu {
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
             KeyCode::Backspace => Self::dismiss(),
-            KeyCode::Enter => self.trigger_selected(),
+            KeyCode::Enter | KeyCode::Tab => self.trigger_selected(),
             KeyCode::Up => {
                 self.select_previous();
                 ComponentUpdate::render(RenderRequest::Immediate)
@@ -466,7 +466,7 @@ mod tests {
         );
         assert_eq!(
             row_segment(&terminal, 14, 1, 58),
-            "│            ↑↓ move · enter open · esc close            │"
+            "│          ↑↓ move · enter/tab open · esc close          │"
         );
         assert_eq!(
             row_segment(&terminal, 15, 1, 58),
@@ -512,6 +512,17 @@ mod tests {
         menu.update(key(KeyCode::Char('h')));
         assert_eq!(menu.query, "th");
         assert_eq!(menu.selected, 0);
+    }
+
+    #[test]
+    fn tab_triggers_the_selected_action() {
+        let mut menu = ActionsMenu::new(available());
+        menu.update(key(KeyCode::Down));
+
+        assert_eq!(
+            menu.update(key(KeyCode::Tab)).effects,
+            [ActionsEffect::Trigger(Action::FastMode)]
+        );
     }
 
     #[test]

--- a/src/tui/components/file_finder.rs
+++ b/src/tui/components/file_finder.rs
@@ -17,7 +17,7 @@ use std::{cmp::Reverse, fs, path::Path};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter insert", "esc close"];
+const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab insert", "esc close"];
 const SEARCH_LABEL: &str = "Search: ";
 const FOCUS_MARKER: &str = "› ";
 const SKIPPED_DIRECTORIES: [&str; 4] = [".git", ".jj", "node_modules", "target"];
@@ -59,7 +59,7 @@ impl FileFinder {
 
         match key.code {
             KeyCode::Esc => Self::dismiss(),
-            KeyCode::Enter => self.handle_enter(),
+            KeyCode::Enter | KeyCode::Tab => self.handle_enter(),
             KeyCode::Up => {
                 self.select_previous();
                 ComponentUpdate::render(RenderRequest::Immediate)
@@ -343,6 +343,18 @@ mod tests {
     }
 
     #[test]
+    fn tab_inserts_the_selected_search_result() {
+        let workspace = workspace();
+        let mut finder = FileFinder::new(workspace.path());
+        finder.update(FileFinderEvent::Query("read".to_owned()));
+
+        assert_eq!(
+            finder.update(key(KeyCode::Tab)).effects,
+            [FileFinderEffect::Insert("README.md".to_owned())]
+        );
+    }
+
+    #[test]
     fn arrows_navigate_results_before_selection() {
         let workspace = workspace();
         let mut finder = FileFinder::new(workspace.path());
@@ -390,12 +402,12 @@ mod tests {
                 .iter()
                 .map(|cell| cell.symbol())
                 .collect::<String>()
-                .contains("enter insert")
+                .contains("enter/tab insert")
         }));
     }
 
     #[test]
-    fn footer_says_when_enter_will_insert() {
+    fn footer_says_when_enter_or_tab_will_insert() {
         let workspace = workspace();
         let mut finder = FileFinder::new(workspace.path());
         finder.update(FileFinderEvent::Query("read".to_owned()));
@@ -416,7 +428,7 @@ mod tests {
                         .iter()
                         .map(|cell| cell.symbol())
                         .collect::<String>()
-                        .contains("enter insert")
+                        .contains("enter/tab insert")
                 })
         );
     }

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -1558,7 +1558,7 @@ fn is_file_finder_navigation(event: &Event) -> bool {
     matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
         && matches!(
             key.code,
-            KeyCode::Enter | KeyCode::Up | KeyCode::Down | KeyCode::Esc
+            KeyCode::Enter | KeyCode::Tab | KeyCode::Up | KeyCode::Down | KeyCode::Esc
         )
 }
 
@@ -2072,8 +2072,7 @@ mod tests {
         assert_eq!(root.composer().draft(), "name@example.com");
     }
 
-    #[test]
-    fn selecting_a_file_inserts_its_relative_path_at_the_composer_cursor() {
+    fn assert_file_selection(key_code: KeyCode) {
         let workspace = tempfile::tempdir().unwrap();
         fs::write(workspace.path().join("notes.md"), "remember this").unwrap();
         let mut root = RootNode::new(workspace.path(), ReasoningEffort::Medium);
@@ -2085,10 +2084,20 @@ mod tests {
             root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
         }
 
-        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        root.update(key(key_code, KeyModifiers::NONE));
 
         assert!(root.overlay.is_none());
         assert_eq!(root.composer().draft(), "inspect @notes.md ");
+    }
+
+    #[test]
+    fn enter_selects_a_file_at_the_composer_cursor() {
+        assert_file_selection(KeyCode::Enter);
+    }
+
+    #[test]
+    fn tab_selects_a_file_at_the_composer_cursor() {
+        assert_file_selection(KeyCode::Tab);
     }
 
     #[test]

--- a/src/tui/components/session_picker.rs
+++ b/src/tui/components/session_picker.rs
@@ -19,7 +19,7 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter resume", "esc close"];
+const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab resume", "esc close"];
 const SEARCH_LABEL: &str = "Search: ";
 
 pub(super) enum SessionPickerEvent {
@@ -77,7 +77,7 @@ impl SessionPicker {
                 }
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
-            KeyCode::Enter => self.resume_selected(),
+            KeyCode::Enter | KeyCode::Tab => self.resume_selected(),
             KeyCode::Char(character)
                 if !key
                     .modifiers
@@ -284,6 +284,22 @@ mod tests {
         }
         assert_eq!(
             picker.update(key(KeyCode::Enter)).effects,
+            [SessionPickerEffect::Resume("two".to_owned())]
+        );
+    }
+
+    #[test]
+    fn tab_resumes_the_selected_session() {
+        let mut picker = SessionPicker::new(vec![
+            summary("one", "fix parser"),
+            summary("two", "write docs"),
+        ]);
+        for character in "docs".chars() {
+            picker.update(key(KeyCode::Char(character)));
+        }
+
+        assert_eq!(
+            picker.update(key(KeyCode::Tab)).effects,
             [SessionPickerEffect::Resume("two".to_owned())]
         );
     }


### PR DESCRIPTION
## Summary

- allow Tab to select the highlighted action, file, or session search result
- route Tab through the file-search overlay instead of forwarding it to the composer
- advertise Enter and Tab selection in each menu footer
- add component and end-to-end regression coverage

## Validation

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`