### PR TITLE
chore: migrate to nanocodex 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1233,7 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1766,7 +1766,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2000,7 +1999,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2421,7 +2420,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.3",
  "http",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -2454,7 +2453,7 @@ dependencies = [
  "nix 0.31.3",
  "oauth2",
  "portable-pty",
- "reqwest 0.13.4",
+ "reqwest",
  "rmcp",
  "rquickjs",
  "schemars",
@@ -3219,7 +3218,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3512,44 +3511,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3614,7 +3575,7 @@ dependencies = [
  "http",
  "oauth2",
  "pin-project-lite",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "sse-stream",
@@ -3715,7 +3676,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3726,7 +3687,6 @@ checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3773,7 +3733,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3984,18 +3944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,7 +4109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4345,8 +4293,9 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "rstest",
+ "rustls",
  "self-replace",
  "semver",
  "serde",
@@ -4388,10 +4337,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4404,7 +4353,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4414,7 +4363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4853,7 +4802,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5129,15 +5078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5237,7 +5177,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,13 +360,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -540,12 +540,7 @@ version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cbd8ffdfb7b4c2ff038726178a780a94f90525ed0ad264c0afaa75dd8c18a64"
 dependencies = [
- "cached",
- "deunicode",
  "fxhash",
- "rust-stemmers",
- "stop-words",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -595,39 +590,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "cached"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c"
-dependencies = [
- "ahash",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "hashbrown 0.15.5",
- "once_cell",
- "thiserror 2.0.19",
- "web-time",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cast"
@@ -1075,36 +1037,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1122,22 +1060,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.119",
 ]
@@ -1181,12 +1108,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -1473,12 +1394,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1732,24 +1647,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1760,7 +1664,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2075,7 +1979,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2474,129 +2378,84 @@ dependencies = [
 
 [[package]]
 name = "nanocodex"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36bac98daeca2b8ad2d8acd55762d1faba4f1f0281f19fdad444168fca5733e"
+checksum = "caf8dc41ac1a4ea5d1111b4924b578cdf850544d94a65629d91766a36eddc1da"
 dependencies = [
- "async-trait",
- "base64",
- "chrono",
- "getrandom 0.3.4",
- "iana-time-zone",
- "image",
- "js-sys",
- "nanocodex-core",
- "nanocodex-macros",
- "nanocodex-mcp",
- "nanocodex-service",
+ "nanocodex-agent",
+ "nanocodex-oai-api",
  "nanocodex-tools",
- "reqwest 0.13.4",
- "schemars",
+]
+
+[[package]]
+name = "nanocodex-agent"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc4032756f50cb9064354a3e5c955cabd7a21c3357d78f8c6dc52fb74ba2e5b"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "iana-time-zone",
+ "nanocodex-oai-api",
+ "nanocodex-tools",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
- "url",
  "uuid",
- "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
-name = "nanocodex-core"
-version = "0.2.0"
+name = "nanocodex-oai-api"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8e3c02544e505783e6acaa3ada2b805a1b1aa9cdd4b75cd1669f6cfd74aad6"
-dependencies = [
- "serde",
- "serde_json",
- "smallvec",
- "thiserror 2.0.19",
- "tokio",
- "web-time",
-]
-
-[[package]]
-name = "nanocodex-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf401faacbda9597f3b04cfcc9550847024d763d737933ab0c5ebc28575a5a7"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "nanocodex-mcp"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c764076b92d39be6961e58e5b4c4fbbdd3d7700a6743dc390fa4c7c606c57"
+checksum = "1ba9de4ec8a3bc051efb22462d5bd3357d16b8e25105026240b47794525b00b7"
 dependencies = [
  "async-trait",
- "bm25",
- "http",
- "nanocodex-core",
- "nanocodex-tools",
- "oauth2",
- "reqwest 0.13.4",
- "rmcp",
- "rustls",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nanocodex-service"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b08086f54424a74263e4a6574c97bbf9796adb6f10cd4cae7d7d8571dbfd5a2"
-dependencies = [
  "base64",
  "futures-util",
+ "getrandom 0.4.3",
  "http",
- "js-sys",
- "nanocodex-core",
  "reqwest 0.13.4",
- "rustls",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "smallvec",
  "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "tower",
  "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+ "url",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "nanocodex-tools"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e4f71ca57cf504e785cc8d87e16ace90915456826e052f309b5255d10308b4"
+checksum = "5d3a781e26a7993328c2dd2fea965d1be2b36f659f27be4f63a69c7e056c63ac"
 dependencies = [
  "async-trait",
  "base64",
+ "bm25",
  "futures-util",
+ "getrandom 0.4.3",
+ "http",
  "image",
- "js-sys",
- "nanocodex-core",
- "nix 0.30.1",
+ "nanocodex-oai-api",
+ "nanocodex-tools-macros",
+ "nix 0.31.3",
+ "oauth2",
  "portable-pty",
- "rand 0.9.5",
  "reqwest 0.13.4",
+ "rmcp",
  "rquickjs",
  "schemars",
  "serde",
@@ -2604,9 +2463,20 @@ dependencies = [
  "sha1",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "nanocodex-tools-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f139177f83c5c3df3cab3ad04c6a61ed4649b82271488cd9bd36e906a8b954"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2632,18 +2502,6 @@ dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases 0.2.2",
- "libc",
 ]
 
 [[package]]
@@ -2786,7 +2644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -3285,20 +3143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "process-wrap"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
-dependencies = [
- "futures",
- "indexmap",
- "nix 0.31.3",
- "tokio",
- "tracing",
- "windows",
-]
-
-[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,18 +3250,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3442,31 +3276,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3759,7 +3574,6 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3800,7 +3614,6 @@ dependencies = [
  "http",
  "oauth2",
  "pin-project-lite",
- "process-wrap",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -3869,16 +3682,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
  "unicode-ident",
-]
-
-[[package]]
-name = "rust-stemmers"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
-dependencies = [
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -4228,6 +4031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,6 +4045,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4380,15 +4200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stop-words"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645a3d441ccf4bf47f2e4b7681461986681a6eeea9937d4c3bc9febd61d17c71"
-dependencies = [
- "serde_json",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4530,7 +4341,6 @@ dependencies = [
  "miette",
  "minisign-verify",
  "nanocodex",
- "nanocodex-core",
  "png",
  "pulldown-cmark",
  "ratatui",
@@ -4542,7 +4352,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "shlex",
  "syntect",
  "tar",
@@ -4653,7 +4463,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -5146,6 +4956,7 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -5350,7 +5161,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -5436,27 +5247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5467,17 +5257,6 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -5507,16 +5286,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core",
- "windows-link",
-]
 
 [[package]]
 name = "windows-result"
@@ -5618,15 +5387,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ futures-util = "0.3.33"
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = "0.2.0"
-nanocodex-core = "0.2.0"
+nanocodex = "0.3.0"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 png = "0.18.1"
 ratatui = "0.30.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ pulldown-cmark = { version = "0.13.4", default-features = false }
 png = "0.18.1"
 ratatui = "0.30.2"
 rayon = "1.12.0"
-reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 self-replace = "1.5.0"
 semver = { version = "1.0.28", features = ["serde"] }
 serde = { version = "1.0.229", features = ["derive", "rc"] }
@@ -62,6 +62,7 @@ zstd = "0.13.3"
 [dev-dependencies]
 criterion = { package = "codspeed-criterion-compat", version = "5.0.1" }
 rstest = "0.26.1"
+rustls = { version = "0.23.42", default-features = false, features = ["std"] }
 tower = "0.5.3"
 
 [build-dependencies]

--- a/src/app/auth.rs
+++ b/src/app/auth.rs
@@ -5,7 +5,7 @@ use crate::app::{
     error::{AuthError, AuthResult, SecretError},
     secret::SecretString,
 };
-use nanocodex::{
+use nanocodex::oai::auth::{
     ChatGptAuthStatus, ChatGptLogin, OpenAiAuth, chatgpt_auth_status, load_chatgpt_auth,
     logout_chatgpt,
 };
@@ -150,7 +150,7 @@ mod tests {
         error::AuthError,
         secret::SecretString,
     };
-    use nanocodex::OpenAiAuthMode;
+    use nanocodex::oai::auth::OpenAiAuthMode;
     use std::{cell::Cell, fs};
     use tempfile::tempdir;
 

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -2,8 +2,11 @@
 
 use crate::tui::{session::SessionError, transcript::TranscriptError};
 use miette::Diagnostic;
-use nanocodex::{ChatGptAuthError, McpBuildError, NanocodexError};
-use nanocodex_core::EventError;
+use nanocodex::{
+    NanocodexError,
+    oai::{OpenAiError, auth::ChatGptAuthError, events::EventError},
+    tools::mcp::McpBuildError,
+};
 use std::{
     env::VarError, error::Error as StdError, io, path::PathBuf, result::Result as StdResult,
 };
@@ -26,6 +29,8 @@ pub(crate) enum Error {
     ExternalEditor(#[from] ExternalEditorError),
     #[error("failed to configure MCP servers: {0}")]
     Mcp(#[source] McpBuildError),
+    #[error(transparent)]
+    OpenAi(#[from] OpenAiError),
     #[error(transparent)]
     Runtime(#[from] RuntimeError),
     #[error(transparent)]
@@ -166,6 +171,8 @@ pub(crate) enum RuntimeError {
     SessionTask(#[source] tokio::task::JoinError),
     #[error("the Nanocodex worker stopped before accepting a command")]
     AgentWorkerStopped,
+    #[error("invalid Nanocodex session ID: {0}")]
+    InvalidSessionId(#[source] nanocodex::oai::session::SessionIdError),
     #[error("failed to resolve workspace {path}: {source}")]
     ResolveWorkspace {
         path: PathBuf,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -981,6 +981,11 @@ mod tests {
     }
 
     #[test]
+    fn resolves_one_process_tls_provider() {
+        rustls::ClientConfig::builder();
+    }
+
+    #[test]
     fn parses_v_prefixed_semver_and_compares_by_semver() {
         let release = release("v1.2.3", &[]);
         assert_eq!(release.version, Version::new(1, 2, 3));

--- a/src/core/extensions/mcp.rs
+++ b/src/core/extensions/mcp.rs
@@ -4,7 +4,7 @@ use crate::app::{
     config::{Config, McpServerConfig},
     error::{Error, Result},
 };
-use nanocodex::{Mcp, McpServer};
+use nanocodex::tools::mcp::{Mcp, McpServer};
 use std::{env, env::VarError};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
@@ -94,7 +94,7 @@ mod tests {
         config::{Config, ConfigOverrides},
         error::Error,
     };
-    use nanocodex::McpBuildError;
+    use nanocodex::tools::mcp::McpBuildError;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
     use std::{env::VarError, ffi::OsString, fs};

--- a/src/core/extensions/subagents/harness.rs
+++ b/src/core/extensions/subagents/harness.rs
@@ -216,7 +216,7 @@ impl Harness {
                 }
                 HarnessEvent::Command(None) => {
                     self.fail_pending("subagent harness stopped").await;
-                    drop(self.stop_active().await);
+                    drop(self.close().await);
                     return;
                 }
                 HarnessEvent::Deferred(Some(command)) => {
@@ -554,7 +554,7 @@ impl Harness {
             }
         };
         let control = turn.control();
-        let result = tokio::spawn(async move { turn.result().await });
+        let result = tokio::spawn(turn);
         self.active = Some(ActiveTurn {
             control,
             result,
@@ -564,12 +564,11 @@ impl Harness {
     }
 
     async fn stop_active(&mut self) -> std::io::Result<()> {
-        let Some(mut active) = self.active.take() else {
+        let Some(active) = self.active.as_ref() else {
             return Ok(());
         };
         let cancellation = active.control.cancel().await;
-        let result = (&mut active.result).await;
-        self.publish_turn_result(result).await;
+        self.finish_active().await;
         match cancellation {
             Ok(()) | Err(NanocodexError::TurnNotCancellable) => Ok(()),
             Err(error) => Err(std::io::Error::other(format!(
@@ -577,6 +576,14 @@ impl Harness {
                 self.id
             ))),
         }
+    }
+
+    async fn finish_active(&mut self) {
+        let Some(mut active) = self.active.take() else {
+            return;
+        };
+        let result = (&mut active.result).await;
+        self.publish_turn_result(result).await;
     }
 
     async fn turn_finished(
@@ -604,13 +611,18 @@ impl Harness {
     }
 
     async fn close(&mut self) -> std::io::Result<()> {
-        let stop_result = self.stop_active().await;
-        self.agent = None;
+        let shutdown_result = match self.agent.take() {
+            Some(agent) => agent.shutdown().await.map_err(|error| {
+                std::io::Error::other(format!("could not close agent {}: {error}", self.id))
+            }),
+            None => Ok(()),
+        };
+        self.finish_active().await;
         if let Some(registry) = self.registry.upgrade() {
             registry
                 .harness_closed(&self.root_session_id, self.id)
                 .await;
         }
-        stop_result
+        shutdown_result
     }
 }

--- a/src/core/extensions/subagents/harness.rs
+++ b/src/core/extensions/subagents/harness.rs
@@ -86,7 +86,7 @@ struct Harness {
 
 struct ActiveTurn {
     control: TurnControl,
-    result: JoinHandle<nanocodex::Result<nanocodex::TurnResult>>,
+    result: JoinHandle<nanocodex::agent::Result<nanocodex::TurnResult>>,
     _capacity: TurnCapacity,
 }
 
@@ -95,7 +95,7 @@ enum HarnessEvent {
     Deferred(Option<DeliveryCommand>),
     Urgent(Option<DeliveryCommand>),
     CapacityChanged,
-    TurnFinished(Result<nanocodex::Result<nanocodex::TurnResult>, JoinError>),
+    TurnFinished(Result<nanocodex::agent::Result<nanocodex::TurnResult>, JoinError>),
 }
 
 impl HarnessHandle {
@@ -581,7 +581,7 @@ impl Harness {
 
     async fn turn_finished(
         &mut self,
-        result: Result<nanocodex::Result<nanocodex::TurnResult>, JoinError>,
+        result: Result<nanocodex::agent::Result<nanocodex::TurnResult>, JoinError>,
     ) {
         self.active = None;
         self.publish_turn_result(result).await;
@@ -589,7 +589,7 @@ impl Harness {
 
     async fn publish_turn_result(
         &self,
-        result: Result<nanocodex::Result<nanocodex::TurnResult>, JoinError>,
+        result: Result<nanocodex::agent::Result<nanocodex::TurnResult>, JoinError>,
     ) {
         let result = result.unwrap_or_else(|error| {
             Err(NanocodexError::InvalidRequest(format!(

--- a/src/core/extensions/subagents/model.rs
+++ b/src/core/extensions/subagents/model.rs
@@ -1,4 +1,4 @@
-use nanocodex::AgentEvent;
+use nanocodex::agent::events::AgentEvent;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,

--- a/src/core/extensions/subagents/runtime.rs
+++ b/src/core/extensions/subagents/runtime.rs
@@ -1549,11 +1549,13 @@ mod tests {
     use crate::core::extensions::subagents::{
         AgentUpdate, MessageDeliveryState, MessageDisposition, MessagePriority, MessagePurpose,
     };
-    use nanocodex::oai::{
-        ResponseError,
-        tower::{ResponsesAttempt, ResponsesServiceResponse},
+    use nanocodex::{
+        Nanocodex, OpenAi,
+        oai::{
+            ResponseError,
+            tower::{ResponsesAttempt, ResponsesServiceResponse},
+        },
     };
-    use nanocodex::{Nanocodex, OpenAi};
     use serde_json::json;
     use std::{
         future::{Pending, pending},

--- a/src/core/extensions/subagents/runtime.rs
+++ b/src/core/extensions/subagents/runtime.rs
@@ -906,7 +906,7 @@ impl Registry {
         &self,
         root_session_id: &str,
         id: AgentId,
-        result: nanocodex::Result<nanocodex::TurnResult>,
+        result: nanocodex::agent::Result<nanocodex::TurnResult>,
     ) {
         let status = {
             let mut state = self.state.lock().await;
@@ -1549,9 +1549,11 @@ mod tests {
     use crate::core::extensions::subagents::{
         AgentUpdate, MessageDeliveryState, MessageDisposition, MessagePriority, MessagePurpose,
     };
-    use nanocodex::{
-        Nanocodex, NanocodexError, Responses, ResponsesAttempt, ResponsesServiceResponse,
+    use nanocodex::oai::{
+        ResponseError,
+        tower::{ResponsesAttempt, ResponsesServiceResponse},
     };
+    use nanocodex::{Nanocodex, OpenAi};
     use serde_json::json;
     use std::{
         future::{Pending, pending},
@@ -1573,7 +1575,7 @@ mod tests {
 
     impl Service<ResponsesAttempt> for PendingService {
         type Response = ResponsesServiceResponse;
-        type Error = NanocodexError;
+        type Error = ResponseError;
         type Future = Pending<StdResult<Self::Response, Self::Error>>;
 
         fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<StdResult<(), Self::Error>> {
@@ -1587,15 +1589,13 @@ mod tests {
     }
 
     fn pending_agent(called: Arc<Notify>) -> (Nanocodex, nanocodex::AgentEvents) {
-        let responses = Responses::builder()
+        let openai = OpenAi::builder("test-key")
             .service(move || PendingService {
                 called: Arc::clone(&called),
             })
-            .build();
-        Nanocodex::builder("test-key")
-            .responses(responses)
             .build()
-            .unwrap()
+            .unwrap();
+        Nanocodex::builder(openai).build().unwrap()
     }
 
     fn test_contract() -> OutputContract {

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -7,8 +7,12 @@ use super::{
     runtime::{AgentDirectoryEntry, AgentSummary, OutputContract, Registry, forward_events},
 };
 use nanocodex::{
-    AgentHandle, Tool, ToolContext, ToolDefinition, ToolExecution, ToolInput, ToolResult, Tools,
-    ToolsBuildError, async_trait,
+    Tool, Tools,
+    agent::AgentHandle,
+    tools::{
+        ToolsBuildError,
+        contract::{ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, async_trait},
+    },
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -20,6 +24,11 @@ use tokio::sync::oneshot;
 
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+const SPAWN_AGENT_TOOL: &str = "spawn_agent";
+const SUBMIT_RESULT_TOOL: &str = "submit_result";
+const SEND_AGENT_MESSAGE_TOOL: &str = "send_agent_message";
+const LIST_AGENTS_TOOL: &str = "list_agents";
+const WAIT_AGENT_TOOL: &str = "wait_agent";
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -89,7 +98,7 @@ struct LifecycleReport {
 }
 
 fn json_output(value: &impl Serialize) -> ToolResult {
-    Ok(ToolExecution::from_json(serde_json::to_value(value)?, true))
+    Ok(ToolOutput::from_json(serde_json::to_value(value)?, true))
 }
 
 struct SpawnAgent {
@@ -99,13 +108,9 @@ struct SpawnAgent {
 
 #[async_trait]
 impl Tool for SpawnAgent {
-    fn name(&self) -> &'static str {
-        "spawn_agent"
-    }
-
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
-            self.name(),
+            SPAWN_AGENT_TOOL,
             "Starts a reusable clean-room subagent without inherited conversation history and immediately returns its ID.",
             json!({
                 "type": "object",
@@ -141,7 +146,7 @@ impl Tool for SpawnAgent {
             .upgrade()
             .ok_or_else(|| std::io::Error::other("subagent runtime is closed"))?;
         let capacity = registry.reserve_turn()?;
-        let reservation = registry.reserve(context.session_id).await?;
+        let reservation = registry.reserve(context.session_id()).await?;
         let id = reservation.id;
         let (child, events) = self.parent.spawn().await?;
         let session_id = events.request_id().to_owned();
@@ -202,13 +207,9 @@ struct SubmitResult {
 
 #[async_trait]
 impl Tool for SubmitResult {
-    fn name(&self) -> &'static str {
-        "submit_result"
-    }
-
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
-            self.name(),
+            SUBMIT_RESULT_TOOL,
             "Submits the current subagent turn's final JSON output. Call exactly once with a value matching the output schema in the task prompt. Invalid values can be corrected and retried.",
             json!({
                 "type": "object",
@@ -243,9 +244,9 @@ impl Tool for SubmitResult {
             .upgrade()
             .ok_or_else(|| std::io::Error::other("subagent runtime is closed"))?;
         registry
-            .submit_result(context.session_id, turn_token, output)
+            .submit_result(context.session_id(), turn_token, output)
             .await?;
-        Ok(ToolExecution::from_json(json!({ "accepted": true }), true))
+        Ok(ToolOutput::from_json(json!({ "accepted": true }), true))
     }
 }
 
@@ -255,13 +256,9 @@ struct SendAgentMessage {
 
 #[async_trait]
 impl Tool for SendAgentMessage {
-    fn name(&self) -> &'static str {
-        "send_agent_message"
-    }
-
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
-            self.name(),
+            SEND_AGENT_MESSAGE_TOOL,
             "Sends a bounded directed message to any other agent in the same task tree. Deferred messages start an idle agent or queue behind its active turn. If a send is queued, do not wait for it inside the current turn; finish the turn so queued messages can be delivered. Urgent messages steer a running agent at its next safe model boundary. Delegate messages replace the recipient's assigned task, retain its output schema, and require management authority.",
             json!({
                 "type": "object",
@@ -315,7 +312,7 @@ impl Tool for SendAgentMessage {
             .ok_or_else(|| std::io::Error::other("subagent runtime is closed"))?;
         let receipt = registry
             .send_message(
-                context.session_id,
+                context.session_id(),
                 agent_id,
                 priority,
                 purpose,
@@ -333,13 +330,9 @@ struct ListAgents {
 
 #[async_trait]
 impl Tool for ListAgents {
-    fn name(&self) -> &'static str {
-        "list_agents"
-    }
-
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
-            self.name(),
+            LIST_AGENTS_TOOL,
             "Lists a compact directory of agents in the same task tree. Active recipients are returned by default; completed agents can be included when a follow-up message is needed.",
             json!({
                 "type": "object",
@@ -371,7 +364,7 @@ impl Tool for ListAgents {
             .ok_or_else(|| std::io::Error::other("subagent runtime is closed"))?;
         json_output(&AgentDirectory {
             agents: registry
-                .directory(context.session_id, include_completed, include_self)
+                .directory(context.session_id(), include_completed, include_self)
                 .await,
         })
     }
@@ -383,13 +376,9 @@ struct WaitAgent {
 
 #[async_trait]
 impl Tool for WaitAgent {
-    fn name(&self) -> &'static str {
-        "wait_agent"
-    }
-
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
-            self.name(),
+            WAIT_AGENT_TOOL,
             "Waits until any requested subagent reaches a terminal status and returns current statuses and reports. Use one call with multiple IDs instead of polling the workspace.",
             json!({
                 "type": "object",
@@ -428,7 +417,7 @@ impl Tool for WaitAgent {
             .unwrap_or(DEFAULT_WAIT_TIMEOUT)
             .min(MAX_WAIT_TIMEOUT);
         let (agents, timed_out) = registry
-            .wait(context.session_id, &agent_ids, duration)
+            .wait(context.session_id(), &agent_ids, duration)
             .await?;
         json_output(&WaitReport { agents, timed_out })
     }
@@ -445,15 +434,17 @@ struct ChangeAgentLifecycle {
     operation: LifecycleOperation,
 }
 
-#[async_trait]
-impl Tool for ChangeAgentLifecycle {
-    fn name(&self) -> &'static str {
+impl ChangeAgentLifecycle {
+    fn tool_name(&self) -> &'static str {
         match self.operation {
             LifecycleOperation::Interrupt => "interrupt_agent",
             LifecycleOperation::Close => "close_agent",
         }
     }
+}
 
+#[async_trait]
+impl Tool for ChangeAgentLifecycle {
     fn definition(&self) -> ToolDefinition {
         let description = match self.operation {
             LifecycleOperation::Interrupt => {
@@ -464,7 +455,7 @@ impl Tool for ChangeAgentLifecycle {
             }
         };
         ToolDefinition::function(
-            self.name(),
+            self.tool_name(),
             description,
             json!({
                 "type": "object",
@@ -489,9 +480,9 @@ impl Tool for ChangeAgentLifecycle {
             .ok_or_else(|| std::io::Error::other("subagent runtime is closed"))?;
         let agents = match self.operation {
             LifecycleOperation::Interrupt => {
-                registry.interrupt(context.session_id, agent_id).await?
+                registry.interrupt(context.session_id(), agent_id).await?
             }
-            LifecycleOperation::Close => registry.close(context.session_id, agent_id).await?,
+            LifecycleOperation::Close => registry.close(context.session_id(), agent_id).await?,
         };
         json_output(&LifecycleReport { agents })
     }

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -149,7 +149,7 @@ impl Tool for SpawnAgent {
         let reservation = registry.reserve(context.session_id()).await?;
         let id = reservation.id;
         let (child, events) = self.parent.spawn().await?;
-        let session_id = events.request_id().to_owned();
+        let session_id = child.session_id().to_string();
         let descriptor = AgentDescriptor {
             id,
             session_id,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -323,11 +323,13 @@ mod tests {
         config::SkillsConfig,
         error::{Error, RuntimeError},
     };
-    use nanocodex::oai::{
-        ResponseError,
-        tower::{ResponsesAttempt, ResponsesServiceConfig, ResponsesServiceResponse},
+    use nanocodex::{
+        Nanocodex, OpenAi,
+        oai::{
+            ResponseError,
+            tower::{ResponsesAttempt, ResponsesServiceConfig, ResponsesServiceResponse},
+        },
     };
-    use nanocodex::{Nanocodex, OpenAi};
     use std::{
         fs,
         future::{Pending, pending},

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,8 +15,10 @@ use crate::{
     },
     tui::session::ResumeState,
 };
-use nanocodex::{AgentEvents, Nanocodex, NanocodexError, Responses, Tools, TurnControl};
-use nanocodex_core::ModelConfig;
+use nanocodex::{
+    AgentEvents, Nanocodex, NanocodexError, OpenAi, Tools, TurnControl, agent::session::SessionId,
+    oai::tower::ResponsesServiceConfig,
+};
 #[cfg(feature = "harbor-evals")]
 use orchestration::{OrchestrationRecorder, RunOutcome};
 use std::{
@@ -91,13 +93,14 @@ impl ConfiguredAgent {
         let mcp = mcp_provider(config)?;
         let auth = config.auth().load()?;
 
-        let mut responses = Responses::builder();
+        let mut openai = OpenAi::builder(auth);
         if let Some(url) = agent_config.websocket_url() {
-            responses = responses.websocket_url(url);
+            openai = openai.websocket_url(url);
         }
         if let Some(url) = agent_config.api_base_url() {
-            responses = responses.api_base_url(url);
+            openai = openai.api_base_url(url);
         }
+        let openai = openai.build()?;
 
         let mut tools = Tools::builder()
             .web_search(agent_config.web_search())
@@ -108,12 +111,11 @@ impl ConfiguredAgent {
         let tools = tools.build().map_err(NanocodexError::from)?;
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
-        let mut builder = Nanocodex::builder(auth)
+        let mut builder = Nanocodex::builder(openai)
             .workspace(workspace)
             .thinking(thinking.into())
             .reasoning_mode(reasoning_mode.into())
             .fast_mode(agent_config.fast_mode())
-            .responses(responses.build())
             .tools_factory(move |agent| {
                 subagents::install_tools(tools.clone(), agent, Arc::clone(&subagents))
             });
@@ -133,6 +135,9 @@ impl ConfiguredAgent {
         );
         builder = builder.instructions(Arc::clone(&instructions));
         if let Some(session_id) = session_id {
+            let session_id = session_id
+                .parse::<SessionId>()
+                .map_err(RuntimeError::InvalidSessionId)?;
             builder = builder.session_id(session_id);
         }
         if let Some(snapshot) = snapshot {
@@ -278,7 +283,7 @@ fn fresh_instructions(
     let catalog = SkillCatalog::load(skills);
     let mut instructions = custom
         .map(str::to_owned)
-        .unwrap_or_else(|| ModelConfig::default().system_prompt.to_string());
+        .unwrap_or_else(|| ResponsesServiceConfig::default().system_prompt.to_string());
     instructions.push_str("\n\n");
     instructions.push_str(DEFAULT_APPEND_INSTRUCTIONS);
     if let Some(appended) = appended {
@@ -311,14 +316,15 @@ mod tests {
         config::SkillsConfig,
         error::{Error, RuntimeError},
     };
-    use nanocodex::{
-        Nanocodex, NanocodexError, Responses, ResponsesAttempt, ResponsesServiceResponse,
+    use nanocodex::oai::{
+        ResponseError,
+        auth::{
+            OpenAiAuth, OpenAiAuthError, OpenAiAuthFuture, OpenAiAuthMode, OpenAiAuthSnapshot,
+            OpenAiAuthSource,
+        },
+        tower::{ResponsesAttempt, ResponsesServiceConfig, ResponsesServiceResponse},
     };
-    use nanocodex_core::{
-        ModelConfig, OpenAiAuth, OpenAiAuthError, OpenAiAuthFuture, OpenAiAuthMode,
-        OpenAiAuthSnapshot, OpenAiAuthSource, Thinking,
-        responses::{RequestProfile, ResponseCreate},
-    };
+    use nanocodex::{Nanocodex, OpenAi};
     use std::{
         fs,
         future::{Pending, pending},
@@ -366,7 +372,7 @@ mod tests {
 
     impl Service<ResponsesAttempt> for PendingService {
         type Response = ResponsesServiceResponse;
-        type Error = NanocodexError;
+        type Error = ResponseError;
         type Future = Pending<StdResult<Self::Response, Self::Error>>;
 
         fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<StdResult<(), Self::Error>> {
@@ -397,7 +403,7 @@ mod tests {
     #[test]
     fn fresh_instructions_include_the_default_append() {
         let disabled = SkillsConfig::from_roots(false, Vec::new());
-        let default = ModelConfig::default().system_prompt;
+        let default = ResponsesServiceConfig::default().system_prompt;
 
         assert_eq!(
             fresh_instructions(None, None, &disabled),
@@ -412,7 +418,7 @@ mod tests {
     #[test]
     fn appended_instructions_extend_the_default_or_replacement() {
         let disabled = SkillsConfig::from_roots(false, Vec::new());
-        let default = ModelConfig::default().system_prompt;
+        let default = ResponsesServiceConfig::default().system_prompt;
 
         let instructions = fresh_instructions(None, Some("Project instructions."), &disabled);
         assert_eq!(
@@ -443,7 +449,7 @@ mod tests {
         let enabled = SkillsConfig::from_roots(true, vec![directory.path().to_path_buf()]);
 
         let instructions = fresh_instructions(None, None, &enabled);
-        let default = ModelConfig::default().system_prompt;
+        let default = ResponsesServiceConfig::default().system_prompt;
 
         assert!(instructions.starts_with(default.as_ref()));
         assert!(instructions.contains("Review code carefully."));
@@ -554,46 +560,33 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_requests_disable_response_storage() {
+    fn chatgpt_rejects_response_storage() {
         let auth = OpenAiAuth::managed_chatgpt(Arc::new(TestChatGptAuth));
-        let config = ModelConfig {
-            auth,
-            store_responses: false,
-            ..ModelConfig::default()
+        let error = match OpenAi::builder(auth).store(true).build() {
+            Ok(_) => panic!("ChatGPT response storage must be rejected"),
+            Err(error) => error,
         };
-        let profile = RequestProfile::new("session", "lineage", Arc::from([]));
 
-        let request = serde_json::to_value(ResponseCreate::warmup(
-            &config,
-            Thinking::Medium,
-            false,
-            &profile,
-            None,
-        ))
-        .unwrap();
-
-        assert_eq!(request["store"], false);
+        assert!(error.to_string().contains("does not support store: true"));
     }
 
     #[tokio::test]
     async fn cancellation_stops_the_turn_and_waits_for_the_driver() {
         let called = Arc::new(Notify::new());
         let service_called = Arc::clone(&called);
-        let responses = Responses::builder()
+        let openai = OpenAi::builder("test-key")
             .service(move || PendingService {
                 called: Arc::clone(&service_called),
             })
-            .build();
-        let (agent, events) = Nanocodex::builder("test-key")
-            .responses(responses)
             .build()
             .unwrap();
+        let (agent, events) = Nanocodex::builder(openai).build().unwrap();
         let (_registry, subagent_control, subagent_updates) =
             crate::core::extensions::subagents::channel(32);
         let configured = ConfiguredAgent {
             agent,
             events,
-            instructions: ModelConfig::default().system_prompt,
+            instructions: ResponsesServiceConfig::default().system_prompt,
             subagent_updates,
             subagent_control,
         };

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -170,28 +170,30 @@ impl ConfiguredAgent {
         #[cfg(not(feature = "harbor-evals"))]
         let subagent_drain =
             tokio::spawn(async move { while subagent_updates.recv().await.is_some() {} });
-        let root_session_id = self.events.request_id().to_owned();
+        let root_session_id = self.agent.session_id().to_string();
         if shutdown.is_cancelled() {
-            self.shutdown().await;
+            let shutdown_result = self.shutdown().await;
             #[cfg(feature = "harbor-evals")]
             recorder
                 .finish(&root_session_id, RunOutcome::Cancelled)
                 .await?;
             #[cfg(not(feature = "harbor-evals"))]
             subagent_drain.abort();
+            shutdown_result?;
             return Ok(());
         }
 
         let turn = match self.agent.prompt(prompt).await {
             Ok(turn) => turn,
             Err(error) => {
-                self.shutdown().await;
+                let shutdown_result = self.shutdown().await;
                 #[cfg(feature = "harbor-evals")]
                 recorder
                     .finish(&root_session_id, RunOutcome::Failed)
                     .await?;
                 #[cfg(not(feature = "harbor-evals"))]
                 subagent_drain.abort();
+                shutdown_result?;
                 return Err(error.into());
             }
         };
@@ -214,11 +216,11 @@ impl ConfiguredAgent {
             self.subagent_control.cancel_all(&root_session_id).await;
         }
 
-        let turn_result = turn.result().await;
+        let turn_result = turn.await;
         let was_cancelled = matches!(cancellation, Cancellation::Requested);
         drop(control);
         self.subagent_control.close_all(&root_session_id).await;
-        self.shutdown().await;
+        let shutdown_result = self.shutdown().await;
         #[cfg(feature = "harbor-evals")]
         {
             let outcome = if was_cancelled {
@@ -238,14 +240,19 @@ impl ConfiguredAgent {
             return Err(error.into());
         }
         match turn_result {
-            Err(NanocodexError::TurnCancelled) if was_cancelled => Ok(()),
-            result => result.map(|_| ()).map_err(Into::into),
+            Err(NanocodexError::TurnCancelled) if was_cancelled => {}
+            Err(error) => return Err(error.into()),
+            Ok(_) => {}
         }
+        shutdown_result?;
+        Ok(())
     }
 
-    async fn shutdown(mut self) {
+    async fn shutdown(mut self) -> nanocodex::agent::Result<()> {
+        let result = self.agent.shutdown().await;
         drop(self.agent);
         while self.events.recv().await.is_some() {}
+        result
     }
 
     fn resolve_workspace(path: &Path) -> Result<PathBuf> {
@@ -318,10 +325,6 @@ mod tests {
     };
     use nanocodex::oai::{
         ResponseError,
-        auth::{
-            OpenAiAuth, OpenAiAuthError, OpenAiAuthFuture, OpenAiAuthMode, OpenAiAuthSnapshot,
-            OpenAiAuthSource,
-        },
         tower::{ResponsesAttempt, ResponsesServiceConfig, ResponsesServiceResponse},
     };
     use nanocodex::{Nanocodex, OpenAi};
@@ -337,33 +340,6 @@ mod tests {
     use tokio::{sync::Notify, time::timeout};
     use tokio_util::sync::CancellationToken;
     use tower::Service;
-
-    struct TestChatGptAuth;
-
-    impl OpenAiAuthSource for TestChatGptAuth {
-        fn validate(&self) -> StdResult<(), OpenAiAuthError> {
-            Ok(())
-        }
-
-        fn snapshot(&self) -> OpenAiAuthFuture<'_, StdResult<OpenAiAuthSnapshot, OpenAiAuthError>> {
-            Box::pin(async {
-                Ok(OpenAiAuthSnapshot::new(
-                    OpenAiAuthMode::ChatGpt,
-                    "test-token",
-                    Some("test-account"),
-                    false,
-                    1,
-                ))
-            })
-        }
-
-        fn recover_unauthorized(
-            &self,
-            _rejected: &OpenAiAuthSnapshot,
-        ) -> OpenAiAuthFuture<'_, StdResult<(), OpenAiAuthError>> {
-            Box::pin(async { Ok(()) })
-        }
-    }
 
     #[derive(Clone)]
     struct PendingService {
@@ -557,17 +533,6 @@ mod tests {
             .as_ref(),
             "Old custom."
         );
-    }
-
-    #[test]
-    fn chatgpt_rejects_response_storage() {
-        let auth = OpenAiAuth::managed_chatgpt(Arc::new(TestChatGptAuth));
-        let error = match OpenAi::builder(auth).store(true).build() {
-            Ok(_) => panic!("ChatGPT response storage must be rejected"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("does not support store: true"));
     }
 
     #[tokio::test]

--- a/src/core/orchestration.rs
+++ b/src/core/orchestration.rs
@@ -6,8 +6,10 @@ use crate::{
         AgentDescriptor, AgentId, AgentMessageUpdate, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     },
 };
-use nanocodex::agent::events::{AgentEvent, AgentEventKind};
-use serde::{Deserialize, Serialize};
+use nanocodex::agent::events::{
+    AgentEvent, AgentEventData, AgentEventKind, EventUsage, RunEvent, RunTerminal,
+};
+use serde::Serialize;
 use std::{
     collections::BTreeMap,
     fs::File,
@@ -128,31 +130,21 @@ struct ChildMetrics {
     model_calls: u64,
     tool_calls: u64,
     cost_usd: Option<f64>,
-    usage: TokenUsage,
-    warmup_usage: TokenUsage,
+    #[serde(with = "SerializableEventUsage")]
+    usage: EventUsage,
+    #[serde(with = "SerializableEventUsage")]
+    warmup_usage: EventUsage,
 }
 
-#[derive(Clone, Default, Deserialize, Serialize)]
-#[serde(default)]
-struct TokenUsage {
+#[derive(Serialize)]
+#[serde(remote = "EventUsage")]
+struct SerializableEventUsage {
     input_tokens: u64,
     cached_input_tokens: u64,
     cache_write_input_tokens: u64,
     output_tokens: u64,
     reasoning_output_tokens: u64,
     total_tokens: u64,
-}
-
-#[derive(Deserialize)]
-struct TerminalMetrics {
-    #[serde(default)]
-    model_calls: u64,
-    #[serde(default)]
-    cost_usd: Option<f64>,
-    #[serde(default)]
-    usage: TokenUsage,
-    #[serde(default)]
-    warmup_usage: TokenUsage,
 }
 
 impl OrchestrationRecorder {
@@ -347,34 +339,44 @@ impl ChildMetrics {
         if !event.kind.is_terminal() {
             return;
         }
-        let Ok(metrics) = event.decode_payload::<TerminalMetrics>() else {
+
+        let Ok(AgentEventData::Run(run)) = event.data() else {
             return;
         };
+        let terminal = match run {
+            RunEvent::Completed(terminal) | RunEvent::Failed(terminal) => terminal,
+            _ => return,
+        };
+
+        self.observe_terminal(&terminal);
+    }
+
+    fn observe_terminal(&mut self, terminal: &RunTerminal) {
         self.turns = self.turns.saturating_add(1);
-        self.model_calls = self.model_calls.saturating_add(metrics.model_calls);
-        if let Some(cost_usd) = metrics.cost_usd {
+        self.model_calls = self
+            .model_calls
+            .saturating_add(u64::from(terminal.metrics.model_calls));
+        if let Some(cost_usd) = terminal.cost_usd {
             *self.cost_usd.get_or_insert(0.0) += cost_usd;
         }
-        self.usage.add(&metrics.usage);
-        self.warmup_usage.add(&metrics.warmup_usage);
+        add_usage(&mut self.usage, &terminal.metrics.usage);
+        add_usage(&mut self.warmup_usage, &terminal.metrics.warmup_usage);
     }
 }
 
-impl TokenUsage {
-    fn add(&mut self, usage: &Self) {
-        self.input_tokens = self.input_tokens.saturating_add(usage.input_tokens);
-        self.cached_input_tokens = self
-            .cached_input_tokens
-            .saturating_add(usage.cached_input_tokens);
-        self.cache_write_input_tokens = self
-            .cache_write_input_tokens
-            .saturating_add(usage.cache_write_input_tokens);
-        self.output_tokens = self.output_tokens.saturating_add(usage.output_tokens);
-        self.reasoning_output_tokens = self
-            .reasoning_output_tokens
-            .saturating_add(usage.reasoning_output_tokens);
-        self.total_tokens = self.total_tokens.saturating_add(usage.total_tokens);
-    }
+fn add_usage(total: &mut EventUsage, usage: &EventUsage) {
+    total.input_tokens = total.input_tokens.saturating_add(usage.input_tokens);
+    total.cached_input_tokens = total
+        .cached_input_tokens
+        .saturating_add(usage.cached_input_tokens);
+    total.cache_write_input_tokens = total
+        .cache_write_input_tokens
+        .saturating_add(usage.cache_write_input_tokens);
+    total.output_tokens = total.output_tokens.saturating_add(usage.output_tokens);
+    total.reasoning_output_tokens = total
+        .reasoning_output_tokens
+        .saturating_add(usage.reasoning_output_tokens);
+    total.total_tokens = total.total_tokens.saturating_add(usage.total_tokens);
 }
 
 impl<'a> From<&'a AgentDescriptor> for AgentRecord<'a> {
@@ -401,6 +403,52 @@ mod tests {
     use std::{fs, sync::Arc};
     use tempfile::tempdir;
     use tokio::sync::mpsc;
+
+    fn run_terminal(model_calls: u32, cost_usd: Option<f64>) -> Value {
+        json!({
+            "status": "completed",
+            "model": "gpt-5.6-sol",
+            "reasoning_mode": "summary",
+            "effort": "high",
+            "transport": "responses_websocket_v2",
+            "orchestration": "local",
+            "duration_ms": 1,
+            "duration_ns": 1_000_000,
+            "model_calls": model_calls,
+            "steers": 0,
+            "compactions": 0,
+            "tool_calls": 0,
+            "connection_attempts": 1,
+            "websocket_reconnects": 0,
+            "response_attempts": model_calls,
+            "response_retries": 0,
+            "connection_duration_ns": 100,
+            "retry_backoff_duration_ns": 0,
+            "model_duration_ns": 900_000,
+            "compaction_duration_ns": 0,
+            "warmup_duration_ns": 100_000,
+            "tool_work_duration_ns": 0,
+            "tool_wall_duration_ns": 0,
+            "usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 60,
+                "cache_write_input_tokens": 0,
+                "output_tokens": 20,
+                "reasoning_output_tokens": 0,
+                "total_tokens": 120
+            },
+            "warmup_usage": {
+                "input_tokens": 10,
+                "cached_input_tokens": 0,
+                "cache_write_input_tokens": 0,
+                "output_tokens": 0,
+                "reasoning_output_tokens": 0,
+                "total_tokens": 10
+            },
+            "estimated_cost": null,
+            "cost_usd": cost_usd
+        })
+    }
 
     #[tokio::test]
     async fn records_child_lifecycle_and_final_cleanup_state() {
@@ -431,22 +479,7 @@ mod tests {
                         request_id: Arc::from("child"),
                         seq: 1,
                         kind: AgentEventKind::RunCompleted,
-                        payload: to_raw_value(&json!({
-                            "model_calls": 2,
-                            "cost_usd": 0.25,
-                            "usage": {
-                                "input_tokens": 100,
-                                "cached_input_tokens": 60,
-                                "output_tokens": 20,
-                                "total_tokens": 120
-                            },
-                            "warmup_usage": {
-                                "input_tokens": 10,
-                                "total_tokens": 10
-                            }
-                        }))
-                        .unwrap()
-                        .into(),
+                        payload: to_raw_value(&run_terminal(2, Some(0.25))).unwrap().into(),
                     },
                 },
             })
@@ -511,7 +544,7 @@ mod tests {
                         request_id: Arc::from("child"),
                         seq: 1,
                         kind: AgentEventKind::RunCompleted,
-                        payload: to_raw_value(&json!({ "model_calls": 1 })).unwrap().into(),
+                        payload: to_raw_value(&run_terminal(1, None)).unwrap().into(),
                     },
                 },
             })

--- a/src/core/orchestration.rs
+++ b/src/core/orchestration.rs
@@ -6,7 +6,7 @@ use crate::{
         AgentDescriptor, AgentId, AgentMessageUpdate, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     },
 };
-use nanocodex::{AgentEvent, AgentEventKind};
+use nanocodex::agent::events::{AgentEvent, AgentEventKind};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -396,7 +396,7 @@ mod tests {
     use crate::core::extensions::subagents::{
         AgentDescriptor, AgentId, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     };
-    use nanocodex::{AgentEvent, AgentEventKind};
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use serde_json::{Value, json, value::to_raw_value};
     use std::{fs, sync::Arc};
     use tempfile::tempdir;
@@ -445,7 +445,8 @@ mod tests {
                                 "total_tokens": 10
                             }
                         }))
-                        .unwrap(),
+                        .unwrap()
+                        .into(),
                     },
                 },
             })
@@ -510,7 +511,7 @@ mod tests {
                         request_id: Arc::from("child"),
                         seq: 1,
                         kind: AgentEventKind::RunCompleted,
-                        payload: to_raw_value(&json!({ "model_calls": 1 })).unwrap(),
+                        payload: to_raw_value(&json!({ "model_calls": 1 })).unwrap().into(),
                     },
                 },
             })

--- a/src/tui/agent_events.rs
+++ b/src/tui/agent_events.rs
@@ -1,7 +1,7 @@
 //! Lossless forwarding for active and retiring Nanocodex event streams.
 
 use crate::tui::pane::PaneId;
-use nanocodex::{AgentEvent, AgentEvents};
+use nanocodex::{AgentEvents, agent::events::AgentEvent};
 use tokio::sync::mpsc;
 
 pub(crate) enum ForwardedAgentEvent {

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -47,7 +47,7 @@ use components::{AppEvent, AppNode, RootNode};
 use config::{ReasoningEffort, ReasoningMode};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-use nanocodex::{AgentEvent, AgentEventKind};
+use nanocodex::agent::events::{AgentEvent, AgentEventKind};
 use pane::PaneId;
 use ratatui::{Terminal, backend::TestBackend};
 use serde_json::{json, value::to_raw_value};
@@ -382,7 +382,7 @@ fn agent_record(
             request_id: Arc::from("benchmark"),
             seq: sequence,
             kind,
-            payload: to_raw_value(&payload).unwrap(),
+            payload: to_raw_value(&payload).unwrap().into(),
         },
     ))
 }
@@ -404,7 +404,7 @@ fn write_session_segment(
         LocalEvent::SessionStarted(SessionStarted {
             session_id: session_id.to_owned(),
             parent_session_id: None,
-            model: nanocodex::MODEL.to_owned(),
+            model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
@@ -451,7 +451,7 @@ fn write_mixed_session_segment(config_path: &Path, session_id: &str, workspace: 
         LocalEvent::SessionStarted(SessionStarted {
             session_id: session_id.to_owned(),
             parent_session_id: None,
-            model: nanocodex::MODEL.to_owned(),
+            model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
@@ -471,7 +471,7 @@ fn write_mixed_session_segment(config_path: &Path, session_id: &str, workspace: 
 fn save_benchmark_checkpoint(config_path: &Path, session_id: &str) {
     let snapshot = serde_json::from_value(json!({
         "version": 1,
-        "model": nanocodex::MODEL,
+        "model": nanocodex::oai::MODEL,
         "lineage_id": session_id,
         "prompt_cache_key": "benchmark-cache-key",
         "workspace": "/benchmark-workspace",

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -19,7 +19,7 @@ use crate::{
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use history::PromptHistory;
 use layout::{VisualLayout, byte_at_column};
-use nanocodex::MODEL;
+use nanocodex::oai::MODEL;
 use ratatui::{
     Frame,
     buffer::Buffer,
@@ -1147,7 +1147,7 @@ mod tests {
         tui::theme::Theme,
     };
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-    use nanocodex::{PromptInput, UserInput};
+    use nanocodex::agent::input::{PromptInput, UserInput};
     use ratatui::{Terminal, backend::TestBackend, layout::Position, style::Color};
     use std::{
         path::Path,

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -1928,7 +1928,10 @@ mod tests {
         Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
         MouseEventKind,
     };
-    use nanocodex::{AgentEvent, AgentEventKind, PromptInput, UserInput};
+    use nanocodex::agent::{
+        events::{AgentEvent, AgentEventKind},
+        input::{PromptInput, UserInput},
+    };
     use ratatui::{
         Terminal,
         backend::TestBackend,
@@ -2010,7 +2013,8 @@ mod tests {
                     "steer_index": 1,
                     "instruction_bytes": 5,
                 }))
-                .unwrap(),
+                .unwrap()
+                .into(),
             },
         )))
     }
@@ -2028,7 +2032,7 @@ mod tests {
                 request_id: Arc::from("opaque-test-id"),
                 seq: sequence,
                 kind,
-                payload: to_raw_value(&payload).unwrap(),
+                payload: to_raw_value(&payload).unwrap().into(),
             },
         ))
     }
@@ -2183,7 +2187,8 @@ mod tests {
                             "purpose": "coordinate"
                         }
                     }))
-                    .unwrap(),
+                    .unwrap()
+                    .into(),
                 },
             ),
         )));
@@ -2356,7 +2361,8 @@ mod tests {
                     "phase": "final_answer",
                     "text": "Open [the site](https://example.com).",
                 }))
-                .unwrap(),
+                .unwrap()
+                .into(),
             },
         );
         root.update(super::RootEvent::Transcript(Arc::new(record)));

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -2069,6 +2069,15 @@ mod tests {
             2,
             AgentEventKind::ModelCallCompleted,
             json!({
+                "call_index": 1,
+                "model": "gpt-5.6-sol",
+                "attempt": 1,
+                "connection_generation": 1,
+                "status": "completed",
+                "duration_ns": 1,
+                "time_to_first_event_ns": 1,
+                "time_to_first_output_ns": 1,
+                "tool_calls": 0,
                 "usage": {
                     "input_tokens": 1_000,
                     "input_tokens_details": {"cached_tokens": 800},

--- a/src/tui/components/subagents.rs
+++ b/src/tui/components/subagents.rs
@@ -1058,7 +1058,7 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::{AgentEvent, AgentEventKind};
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use ratatui::{Terminal, backend::TestBackend, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{
@@ -1084,7 +1084,7 @@ mod tests {
                 request_id: Arc::from("child-session"),
                 seq: 1,
                 kind,
-                payload: to_raw_value(&payload).unwrap(),
+                payload: to_raw_value(&payload).unwrap().into(),
             },
         }
     }

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -1298,7 +1298,7 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::{AgentEvent, AgentEventKind};
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use ratatui::{Terminal, backend::TestBackend, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{sync::Arc, time::Duration};
@@ -1343,7 +1343,7 @@ mod tests {
                 request_id: Arc::from("test"),
                 seq: sequence,
                 kind,
-                payload: to_raw_value(&payload).unwrap(),
+                payload: to_raw_value(&payload).unwrap().into(),
             },
         ))
     }

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -347,7 +347,7 @@ pub(crate) fn outbound_context_snapshot(record: &TranscriptRecord) -> Option<(bo
 mod tests {
     use super::{ContextDiagnostics, ContinuationMode};
     use crate::tui::transcript::TranscriptRecord;
-    use nanocodex::{AgentEvent, AgentEventKind};
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use serde_json::{Value, json, value::to_raw_value};
     use std::sync::Arc;
 
@@ -360,7 +360,7 @@ mod tests {
                 request_id: Arc::from("secret-request-id"),
                 seq: sequence,
                 kind,
-                payload: to_raw_value(&payload).unwrap(),
+                payload: to_raw_value(&payload).unwrap().into(),
             },
         )
     }

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -1,6 +1,11 @@
 //! Content-free context diagnostics projected from transcript telemetry.
 
 use crate::tui::transcript::TranscriptRecord;
+use nanocodex::oai::{
+    self,
+    events::{CompactionStarted, ModelCallCompleted},
+    responses::Usage,
+};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
@@ -10,7 +15,7 @@ pub(crate) enum ContinuationMode {
     PreviousResponse,
 }
 
-pub(crate) const MODEL_WINDOW_TOKENS: u64 = 272_000;
+pub(crate) const MODEL_WINDOW_TOKENS: u64 = oai::CONTEXT_WINDOW_TOKENS;
 pub(crate) const AUTO_COMPACT_TOKEN_LIMIT: u64 = 244_800;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -155,7 +160,7 @@ impl ContextDiagnostics {
         let usage = event
             .response
             .and_then(|response| response.usage)
-            .map(Usage::into_tokens);
+            .map(usage_into_tokens);
         let completed_tokens = usage.map(|usage| usage.total);
         self.set_usage(usage);
         ContextObservation { completed_tokens }
@@ -165,7 +170,7 @@ impl ContextDiagnostics {
         let Ok(payload) = record.decode_payload::<ModelCallCompleted>() else {
             return;
         };
-        self.set_usage(payload.usage.map(Usage::into_tokens));
+        self.set_usage(payload.usage.map(usage_into_tokens));
     }
 
     fn observe_context_snapshot(&mut self, record: &TranscriptRecord) {
@@ -198,8 +203,8 @@ impl ContextDiagnostics {
         let before_tokens = payload
             .as_ref()
             .map(|payload| payload.active_context_tokens);
-        if let Some(limit) = payload.and_then(|payload| payload.auto_compact_token_limit) {
-            self.auto_compact_token_limit = limit;
+        if let Some(payload) = payload {
+            self.auto_compact_token_limit = payload.auto_compact_token_limit;
         }
         self.compactions_started = self.compactions_started.saturating_add(1);
         self.last_compaction = Some(CompactionDiagnostics {
@@ -255,49 +260,17 @@ struct ContextSnapshot {
     previous_response: bool,
 }
 
-#[derive(Deserialize)]
-struct ModelCallCompleted {
-    usage: Option<Usage>,
-}
-
-#[derive(Deserialize)]
-struct CompactionStarted {
-    active_context_tokens: u64,
-    #[serde(default)]
-    auto_compact_token_limit: Option<u64>,
-}
-
-#[derive(Clone, Copy, Deserialize)]
-struct Usage {
-    #[serde(default)]
-    input_tokens: u64,
-    #[serde(default)]
-    input_tokens_details: Option<InputTokenDetails>,
-    #[serde(default)]
-    output_tokens: u64,
-    #[serde(default)]
-    total_tokens: u64,
-}
-
-impl Usage {
-    fn into_tokens(self) -> TokenUsage {
-        let cached_input = self
-            .input_tokens_details
-            .map_or(0, |details| details.cached_tokens);
-        TokenUsage {
-            input: self.input_tokens,
-            cached_input,
-            uncached_input: self.input_tokens.saturating_sub(cached_input),
-            output: self.output_tokens,
-            total: self.total_tokens,
-        }
+fn usage_into_tokens(usage: Usage) -> TokenUsage {
+    let cached_input = usage
+        .input_tokens_details
+        .map_or(0, |details| details.cached_tokens);
+    TokenUsage {
+        input: usage.input_tokens,
+        cached_input,
+        uncached_input: usage.input_tokens.saturating_sub(cached_input),
+        output: usage.output_tokens,
+        total: usage.total_tokens,
     }
-}
-
-#[derive(Clone, Copy, Deserialize)]
-struct InputTokenDetails {
-    #[serde(default)]
-    cached_tokens: u64,
 }
 
 fn raw_value_is_string(value: &RawValue) -> bool {
@@ -369,6 +342,22 @@ mod tests {
         json!({"direction": direction, "phase": "generation", "event": event})
     }
 
+    fn model_call_completed(usage: Value) -> Value {
+        json!({
+            "call_index": 1,
+            "model": "gpt-5.6-sol",
+            "response_id": "secret-continuation-token",
+            "attempt": 1,
+            "connection_generation": 1,
+            "status": "completed",
+            "duration_ns": 1,
+            "time_to_first_event_ns": 1,
+            "time_to_first_output_ns": 1,
+            "tool_calls": 0,
+            "usage": usage
+        })
+    }
+
     #[test]
     fn complete_telemetry_projects_only_safe_facts_and_counts() {
         let records = [
@@ -389,21 +378,19 @@ mod tests {
                 2,
                 2,
                 AgentEventKind::ModelCallCompleted,
-                json!({
-                    "response_id": "secret-continuation-token",
-                    "usage": {
+                model_call_completed(json!({
                         "input_tokens": 1_000,
                         "input_tokens_details": {"cached_tokens": 750},
                         "output_tokens": 80,
                         "total_tokens": 1_080
-                    }
-                }),
+                })),
             ),
             agent(
                 3,
                 100,
                 AgentEventKind::ModelCompactionStarted,
                 json!({
+                    "after_model_call_index": 1,
                     "active_context_tokens": 900,
                     "auto_compact_token_limit": 200_000,
                     "previous_response_id": "secret-response-id"
@@ -421,9 +408,9 @@ mod tests {
                 5,
                 120,
                 AgentEventKind::ModelCallCompleted,
-                json!({
-                    "usage": {"input_tokens": 400, "output_tokens": 20, "total_tokens": 420}
-                }),
+                model_call_completed(
+                    json!({"input_tokens": 400, "output_tokens": 20, "total_tokens": 420}),
+                ),
             ),
         ];
         let diagnostics = ContextDiagnostics::rebuild(records.iter());
@@ -436,7 +423,10 @@ mod tests {
         assert_eq!(diagnostics.usage.unwrap().total, 420);
         assert_eq!(diagnostics.compactions_started, 1);
         assert_eq!(diagnostics.compactions_completed, 1);
-        assert_eq!(diagnostics.model_window_tokens, 272_000);
+        assert_eq!(
+            diagnostics.model_window_tokens,
+            nanocodex::oai::CONTEXT_WINDOW_TOKENS
+        );
         assert_eq!(diagnostics.auto_compact_token_limit, 200_000);
         assert_eq!(
             diagnostics.last_compaction.unwrap().before_tokens,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1099,7 +1099,7 @@ fn open_pane(
     journal.defer_start(SessionStarted {
         session_id: session_id.to_owned(),
         parent_session_id: parent_session_id.map(str::to_owned),
-        model: nanocodex::MODEL.to_owned(),
+        model: nanocodex::oai::MODEL.to_owned(),
         effort,
         reasoning_mode,
         fast_mode,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -300,7 +300,7 @@ pub(crate) async fn run(
         subagent_updates,
         subagent_control,
     } = configured;
-    let main_session_id = events.request_id().to_owned();
+    let main_session_id = agent.session_id().to_string();
     let (writer_sender, mut writer_updates) = mpsc::unbounded_channel();
     let mut panes = HashMap::new();
     panes.insert(

--- a/src/tui/prompt.rs
+++ b/src/tui/prompt.rs
@@ -1,6 +1,6 @@
 //! Displayable prompt text paired with model-only image content.
 
-use nanocodex::{Prompt, UserInput};
+use nanocodex::agent::input::{Prompt, UserInput};
 use std::{fmt, ops::Range};
 
 #[derive(Clone, Eq, PartialEq)]
@@ -113,7 +113,7 @@ impl From<String> for Submission {
 #[cfg(test)]
 mod tests {
     use super::Submission;
-    use nanocodex::{PromptInput, UserInput};
+    use nanocodex::agent::input::{PromptInput, UserInput};
 
     #[test]
     fn multimodal_prompt_replaces_markers_with_ordered_images() {

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -7,7 +7,7 @@ use crate::{
         transcript::{self, LocalEvent, SessionStarted, TranscriptRecord},
     },
 };
-use nanocodex::SessionSnapshot;
+use nanocodex::agent::session::SessionSnapshot;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -988,7 +988,10 @@ mod tests {
         app::config::{ReasoningEffort, ReasoningMode},
         tui::transcript::{LocalEvent, SessionStarted, TranscriptJournal, TurnId},
     };
-    use nanocodex::{AgentEvent, AgentEventKind, SessionSnapshot};
+    use nanocodex::agent::{
+        events::{AgentEvent, AgentEventKind},
+        session::SessionSnapshot,
+    };
     use serde_json::{Value, json, value::to_raw_value};
     use std::{fs, io::Write, path::Path, sync::Arc};
     use tempfile::tempdir;
@@ -996,7 +999,7 @@ mod tests {
     fn snapshot(lineage: &str) -> SessionSnapshot {
         serde_json::from_value(json!({
             "version": 1,
-            "model": nanocodex::MODEL,
+            "model": nanocodex::oai::MODEL,
             "lineage_id": lineage,
             "prompt_cache_key": "test-cache-key",
             "workspace": "/work",
@@ -1046,6 +1049,16 @@ mod tests {
     fn checkpoint_filenames_are_distinct_and_path_safe() {
         assert_eq!(encode_filename("a/b"), "612f62");
         assert_ne!(encode_filename("a/b"), encode_filename("a_b"));
+    }
+
+    #[test]
+    fn nanocodex_0_2_snapshot_shape_remains_compatible() {
+        let snapshot = serde_json::to_value(snapshot("legacy-lineage")).unwrap();
+
+        assert_eq!(snapshot["version"], 1);
+        assert_eq!(snapshot["lineage_id"], "legacy-lineage");
+        assert!(snapshot.get("base_instructions").is_none());
+        assert!(snapshot.get("context_snapshot").is_none());
     }
 
     #[test]
@@ -1226,7 +1239,7 @@ mod tests {
                     request_id: Arc::from("request"),
                     seq: u64::try_from(sequence).unwrap(),
                     kind: AgentEventKind::ApiEvent,
-                    payload: to_raw_value(&payload).unwrap(),
+                    payload: to_raw_value(&payload).unwrap().into(),
                 })
                 .unwrap();
         }
@@ -1268,7 +1281,7 @@ mod tests {
                     request_id: Arc::from("request"),
                     seq: sequence,
                     kind,
-                    payload: to_raw_value(&payload).unwrap(),
+                    payload: to_raw_value(&payload).unwrap().into(),
                 })
                 .unwrap();
         }
@@ -1365,7 +1378,7 @@ mod tests {
                     request_id: Arc::from("request"),
                     seq: sequence,
                     kind,
-                    payload: to_raw_value(&payload).unwrap(),
+                    payload: to_raw_value(&payload).unwrap().into(),
                 })
                 .unwrap();
         }

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -3,7 +3,7 @@ use crate::{
     app::config::ReasoningEffort,
     tui::transcript::{LocalEvent, SessionStarted, TranscriptRecord},
 };
-use nanocodex::AgentEvent;
+use nanocodex::agent::events::AgentEvent;
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufRead, BufReader, BufWriter, Write},

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -9,6 +9,13 @@ use crate::{
     },
     tui::format::{format_duration, humanize_tool},
 };
+use nanocodex::{
+    agent::events::{
+        AssistantDelta, AssistantMessage, CompactionCompleted, CompactionFailed,
+        ReasoningSummaryDelta, RunError,
+    },
+    oai::responses::MessagePhase as AgentMessagePhase,
+};
 use serde::Deserialize;
 use serde_json::Value;
 use std::{
@@ -428,8 +435,8 @@ impl TranscriptModel {
     }
 
     fn assistant_delta(&mut self, record: &TranscriptRecord) -> Result<bool, serde_json::Error> {
-        let payload = record.decode_payload::<AssistantPayload>()?;
-        let phase = MessagePhase::from(payload.phase.as_deref());
+        let payload = record.decode_payload::<AssistantDelta>()?;
+        let phase = message_phase(payload.phase);
         let key = AssistantKey {
             call: payload.model_call_index,
             item: payload.item_id,
@@ -457,8 +464,8 @@ impl TranscriptModel {
     }
 
     fn assistant_message(&mut self, record: &TranscriptRecord) -> Result<bool, serde_json::Error> {
-        let payload = record.decode_payload::<AssistantPayload>()?;
-        let phase = MessagePhase::from(payload.phase.as_deref());
+        let payload = record.decode_payload::<AssistantMessage>()?;
+        let phase = message_phase(payload.phase);
         let key = AssistantKey {
             call: payload.model_call_index,
             item: payload.item_id,
@@ -492,7 +499,7 @@ impl TranscriptModel {
     }
 
     fn reasoning_delta(&mut self, record: &TranscriptRecord) -> Result<bool, serde_json::Error> {
-        let payload = record.decode_payload::<ReasoningPayload>()?;
+        let payload = record.decode_payload::<ReasoningSummaryDelta>()?;
         let id = self
             .reasoning
             .get(&payload.model_call_index)
@@ -640,7 +647,7 @@ impl TranscriptModel {
         &mut self,
         record: &TranscriptRecord,
     ) -> Result<bool, serde_json::Error> {
-        let payload = record.decode_payload::<DurationPayload>()?;
+        let payload = record.decode_payload::<CompactionCompleted>()?;
         self.push(EntryKind::ContextCompacted {
             duration_ns: payload.duration_ns,
         });
@@ -649,7 +656,7 @@ impl TranscriptModel {
     }
 
     fn compaction_failed(&mut self, record: &TranscriptRecord) -> Result<bool, serde_json::Error> {
-        let payload = record.decode_payload::<ErrorPayload>()?;
+        let payload = record.decode_payload::<CompactionFailed>()?;
         self.pending_compaction_error = Some(payload.error.clone());
         self.pending_error = Some(payload.error);
         self.transient = self.is_active().then_some(TransientStatus::Thinking);
@@ -898,6 +905,13 @@ fn delivery_advances(current: &MessageDeliveryState, next: &MessageDeliveryState
     current != next && matches!(current, MessageDeliveryState::Admitted { .. })
 }
 
+fn message_phase(phase: Option<AgentMessagePhase>) -> MessagePhase {
+    match phase {
+        Some(AgentMessagePhase::Commentary) => MessagePhase::Commentary,
+        Some(AgentMessagePhase::FinalAnswer) | None => MessagePhase::Final,
+    }
+}
+
 fn visibility(source: &str, kind: &str) -> EventVisibility {
     if source == "tact" {
         return match kind {
@@ -1062,25 +1076,6 @@ struct SessionEnded {
 }
 
 #[derive(Deserialize)]
-struct AssistantPayload {
-    model_call_index: u32,
-    item_id: Option<String>,
-    phase: Option<String>,
-    text: String,
-}
-
-#[derive(Deserialize)]
-struct ReasoningPayload {
-    model_call_index: u32,
-    text: String,
-}
-
-#[derive(Deserialize)]
-struct RunError {
-    message: String,
-}
-
-#[derive(Deserialize)]
 struct ToolCallPayload {
     call_id: String,
     tool: String,
@@ -1095,11 +1090,6 @@ struct ToolResultPayload {
     duration_ns: u64,
     result: Value,
     metadata: Option<Value>,
-}
-
-#[derive(Deserialize)]
-struct DurationPayload {
-    duration_ns: u64,
 }
 
 #[derive(Deserialize)]
@@ -1429,6 +1419,30 @@ mod tests {
         assert!(matches!(
             &model.entries()[0].kind,
             EntryKind::Reasoning { text } if text == "Inspecting the request and event ordering"
+        ));
+    }
+
+    #[test]
+    fn canonical_compaction_events_use_typed_projection() {
+        let mut model = TranscriptModel::default();
+        model.apply(&agent(AgentEventKind::RunStarted, json!({})));
+        model.apply(&agent(
+            AgentEventKind::ModelCompactionCompleted,
+            json!({
+                "after_model_call_index": 1,
+                "attempt": 1,
+                "connection_generation": 1,
+                "status": "completed",
+                "duration_ns": 42,
+                "time_to_first_event_ns": 10,
+                "time_to_first_output_ns": 20,
+                "usage": null
+            }),
+        ));
+
+        assert!(matches!(
+            model.entries().last().map(|entry| &entry.kind),
+            Some(EntryKind::ContextCompacted { duration_ns: 42 })
         ));
     }
 

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -1137,7 +1137,7 @@ mod tests {
             LocalEvent, SessionEnded, SessionOutcome, ShellId, TranscriptRecord, TurnId,
         },
     };
-    use nanocodex::{AgentEvent, AgentEventKind};
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use serde::Serialize;
     use serde_json::{json, value::to_raw_value};
     use std::sync::Arc;
@@ -1159,7 +1159,7 @@ mod tests {
                 request_id: Arc::from("session"),
                 seq: 1,
                 kind,
-                payload: to_raw_value(&payload).unwrap(),
+                payload: to_raw_value(&payload).unwrap().into(),
             },
         )
     }

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -1,5 +1,5 @@
 use crate::app::config::{ReasoningEffort, ReasoningMode};
-use nanocodex::{AgentEvent, AgentEventKind};
+use nanocodex::agent::events::{AgentEvent, AgentEventKind};
 use serde::{Deserialize, Serialize};
 use serde_json::value::{RawValue, to_raw_value};
 use std::{path::PathBuf, sync::Arc};
@@ -123,7 +123,7 @@ pub(crate) struct TranscriptRecord {
     kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     agent: Option<AgentMetadata>,
-    payload: Box<RawValue>,
+    payload: Arc<RawValue>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -237,7 +237,7 @@ impl TranscriptRecord {
             source: TACT_SOURCE.to_owned(),
             kind: kind.to_owned(),
             agent: None,
-            payload,
+            payload: payload.into(),
         })
     }
 
@@ -400,7 +400,7 @@ const fn agent_kind(kind: AgentEventKind) -> &'static str {
 mod tests {
     use super::{LocalEvent, SessionStarted, ShellId, TranscriptRecord, TurnId};
     use crate::app::config::ReasoningMode;
-    use nanocodex::{AgentEvent, AgentEventKind};
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use serde_json::{json, value::to_raw_value};
     use std::sync::Arc;
 
@@ -415,7 +415,7 @@ mod tests {
                 request_id: Arc::from("session-a"),
                 seq: 4,
                 kind: AgentEventKind::AssistantDelta,
-                payload: to_raw_value(&payload).unwrap(),
+                payload: to_raw_value(&payload).unwrap().into(),
             },
         );
         let encoded = serde_json::to_value(record).unwrap();

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -175,17 +175,21 @@ async fn run(
                     }
                     WorkerCommand::ReplaceAgent { pane, agent } => {
                         debug_assert!(!controls.keys().any(|key| key.pane == pane));
-                        match pane {
-                            PaneId::Main => main = Some(agent),
+                        let retired = match pane {
+                            PaneId::Main => main.replace(agent),
                             PaneId::Fork(_) if fork.as_ref().is_some_and(|(id, _)| *id == pane) => {
-                                fork = Some((pane, agent));
+                                fork.replace((pane, agent)).map(|(_, agent)| agent)
                             }
                             PaneId::Fork(_) => {
                                 drop(updates.send(WorkerEvent::ForkFailed {
                                     pane,
                                     error: "session pane is no longer available".to_owned(),
                                 }));
+                                Some(agent)
                             }
+                        };
+                        if let Some(retired) = retired {
+                            drop(retired.shutdown().await);
                         }
                         continue;
                     }
@@ -245,14 +249,14 @@ async fn run(
                         continue;
                     }
                     WorkerCommand::ClosePane(pane) => {
-                        cancel_pane(pane, &controls, &mut cancelled, &updates).await;
-                        match pane {
-                            PaneId::Main => main = None,
+                        let agent = match pane {
+                            PaneId::Main => main.take(),
                             PaneId::Fork(_) if fork.as_ref().is_some_and(|(id, _)| *id == pane) => {
-                                fork = None;
+                                fork.take().map(|(_, agent)| agent)
                             }
-                            PaneId::Fork(_) => {}
-                        }
+                            PaneId::Fork(_) => None,
+                        };
+                        close_pane(pane, agent, &controls, &mut cancelled, &updates).await;
                         continue;
                     }
                 };
@@ -272,7 +276,7 @@ async fn run(
                         turns.spawn(async move {
                             (
                                 key,
-                                turn.result().await.map(|result| Box::new(result.snapshot())),
+                                turn.await.map(|result| Box::new(result.snapshot())),
                             )
                         });
                         drop(updates.send(WorkerEvent::TurnAccepted { pane, id }));
@@ -293,22 +297,16 @@ async fn run(
     commands.close();
     while commands.try_recv().is_ok() {}
 
-    let pending_controls = controls.values().cloned().collect::<Vec<_>>();
-    let mut shutdown_error = None;
-    for control in pending_controls {
-        match control.cancel().await {
-            Ok(()) | Err(NanocodexError::TurnNotCancellable) => {}
-            Err(error) if shutdown_error.is_none() => shutdown_error = Some(error),
-            Err(_) => {}
-        }
-    }
+    let (main_shutdown, fork_shutdown) = tokio::join!(
+        shutdown_agent(main.take()),
+        shutdown_agent(fork.take().map(|(_, agent)| agent)),
+    );
+    let shutdown_error = main_shutdown.err().or_else(|| fork_shutdown.err());
 
     while let Some(result) = turns.join_next().await {
         finish_turn(Some(result), true, &mut controls, &mut cancelled, &updates);
     }
 
-    drop(main);
-    drop(fork);
     drop(updates.send(WorkerEvent::Stopped {
         error: shutdown_error,
     }));
@@ -357,14 +355,7 @@ async fn steer_turn(
                 pane,
                 id: fallback_id,
             };
-            turns.spawn(async move {
-                (
-                    key,
-                    turn.result()
-                        .await
-                        .map(|result| Box::new(result.snapshot())),
-                )
-            });
+            turns.spawn(async move { (key, turn.await.map(|result| Box::new(result.snapshot()))) });
             controls.insert(key, control);
             drop(updates.send(WorkerEvent::TurnAccepted {
                 pane,
@@ -469,6 +460,31 @@ async fn cancel_pane(
     let count = keys.len();
     cancelled.extend(keys);
     drop(updates.send(WorkerEvent::TurnsCancelled { pane, count, error }));
+}
+
+async fn close_pane(
+    pane: PaneId,
+    agent: Option<Nanocodex>,
+    controls: &HashMap<TurnKey, TurnControl>,
+    cancelled: &mut HashSet<TurnKey>,
+    updates: &mpsc::UnboundedSender<WorkerEvent>,
+) {
+    let (keys, mut error) = cancel_turns(controls, Some(pane)).await;
+    let count = keys.len();
+    cancelled.extend(keys);
+    if let Err(shutdown_error) = shutdown_agent(agent).await
+        && error.is_none()
+    {
+        error = Some(shutdown_error.to_string());
+    }
+    drop(updates.send(WorkerEvent::TurnsCancelled { pane, count, error }));
+}
+
+async fn shutdown_agent(agent: Option<Nanocodex>) -> Result<(), NanocodexError> {
+    let Some(agent) = agent else {
+        return Ok(());
+    };
+    agent.shutdown().await
 }
 
 #[cfg(test)]
@@ -859,6 +875,65 @@ mod tests {
             .await
             .expect("the event stream should drain")
             .expect("the drain task should not panic");
+    }
+
+    #[tokio::test]
+    async fn closing_a_pane_waits_for_agent_cleanup() {
+        let called = Arc::new(Notify::new());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (agent, mut events) = pending_agent(Arc::clone(&called), calls);
+        let shutdown = CancellationToken::new();
+        let (commands, mut updates) = spawn(agent, shutdown.clone());
+        let drain = tokio::spawn(async move { while events.recv().await.is_some() {} });
+
+        commands
+            .send(WorkerCommand::Submit {
+                pane: PaneId::Main,
+                id: TurnId::new(1),
+                prompt: "close this pane".to_owned().into(),
+            })
+            .unwrap();
+        timeout(Duration::from_secs(5), called.notified())
+            .await
+            .expect("the model request should start");
+        assert!(matches!(
+            updates.recv().await,
+            Some(WorkerEvent::TurnAccepted { id, .. }) if id == TurnId::new(1)
+        ));
+
+        commands
+            .send(WorkerCommand::ClosePane(PaneId::Main))
+            .unwrap();
+        timeout(Duration::from_secs(5), async {
+            let mut acknowledged = false;
+            let mut finished = false;
+            while !acknowledged || !finished {
+                match updates.recv().await {
+                    Some(WorkerEvent::TurnsCancelled {
+                        count: 1,
+                        error: None,
+                        ..
+                    }) => acknowledged = true,
+                    Some(WorkerEvent::TurnFinished {
+                        id, error: None, ..
+                    }) if id == TurnId::new(1) => finished = true,
+                    Some(_) => {}
+                    None => panic!("worker stopped before the pane closed"),
+                }
+            }
+        })
+        .await
+        .expect("the pane should close");
+        timeout(Duration::from_secs(5), drain)
+            .await
+            .expect("the event stream should close after agent shutdown")
+            .expect("the drain task should not panic");
+
+        shutdown.cancel();
+        assert!(matches!(
+            timeout(Duration::from_secs(5), updates.recv()).await,
+            Ok(Some(WorkerEvent::Stopped { error: None }))
+        ));
     }
 
     #[tokio::test]

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -494,11 +494,13 @@ mod tests {
         app::config::ReasoningEffort,
         tui::{components::QueueId, pane::PaneId, transcript::TurnId},
     };
-    use nanocodex::oai::{
-        ResponseError,
-        tower::{ResponsesAttempt, ResponsesServiceResponse},
+    use nanocodex::{
+        AgentEvents, Nanocodex, OpenAi,
+        oai::{
+            ResponseError,
+            tower::{ResponsesAttempt, ResponsesServiceResponse},
+        },
     };
-    use nanocodex::{AgentEvents, Nanocodex, OpenAi};
     use std::{
         future::{Pending, pending},
         result::Result as StdResult,

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -4,7 +4,9 @@ use crate::{
     app::config::ReasoningEffort,
     tui::{components::QueueId, pane::PaneId, prompt::Submission, transcript::TurnId},
 };
-use nanocodex::{AgentEvents, Nanocodex, NanocodexError, SessionSnapshot, TurnControl};
+use nanocodex::{
+    AgentEvents, Nanocodex, NanocodexError, TurnControl, agent::session::SessionSnapshot,
+};
 use std::collections::{HashMap, HashSet};
 use tokio::{
     sync::mpsc,
@@ -476,10 +478,11 @@ mod tests {
         app::config::ReasoningEffort,
         tui::{components::QueueId, pane::PaneId, transcript::TurnId},
     };
-    use nanocodex::{
-        AgentEvents, Nanocodex, NanocodexError, Responses, ResponsesAttempt,
-        ResponsesServiceResponse,
+    use nanocodex::oai::{
+        ResponseError,
+        tower::{ResponsesAttempt, ResponsesServiceResponse},
     };
+    use nanocodex::{AgentEvents, Nanocodex, OpenAi};
     use std::{
         future::{Pending, pending},
         result::Result as StdResult,
@@ -502,7 +505,7 @@ mod tests {
 
     impl Service<ResponsesAttempt> for PendingService {
         type Response = ResponsesServiceResponse;
-        type Error = NanocodexError;
+        type Error = ResponseError;
         type Future = Pending<StdResult<Self::Response, Self::Error>>;
 
         fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<StdResult<(), Self::Error>> {
@@ -517,16 +520,14 @@ mod tests {
     }
 
     fn pending_agent(called: Arc<Notify>, calls: Arc<AtomicUsize>) -> (Nanocodex, AgentEvents) {
-        let responses = Responses::builder()
+        let openai = OpenAi::builder("test-key")
             .service(move || PendingService {
                 called: Arc::clone(&called),
                 calls: Arc::clone(&calls),
             })
-            .build();
-        Nanocodex::builder("test-key")
-            .responses(responses)
             .build()
-            .unwrap()
+            .unwrap();
+        Nanocodex::builder(openai).build().unwrap()
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- upgrade Nanocodex from 0.2 to 0.3 and migrate to its split provider, agent, and tools APIs
- preserve API-key and ChatGPT auth, custom endpoints, MCP, subagents, Code Mode, event projection, session resume, and transcript replay
- keep transcript and checkpoint formats at v1 because the serialized wire contract remains compatible; add coverage for the Nanocodex 0.2 snapshot shape
- align Tact with Nanocodex upstream on reqwest 0.13 and the aws-lc-rs rustls provider, eliminating the runtime CryptoProvider ambiguity and duplicate TLS stack

## Significant upstream changes

Nanocodex 0.3 constructs OpenAi separately from the agent, reorganizes events/input/sessions/MCP under canonical modules, introduces typed UUIDv7 session IDs and typed tool output, and changes raw event payload ownership from Box to Arc.

## Persistence

No version bump is required. New Nanocodex snapshot fields are optional, 0.2 session IDs were already UUIDv7, and the Box-to-Arc change does not alter serialized JSON.

## Verification

- cargo fmt --check
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
  - 506 unit tests
  - 7 release-pipeline tests
  - all benchmark smoke targets
- cargo package --allow-dirty
- dependency graph confirms aws-lc-rs is the only enabled rustls provider
- independent defect-first review found no actionable findings