### PR TITLE
fix(tui): make selection semantic and scrollable

### DIFF
--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -5,6 +5,7 @@ mod layout;
 
 use super::{
     node::{Component, ComponentUpdate, RenderRequest},
+    selection::{TextRange, TextSpan},
     waved_text::WavedText,
 };
 use crate::{
@@ -18,7 +19,7 @@ use crate::{
 };
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use history::PromptHistory;
-use layout::{VisualLayout, byte_at_column};
+use layout::{VisualLayout, byte_at_column, grapheme_at_column};
 use nanocodex::oai::MODEL;
 use ratatui::{
     Frame,
@@ -413,11 +414,22 @@ impl Composer {
         theme: &Theme,
         focused: bool,
     ) {
+        self.render_focused_with_selection(frame, area, theme, focused, None);
+    }
+
+    pub(super) fn render_focused_with_selection(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        theme: &Theme,
+        focused: bool,
+        selection: Option<TextRange>,
+    ) {
         if area.is_empty() {
             return;
         }
         if area.width < 2 || area.height < 3 {
-            self.render_narrow(frame, area, theme, focused);
+            self.render_narrow(frame, area, theme, focused, selection);
             return;
         }
 
@@ -428,7 +440,11 @@ impl Composer {
             (layout.cursor_row, layout.cursor_column, layout.lines.len())
         };
         let visible_rows = usize::from(area.height - 2);
-        self.keep_cursor_visible(cursor_row, visible_rows, line_count);
+        if selection.is_none() {
+            self.keep_cursor_visible(cursor_row, visible_rows, line_count);
+        } else {
+            self.clamp_scroll(visible_rows, line_count);
+        }
 
         let buffer = frame.buffer_mut();
         buffer.set_style(area, Style::default().fg(theme.text()));
@@ -456,15 +472,66 @@ impl Composer {
                 content_width,
                 theme,
             );
+            if let Some(selection) = selection {
+                render_selection(
+                    buffer,
+                    Position::new(area.x + 1, y),
+                    &self.draft,
+                    line.start..line.end,
+                    selection,
+                    content_width,
+                );
+            }
         }
 
         let cursor_row = cursor_row.saturating_sub(self.scroll);
         let cursor_x = area.x + 1 + u16::try_from(cursor_column).unwrap_or(u16::MAX);
         let cursor_y = area.y + 1 + u16::try_from(cursor_row).unwrap_or(u16::MAX);
         let max_cursor_x = area.right().saturating_sub(2);
-        if focused {
+        if focused && selection.is_none() {
             frame.set_cursor_position(Position::new(cursor_x.min(max_cursor_x), cursor_y));
         }
+    }
+
+    pub(super) fn selection_span(&mut self, position: Position, area: Rect) -> Option<TextSpan> {
+        if area.is_empty() {
+            return None;
+        }
+
+        let width = usize::from(area.width).max(1);
+        self.last_width = width;
+        let position = Position::new(
+            position.x.clamp(area.x, area.right().saturating_sub(1)),
+            position.y.clamp(area.y, area.bottom().saturating_sub(1)),
+        );
+        let row = self.scroll + usize::from(position.y - area.y);
+        let column = usize::from(position.x - area.x);
+        let line = self.visual_layout(width).lines.get(row)?.clone();
+        let range = grapheme_at_column(&self.draft, &line, column);
+        Some(TextSpan::new(0, range.start, range.end))
+    }
+
+    pub(super) fn selection_text(&self, selection: TextRange) -> Option<String> {
+        let range = selection.source_range(0, self.draft.len())?;
+        self.draft.get(range).map(ToOwned::to_owned)
+    }
+
+    pub(super) fn scroll_selection(&mut self, rows: isize, area: Rect) -> bool {
+        if area.is_empty() {
+            return false;
+        }
+
+        let width = usize::from(area.width).max(1);
+        self.last_width = width;
+        let line_count = self.visual_layout(width).lines.len();
+        let visible_rows = usize::from(area.height);
+        let maximum = line_count.saturating_sub(visible_rows);
+        let scroll = self.scroll.saturating_add_signed(rows).min(maximum);
+        if scroll == self.scroll {
+            return false;
+        }
+        self.scroll = scroll;
+        true
     }
 
     pub(crate) fn draft(&self) -> &str {
@@ -800,6 +867,10 @@ impl Composer {
             self.scroll = cursor_row + 1 - visible;
         }
 
+        self.clamp_scroll(visible, line_count);
+    }
+
+    fn clamp_scroll(&mut self, visible: usize, line_count: usize) {
         self.scroll = self.scroll.min(line_count.saturating_sub(visible));
     }
 
@@ -822,7 +893,27 @@ impl Composer {
         &cached.value
     }
 
-    fn render_narrow(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme, focused: bool) {
+    fn render_narrow(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        theme: &Theme,
+        focused: bool,
+        selection: Option<TextRange>,
+    ) {
+        let width = usize::from(area.width).max(1);
+        let (cursor_row, cursor_column, line_count) = {
+            let layout = self.visual_layout(width);
+            (layout.cursor_row, layout.cursor_column, layout.lines.len())
+        };
+        if selection.is_none() {
+            self.scroll = 0;
+        } else {
+            self.clamp_scroll(1, line_count);
+        }
+        let scroll = self.scroll;
+        let line = self.visual_layout(width).lines[scroll].clone();
+
         let buffer = frame.buffer_mut();
         buffer.set_style(area, Style::default().fg(theme.text()));
         render_draft_line(
@@ -830,12 +921,30 @@ impl Composer {
             Position::new(area.x, area.y),
             &self.draft,
             &self.images,
-            0..self.draft.len(),
-            usize::from(area.width),
+            line.start..line.end,
+            width,
             theme,
         );
-        if focused {
-            frame.set_cursor_position(Position::new(area.x, area.y));
+        if let Some(selection) = selection {
+            render_selection(
+                buffer,
+                Position::new(area.x, area.y),
+                &self.draft,
+                line.start..line.end,
+                selection,
+                width,
+            );
+        }
+        if focused && selection.is_none() {
+            let cursor_column = if cursor_row == scroll {
+                u16::try_from(cursor_column).unwrap_or(u16::MAX)
+            } else {
+                0
+            };
+            let cursor_x = area
+                .x
+                .saturating_add(cursor_column.min(area.width.saturating_sub(1)));
+            frame.set_cursor_position(Position::new(cursor_x, area.y));
         }
     }
 
@@ -1193,8 +1302,46 @@ fn render_draft_line(
     }
 }
 
+fn render_selection(
+    buffer: &mut Buffer,
+    position: Position,
+    draft: &str,
+    line: Range<usize>,
+    selection: TextRange,
+    width: usize,
+) {
+    let Some(selected) = selection.source_range(0, draft.len()) else {
+        return;
+    };
+    let start = selected.start.max(line.start);
+    let end = selected.end.min(line.end);
+    if start >= end {
+        return;
+    }
+    let Some(prefix) = draft.get(line.start..start) else {
+        return;
+    };
+    let Some(text) = draft.get(start..end) else {
+        return;
+    };
+    let offset = prefix.width();
+    let selected_width = text.width().min(width.saturating_sub(offset));
+    if selected_width == 0 {
+        return;
+    }
+    let x = position
+        .x
+        .saturating_add(u16::try_from(offset).unwrap_or(u16::MAX));
+    let width = u16::try_from(selected_width).unwrap_or(u16::MAX);
+    buffer.set_style(
+        Rect::new(x, position.y, width, 1),
+        Style::reset().fg(Color::Black).bg(Color::Yellow),
+    );
+}
+
 #[cfg(test)]
 mod tests {
+    use super::super::selection::{Selection, Surface, TextRange};
     use super::{Composer, ComposerEffect, ComposerEvent, context_percent};
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -1202,7 +1349,12 @@ mod tests {
     };
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use nanocodex::agent::input::{PromptInput, UserInput};
-    use ratatui::{Terminal, backend::TestBackend, layout::Position, style::Color};
+    use ratatui::{
+        Terminal,
+        backend::TestBackend,
+        layout::{Position, Rect},
+        style::Color,
+    };
     use std::{
         path::Path,
         time::{Duration, Instant},
@@ -1217,6 +1369,28 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| composer.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        terminal
+    }
+
+    fn render_with_selection(
+        composer: &mut Composer,
+        width: u16,
+        height: u16,
+        selection: TextRange,
+    ) -> Terminal<TestBackend> {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                composer.render_focused_with_selection(
+                    frame,
+                    frame.area(),
+                    &Theme::default(),
+                    true,
+                    Some(selection),
+                );
+            })
             .unwrap();
         terminal
     }
@@ -1712,6 +1886,79 @@ mod tests {
         assert!(rows[1].contains("alpha"));
         assert!(rows[2].contains("betaab"));
         assert!(rows[3].contains("cdefgh"));
+    }
+
+    #[test]
+    fn semantic_selection_preserves_source_across_soft_and_hard_wraps() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("abcdef\ngh".to_owned());
+        let area = Rect::new(10, 5, 3, 3);
+        let anchor = composer.selection_span(Position::new(11, 5), area).unwrap();
+        let head = composer.selection_span(Position::new(11, 7), area).unwrap();
+        let mut selection = Selection::default();
+        selection.begin(Surface::Composer, anchor);
+        selection.drag(head);
+
+        assert_eq!(
+            composer
+                .selection_text(selection.range().unwrap())
+                .as_deref(),
+            Some("bcdef\ngh")
+        );
+    }
+
+    #[test]
+    fn selection_scrolling_keeps_the_semantic_range_visible_without_cursor_follow() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("line 1\nline 2\nline 3\nline 4".to_owned());
+        render(&mut composer, 12, 4);
+        assert_eq!(composer.scroll, 2);
+
+        let content = Rect::new(1, 1, 10, 2);
+        assert!(composer.scroll_selection(-1, content));
+        let anchor = composer
+            .selection_span(Position::new(1, 1), content)
+            .unwrap();
+        let head = composer
+            .selection_span(Position::new(6, 2), content)
+            .unwrap();
+        let mut selection = Selection::default();
+        selection.begin(Surface::Composer, anchor);
+        selection.drag(head);
+        let range = selection.range().unwrap();
+
+        let terminal = render_with_selection(&mut composer, 12, 4, range);
+
+        assert_eq!(composer.scroll, 1);
+        assert_eq!(
+            composer.selection_text(range).as_deref(),
+            Some("line 2\nline 3")
+        );
+        assert_eq!(terminal.backend().buffer()[(1, 1)].bg, Color::Yellow);
+        assert_eq!(terminal.backend().buffer()[(6, 2)].bg, Color::Yellow);
+        assert_eq!(terminal.backend().cursor_position(), Position::new(0, 0));
+    }
+
+    #[test]
+    fn narrow_selection_matches_the_visible_draft_text() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("first\nsecond\nthird".to_owned());
+        render(&mut composer, 12, 4);
+
+        let terminal = render(&mut composer, 2, 2);
+        let visible = terminal.backend().buffer()[(0, 0)].symbol().to_owned();
+        let area = Rect::new(0, 0, 2, 1);
+        let span = composer.selection_span(Position::new(0, 0), area).unwrap();
+        let mut selection = Selection::default();
+        selection.begin(Surface::Composer, span);
+        selection.drag(span);
+
+        assert_eq!(
+            composer
+                .selection_text(selection.range().unwrap())
+                .as_deref(),
+            Some(visible.as_str())
+        );
     }
 
     #[test]

--- a/src/tui/components/composer/layout.rs
+++ b/src/tui/components/composer/layout.rs
@@ -1,5 +1,6 @@
 //! Grapheme-aware soft and hard wrapping for the composer.
 
+use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -165,4 +166,35 @@ pub(super) fn byte_at_column(text: &str, line: &VisualLine, target: usize) -> us
         column = next;
     }
     line.end
+}
+
+pub(super) fn grapheme_at_column(text: &str, line: &VisualLine, target: usize) -> Range<usize> {
+    let mut column = 0;
+    for (offset, grapheme) in text[line.start..line.end].grapheme_indices(true) {
+        let start = line.start + offset;
+        let next = column + grapheme.width();
+        if next > target {
+            return start..start + grapheme.len();
+        }
+        column = next;
+    }
+    line.end..line.end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VisualLayout, grapheme_at_column};
+
+    #[test]
+    fn hit_testing_returns_whole_graphemes() {
+        let text = "a界e\u{301}";
+        let layout = VisualLayout::new(text, 0, 10);
+        let line = &layout.lines[0];
+
+        assert_eq!(grapheme_at_column(text, line, 0), 0..1);
+        assert_eq!(grapheme_at_column(text, line, 1), 1..4);
+        assert_eq!(grapheme_at_column(text, line, 2), 1..4);
+        assert_eq!(grapheme_at_column(text, line, 3), 4..7);
+        assert_eq!(grapheme_at_column(text, line, 4), 7..7);
+    }
 }

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -15,11 +15,11 @@ use super::{
     review_confirmation::{
         ReviewConfirmationEffect, ReviewConfirmationEvent, ReviewDownloadConfirmation,
     },
-    selection::{Selection, Surface},
+    selection::{Selection, Surface, TextSpan},
     session_picker::{SessionPicker, SessionPickerEffect, SessionPickerEvent},
     subagents::{SubagentEffect, SubagentOverlay, SubagentTree},
     theme_selector::{ThemeSelector, ThemeSelectorEffect, ThemeSelectorEvent},
-    transcript::{Transcript, TranscriptEvent},
+    transcript::{ScrollCommand, Transcript, TranscriptEvent},
 };
 use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
@@ -48,6 +48,7 @@ use std::{
 };
 
 const KEY_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(2);
+const SELECTION_SCROLL_INTERVAL: Duration = Duration::from_millis(60);
 const BREADCRUMB_DURATION: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -91,6 +92,12 @@ struct KeyConfirmation {
 struct Notification {
     message: Line<'static>,
     color: Color,
+    deadline: Instant,
+}
+
+struct SelectionAutoScroll {
+    direction: isize,
+    position: Position,
     deadline: Instant,
 }
 
@@ -243,6 +250,7 @@ pub(crate) struct RootNode {
     notification: Option<Notification>,
     discarded_draft: Option<ComposerDraft>,
     selection: Selection,
+    selection_auto_scroll: Option<SelectionAutoScroll>,
     transcript_area: Rect,
     composer_area: Rect,
     composer_content_area: Rect,
@@ -272,6 +280,7 @@ impl RootNode {
             notification: None,
             discarded_draft: None,
             selection: Selection::default(),
+            selection_auto_scroll: None,
             transcript_area: Rect::default(),
             composer_area: Rect::default(),
             composer_content_area: Rect::default(),
@@ -475,6 +484,9 @@ impl RootNode {
                 .as_ref()
                 .map(|confirmation| confirmation.deadline),
             self.notification.as_ref().map(|notice| notice.deadline),
+            self.selection_auto_scroll
+                .as_ref()
+                .map(|scroll| scroll.deadline),
             self.subagents.animation_deadline(),
         ]
         .into_iter()
@@ -523,11 +535,17 @@ impl RootNode {
                 composer_area.height - 2,
             )
         } else {
-            composer_area
+            Rect {
+                height: composer_area.height.min(1),
+                ..composer_area
+            }
         };
         self.transcript.render(frame, transcript_area, theme);
         self.queue.render(frame, queue_area, theme);
-        self.composer.component_mut().render_focused(
+        let composer_selection = (self.selection.surface() == Some(Surface::Composer))
+            .then(|| self.selection.range())
+            .flatten();
+        self.composer.component_mut().render_focused_with_selection(
             frame,
             composer_area,
             theme,
@@ -535,10 +553,14 @@ impl RootNode {
                 && !self.review_active
                 && !self.transcript.component().expandables_focused()
                 && !self.queue.component().focused(),
+            composer_selection,
         );
-        if let Some(selection_area) = self.selection_area() {
-            self.selection
-                .capture_and_render(frame.buffer_mut(), selection_area);
+        if self.selection.surface() == Some(Surface::Transcript)
+            && let Some(range) = self.selection.range()
+        {
+            self.transcript
+                .component()
+                .render_selection(frame.buffer_mut(), range);
         }
         self.transcript
             .component()
@@ -580,6 +602,7 @@ impl RootNode {
     fn update_terminal(&mut self, event: Event) -> ComponentUpdate<RootEffect> {
         if matches!(event, Event::Resize(_, _)) {
             self.selection.clear();
+            self.selection_auto_scroll = None;
             return ComponentUpdate::render(RenderRequest::Immediate);
         }
         if is_confirmation_key_repeat(&event) {
@@ -657,6 +680,7 @@ impl RootNode {
         }
         if is_escape(&event) {
             if self.selection.clear() {
+                self.selection_auto_scroll = None;
                 self.key_confirmation = None;
                 return ComponentUpdate::render(RenderRequest::Immediate);
             }
@@ -816,30 +840,63 @@ impl RootNode {
         let position = Position::new(mouse.column, mouse.row);
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
-                let (surface, area) = self.surface_at(position)?;
-                self.selection.begin(surface, clamp_to(position, area));
+                let (surface, span) = self.selection_span_at(position)?;
+                self.selection.begin(surface, span);
+                self.selection_auto_scroll = None;
                 Some(ComponentUpdate::render(RenderRequest::Immediate))
             }
             MouseEventKind::Drag(MouseButton::Left) => {
-                let area = self.selection_area()?;
-                self.selection.drag(position, area);
+                let surface = self.selection.surface()?;
+                let span = self.selection_span_on(surface, position)?;
+                self.selection.drag(span);
+                self.begin_selection_auto_scroll(surface, position);
                 Some(ComponentUpdate::render(RenderRequest::Immediate))
+            }
+            MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
+                if self.selection.is_active() || self.selection.is_pending() =>
+            {
+                let rows = if mouse.kind == MouseEventKind::ScrollUp {
+                    -3
+                } else {
+                    3
+                };
+                let render = match self.selection.surface()? {
+                    Surface::Transcript => {
+                        self.transcript
+                            .update(TranscriptEvent::Scroll(ScrollCommand::Rows(rows)));
+                        RenderRequest::Immediate
+                    }
+                    Surface::Composer => {
+                        let changed = self
+                            .composer
+                            .component_mut()
+                            .scroll_selection(rows as isize, self.composer_content_area);
+                        if changed {
+                            RenderRequest::Immediate
+                        } else {
+                            RenderRequest::None
+                        }
+                    }
+                };
+                Some(ComponentUpdate::render(render))
             }
             MouseEventKind::Up(MouseButton::Left)
                 if self.selection.is_active() || self.selection.is_pending() =>
             {
-                let area = self.selection_area()?;
-                if !self.selection.finish(position, area) {
+                let surface = self.selection.surface()?;
+                self.selection_auto_scroll = None;
+                let span = self.selection_span_on(surface, position)?;
+                if !self.selection.finish(span) {
                     mouse.kind = MouseEventKind::Down(MouseButton::Left);
                     return None;
                 }
+                let range = self.selection.take_range()?;
+                let text = match surface {
+                    Surface::Transcript => self.transcript.component().selection_text(range),
+                    Surface::Composer => self.composer.component().selection_text(range),
+                };
                 Some(ComponentUpdate {
-                    effects: self
-                        .selection
-                        .take_text()
-                        .map(RootEffect::Copy)
-                        .into_iter()
-                        .collect(),
+                    effects: text.map(RootEffect::Copy).into_iter().collect(),
                     render: RenderRequest::Immediate,
                 })
             }
@@ -847,19 +904,73 @@ impl RootNode {
         }
     }
 
-    fn surface_at(&self, position: Position) -> Option<(Surface, Rect)> {
+    fn selection_span_at(&mut self, position: Position) -> Option<(Surface, TextSpan)> {
         if self.composer_content_area.contains(position) {
-            return Some((Surface::Composer, self.composer_content_area));
+            let span = self
+                .composer
+                .component_mut()
+                .selection_span(position, self.composer_content_area)?;
+            return Some((Surface::Composer, span));
         }
-        self.transcript_area
-            .contains(position)
-            .then_some((Surface::Transcript, self.transcript_area))
+        if !self.transcript_area.contains(position) {
+            return None;
+        }
+        let span = self.transcript.component().selection_span(position)?;
+        Some((Surface::Transcript, span))
     }
 
-    fn selection_area(&self) -> Option<Rect> {
-        match self.selection.surface()? {
-            Surface::Transcript => Some(self.transcript_area),
-            Surface::Composer => Some(self.composer_content_area),
+    fn selection_span_on(&mut self, surface: Surface, position: Position) -> Option<TextSpan> {
+        match surface {
+            Surface::Transcript => {
+                let position = clamp_to(position, self.transcript_area);
+                self.transcript.component().selection_span_nearest(position)
+            }
+            Surface::Composer => {
+                let position = clamp_to(position, self.composer_content_area);
+                self.composer
+                    .component_mut()
+                    .selection_span(position, self.composer_content_area)
+            }
+        }
+    }
+
+    fn begin_selection_auto_scroll(&mut self, surface: Surface, position: Position) {
+        let area = match surface {
+            Surface::Transcript => self.transcript_area,
+            Surface::Composer => self.composer_content_area,
+        };
+        let direction = if position.y <= area.y {
+            -1
+        } else if position.y >= area.bottom().saturating_sub(1) {
+            1
+        } else {
+            self.selection_auto_scroll = None;
+            return;
+        };
+        if let Some(scroll) = &mut self.selection_auto_scroll
+            && scroll.direction == direction
+        {
+            scroll.position = position;
+            return;
+        }
+        self.selection_auto_scroll = Some(SelectionAutoScroll {
+            direction,
+            position,
+            deadline: Instant::now() + SELECTION_SCROLL_INTERVAL,
+        });
+    }
+
+    fn scroll_selected_surface(&mut self, surface: Surface, rows: isize) -> bool {
+        match surface {
+            Surface::Transcript => {
+                self.transcript
+                    .update(TranscriptEvent::Scroll(ScrollCommand::Rows(rows as i32)));
+                true
+            }
+            Surface::Composer => self
+                .composer
+                .component_mut()
+                .scroll_selection(rows, self.composer_content_area),
         }
     }
 
@@ -1577,6 +1688,7 @@ impl RootNode {
         } else {
             RenderRequest::None
         };
+        let selection = self.update_selection_auto_scroll(now);
         let notification = if self
             .notification
             .as_ref()
@@ -1595,9 +1707,33 @@ impl RootNode {
                 .max(composer.render)
                 .max(queue.render)
                 .max(subagents)
+                .max(selection)
                 .max(confirmation)
                 .max(notification),
         }
+    }
+
+    fn update_selection_auto_scroll(&mut self, now: Instant) -> RenderRequest {
+        let Some(mut scroll) = self.selection_auto_scroll.take() else {
+            return RenderRequest::None;
+        };
+        if now < scroll.deadline {
+            self.selection_auto_scroll = Some(scroll);
+            return RenderRequest::None;
+        }
+        let Some(surface) = self.selection.surface() else {
+            return RenderRequest::None;
+        };
+        let Some(span) = self.selection_span_on(surface, scroll.position) else {
+            return RenderRequest::None;
+        };
+        self.selection.drag(span);
+        if !self.scroll_selected_surface(surface, scroll.direction) {
+            return RenderRequest::None;
+        }
+        scroll.deadline = now + SELECTION_SCROLL_INTERVAL;
+        self.selection_auto_scroll = Some(scroll);
+        RenderRequest::Immediate
     }
 
     fn apply_subagent_update(&mut self, update: AgentUpdate) -> ComponentUpdate<RootEffect> {
@@ -3079,11 +3215,11 @@ mod tests {
         root.update(key(KeyCode::Tab, KeyModifiers::NONE));
         assert!(root.queue.component().focused());
 
-        root.update(mouse(MouseEventKind::Down(MouseButton::Left), 10, 9));
-        let update = root.update(mouse(MouseEventKind::Up(MouseButton::Left), 10, 9));
+        let down = root.update(mouse(MouseEventKind::Down(MouseButton::Left), 10, 9));
+        let up = root.update(mouse(MouseEventKind::Up(MouseButton::Left), 10, 9));
 
         assert!(!root.queue.component().focused());
-        assert_eq!(update.render, super::RenderRequest::Immediate);
+        assert_eq!(down.render.max(up.render), super::RenderRequest::Immediate);
     }
 
     #[test]
@@ -3445,6 +3581,303 @@ mod tests {
 
         assert_eq!(update.effects, [RootEffect::Copy("hello".to_owned())]);
         assert!(!root.selection.is_active());
+    }
+
+    #[test]
+    fn transcript_selection_copies_code_source_without_rendered_borders() {
+        let mut terminal = Terminal::new(TestBackend::new(40, 14)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(super::RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::AssistantMessage,
+            json!({
+                "model_call_index": 1,
+                "item_id": "answer",
+                "phase": "final_answer",
+                "text": "```rust\n    let answer = 42;\n```",
+            }),
+        )));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let row = (0..terminal.backend().buffer().area.height)
+            .find(|&row| {
+                (0..terminal.backend().buffer().area.width)
+                    .map(|column| terminal.backend().buffer()[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("    let answer = 42;")
+            })
+            .expect("code should be visible");
+
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), 0, row));
+        root.update(mouse(MouseEventKind::Drag(MouseButton::Left), 39, row));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert_ne!(buffer[(0, row)].bg, Color::Yellow);
+        assert_eq!(buffer[(2, row)].bg, Color::Yellow);
+        assert_ne!(buffer[(39, row)].bg, Color::Yellow);
+
+        let update = root.update(mouse(MouseEventKind::Up(MouseButton::Left), 39, row));
+        assert_eq!(
+            update.effects,
+            [RootEffect::Copy("    let answer = 42;".to_owned())]
+        );
+    }
+
+    #[test]
+    fn transcript_selection_copies_original_markdown_syntax() {
+        let mut terminal = Terminal::new(TestBackend::new(64, 12)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(super::RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::AssistantMessage,
+            json!({
+                "model_call_index": 1,
+                "item_id": "answer",
+                "phase": "final_answer",
+                "text": "**bold** and [site](https://example.com)",
+            }),
+        )));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let row = (0..terminal.backend().buffer().area.height)
+            .find(|&row| {
+                (0..terminal.backend().buffer().area.width)
+                    .map(|column| terminal.backend().buffer()[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("bold and site")
+            })
+            .expect("message should be visible");
+        let start = text_column(terminal.backend().buffer(), row, "bold");
+        let end = text_column(terminal.backend().buffer(), row, "site") + 3;
+
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), start, row));
+        root.update(mouse(MouseEventKind::Drag(MouseButton::Left), end, row));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let destination = text_column(terminal.backend().buffer(), row, "https://example.com");
+        assert_ne!(
+            terminal.backend().buffer()[(destination, row)].bg,
+            Color::Yellow
+        );
+
+        let update = root.update(mouse(MouseEventKind::Up(MouseButton::Left), end, row));
+        assert_eq!(
+            update.effects,
+            [RootEffect::Copy(
+                "**bold** and [site](https://example.com)".to_owned()
+            )]
+        );
+    }
+
+    #[test]
+    fn partial_transcript_selection_does_not_copy_unmatched_markdown_delimiters() {
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(super::RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::AssistantMessage,
+            json!({
+                "model_call_index": 1,
+                "item_id": "answer",
+                "phase": "final_answer",
+                "text": "**bold**",
+            }),
+        )));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let row = (0..root.transcript_area.height)
+            .find(|&row| {
+                (0..40)
+                    .map(|column| terminal.backend().buffer()[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("bold")
+            })
+            .unwrap();
+        let start = text_column(terminal.backend().buffer(), row, "bold");
+
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), start, row));
+        root.update(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            start + 1,
+            row,
+        ));
+        let update = root.update(mouse(MouseEventKind::Up(MouseButton::Left), start + 1, row));
+
+        assert_eq!(update.effects, [RootEffect::Copy("bo".to_owned())]);
+    }
+
+    #[test]
+    fn transcript_selection_survives_scrolling_beyond_the_viewport() {
+        let mut terminal = Terminal::new(TestBackend::new(32, 12)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        for sequence in 1..=10 {
+            let record = TranscriptRecord::from_local(
+                sequence,
+                sequence,
+                LocalEvent::UserSubmitted {
+                    id: TurnId::new(sequence),
+                    text: format!("prompt {sequence}"),
+                },
+            )
+            .unwrap();
+            root.update(super::RootEvent::Transcript(Arc::new(record)));
+        }
+        root.update(key(KeyCode::Home, KeyModifiers::CONTROL));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let start_row = (0..root.transcript_area.height)
+            .find(|&row| {
+                (0..32)
+                    .map(|column| terminal.backend().buffer()[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("prompt 1")
+            })
+            .expect("first prompt should be visible");
+
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), 0, start_row));
+        root.update(mouse(MouseEventKind::ScrollDown, 4, start_row));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let end_row = (0..root.transcript_area.height)
+            .rev()
+            .find(|&row| terminal.backend().buffer()[(0, row)].symbol() == "┃")
+            .expect("a later prompt should be visible");
+        let end_column = (0..32)
+            .rev()
+            .find(|&column| terminal.backend().buffer()[(column, end_row)].symbol() != " ")
+            .expect("prompt should contain text");
+        root.update(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            end_column,
+            end_row,
+        ));
+        let update = root.update(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            end_column,
+            end_row,
+        ));
+
+        assert_eq!(
+            update.effects,
+            [RootEffect::Copy(
+                "prompt 1\n\nprompt 2\n\nprompt 3\n\nprompt 4\n\nprompt 5".to_owned()
+            )]
+        );
+    }
+
+    #[test]
+    fn dragging_at_the_viewport_edge_keeps_extending_the_selection() {
+        let mut terminal = Terminal::new(TestBackend::new(32, 12)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        for sequence in 1..=12 {
+            let record = TranscriptRecord::from_local(
+                sequence,
+                sequence,
+                LocalEvent::UserSubmitted {
+                    id: TurnId::new(sequence),
+                    text: format!("prompt {sequence}"),
+                },
+            )
+            .unwrap();
+            root.update(super::RootEvent::Transcript(Arc::new(record)));
+        }
+        root.update(key(KeyCode::Home, KeyModifiers::CONTROL));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let start_row = (0..root.transcript_area.height)
+            .find(|&row| {
+                (0..32)
+                    .map(|column| terminal.backend().buffer()[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("prompt 1")
+            })
+            .unwrap();
+        let edge = root.transcript_area.bottom().saturating_sub(1);
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), 2, start_row));
+        root.update(mouse(MouseEventKind::Drag(MouseButton::Left), 31, edge));
+
+        for _ in 0..4 {
+            terminal
+                .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+                .unwrap();
+            let deadline = root
+                .selection_auto_scroll
+                .as_ref()
+                .expect("edge drag should keep scrolling")
+                .deadline;
+            root.update(super::RootEvent::AnimationFrame(deadline));
+        }
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let update = root.update(mouse(MouseEventKind::Up(MouseButton::Left), 31, edge));
+        let [RootEffect::Copy(text)] = update.effects.as_slice() else {
+            panic!("edge drag should copy the semantic selection");
+        };
+
+        assert!(text.starts_with("prompt 1\n\n"));
+        assert!(text.contains("prompt 6"));
+        assert!(!text.contains('┃'));
+        assert!(root.selection_auto_scroll.is_none());
+    }
+
+    #[test]
+    fn composer_selection_scrolls_without_losing_offscreen_text() {
+        let mut terminal = Terminal::new(TestBackend::new(32, 12)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(super::RootEvent::ReplaceDraft(
+            (1..=10)
+                .map(|line| format!("line {line}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let start_row = root.composer_content_area.bottom().saturating_sub(1);
+        let start_column = text_column(terminal.backend().buffer(), start_row, "line 10");
+
+        root.update(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            start_column + 6,
+            start_row,
+        ));
+        root.update(mouse(MouseEventKind::ScrollUp, start_column, start_row));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let end_row = root.composer_content_area.y;
+        let end_column = text_column(terminal.backend().buffer(), end_row, "line 2");
+        root.update(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            end_column,
+            end_row,
+        ));
+        let update = root.update(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            end_column,
+            end_row,
+        ));
+
+        assert_eq!(
+            update.effects,
+            [RootEffect::Copy(
+                (2..=10)
+                    .map(|line| format!("line {line}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )]
+        );
     }
 
     #[test]

--- a/src/tui/components/selection.rs
+++ b/src/tui/components/selection.rs
@@ -1,10 +1,6 @@
-//! Shared mouse selection over rendered component surfaces.
+//! Semantic selection shared by transcript and composer surfaces.
 
-use ratatui::{
-    buffer::Buffer,
-    layout::{Position, Rect},
-    style::{Color, Style},
-};
+use std::ops::Range;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Surface {
@@ -13,292 +9,170 @@ pub(super) enum Surface {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct Point {
-    surface: Surface,
-    position: Position,
+pub(super) struct TextSpan {
+    pub(super) block: usize,
+    pub(super) start: usize,
+    pub(super) end: usize,
+}
+
+impl TextSpan {
+    pub(super) const fn new(block: usize, start: usize, end: usize) -> Self {
+        Self { block, start, end }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct Range {
-    anchor: Point,
-    head: Point,
+struct Point {
+    surface: Surface,
+    span: TextSpan,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct TextRange {
+    anchor: TextSpan,
+    head: TextSpan,
+}
+
+impl TextRange {
+    pub(super) fn bounds(self) -> (TextSpan, TextSpan) {
+        if (self.anchor.block, self.anchor.start) <= (self.head.block, self.head.start) {
+            (self.anchor, self.head)
+        } else {
+            (self.head, self.anchor)
+        }
+    }
+
+    pub(super) fn source_range(self, block: usize, source_len: usize) -> Option<Range<usize>> {
+        let (start, end) = self.bounds();
+        if block < start.block || block > end.block {
+            return None;
+        }
+        let range_start = if block == start.block { start.start } else { 0 };
+        let range_end = if block == end.block {
+            end.end
+        } else {
+            source_len
+        };
+        (range_start < range_end).then_some(range_start..range_end)
+    }
+
+    pub(super) fn includes(self, block: usize, source: &Range<usize>) -> bool {
+        self.source_range(block, usize::MAX)
+            .is_some_and(|selected| selected.start < source.end && source.start < selected.end)
+    }
 }
 
 #[derive(Default)]
 pub(super) struct Selection {
+    surface: Option<Surface>,
     pending: Option<Point>,
-    range: Option<Range>,
-    snapshot: Option<Snapshot>,
-}
-
-struct Snapshot {
-    area: Rect,
-    rows: Vec<Vec<String>>,
+    range: Option<TextRange>,
 }
 
 impl Selection {
-    pub(super) fn begin(&mut self, surface: Surface, position: Position) {
-        let point = Point { surface, position };
-        self.pending = Some(point);
+    pub(super) fn begin(&mut self, surface: Surface, span: TextSpan) {
+        self.surface = Some(surface);
+        self.pending = Some(Point { surface, span });
         self.range = None;
-        self.snapshot = None;
     }
 
-    pub(super) fn drag(&mut self, position: Position, area: Rect) -> bool {
-        let Some(anchor) = self
-            .pending
-            .or_else(|| self.range.map(|range| range.anchor))
-        else {
+    pub(super) fn drag(&mut self, span: TextSpan) -> bool {
+        let Some(anchor) = self.pending.or_else(|| {
+            self.range.map(|range| Point {
+                surface: self.surface.expect("a range has a surface"),
+                span: range.anchor,
+            })
+        }) else {
             return false;
         };
-        let head = Point {
-            surface: anchor.surface,
-            position: clamp(position, area),
+        let range = TextRange {
+            anchor: anchor.span,
+            head: span,
         };
-        self.range = Some(Range { anchor, head });
-        true
+        let changed = self.range != Some(range);
+        self.range = Some(range);
+        changed
     }
 
-    pub(super) fn finish(&mut self, position: Position, area: Rect) -> bool {
-        let Some(anchor) = self
-            .pending
-            .or_else(|| self.range.map(|range| range.anchor))
-        else {
+    pub(super) fn finish(&mut self, span: TextSpan) -> bool {
+        let Some(anchor) = self.pending.or_else(|| {
+            self.range.map(|range| Point {
+                surface: self.surface.expect("a range has a surface"),
+                span: range.anchor,
+            })
+        }) else {
             return false;
         };
-        let head = Point {
-            surface: anchor.surface,
-            position: clamp(position, area),
-        };
-        if self.range.is_none() && head == anchor {
-            self.cancel_pending();
+        if self.range.is_none() && span == anchor.span {
+            self.pending = None;
             return false;
         }
-        self.range = Some(Range { anchor, head });
+        self.range = Some(TextRange {
+            anchor: anchor.span,
+            head: span,
+        });
         self.pending = None;
         true
-    }
-
-    fn cancel_pending(&mut self) {
-        self.pending = None;
-        if self.range.is_none() {
-            self.snapshot = None;
-        }
     }
 
     pub(super) fn clear(&mut self) -> bool {
         let changed = self.pending.take().is_some() || self.range.take().is_some();
-        self.snapshot = None;
+        self.surface = None;
         changed
     }
 
-    pub(super) fn is_pending(&self) -> bool {
+    pub(super) const fn is_pending(&self) -> bool {
         self.pending.is_some()
     }
 
-    pub(super) fn is_active(&self) -> bool {
+    pub(super) const fn is_active(&self) -> bool {
         self.range.is_some()
     }
 
-    pub(super) fn surface(&self) -> Option<Surface> {
-        self.pending
-            .map(|point| point.surface)
-            .or_else(|| self.range.map(|range| range.anchor.surface))
+    pub(super) const fn surface(&self) -> Option<Surface> {
+        self.surface
     }
 
-    pub(super) fn capture_and_render(&mut self, buffer: &mut Buffer, area: Rect) {
-        if self.pending.is_none() && self.range.is_none() {
-            return;
-        }
-
-        self.snapshot = Some(Snapshot::capture(buffer, area));
-        let Some(range) = self.range else {
-            return;
-        };
-        for position in positions(range, area) {
-            if let Some(cell) = buffer.cell_mut(position) {
-                cell.set_style(Style::reset().fg(Color::Black).bg(Color::Yellow));
-            }
-        }
-    }
-
-    pub(super) fn take_text(&mut self) -> Option<String> {
-        let range = self.range.take()?;
-        self.pending = None;
-        let snapshot = self.snapshot.take()?;
-        let text = snapshot.text(range);
-        (!text.is_empty()).then_some(text)
-    }
-}
-
-impl Snapshot {
-    fn capture(buffer: &Buffer, area: Rect) -> Self {
-        let rows = (area.y..area.bottom())
-            .map(|y| capture_row(buffer, area, y))
-            .collect();
-        Self { area, rows }
-    }
-
-    fn text(&self, range: Range) -> String {
-        let mut lines = Vec::new();
-        for row in selected_rows(range, self.area) {
-            let y = usize::from(row.y.saturating_sub(self.area.y));
-            let start = usize::from(row.start.saturating_sub(self.area.x));
-            let end = usize::from(row.end.saturating_sub(self.area.x));
-            let Some(cells) = self.rows.get(y).and_then(|line| line.get(start..=end)) else {
-                continue;
-            };
-            let line = cells.concat();
-            lines.push(line.trim_end().to_owned());
-        }
-        lines.join("\n")
-    }
-}
-
-fn capture_row(buffer: &Buffer, area: Rect, y: u16) -> Vec<String> {
-    let mut continuation_cells = 0;
-    (area.x..area.right())
-        .map(|x| {
-            if continuation_cells > 0 {
-                continuation_cells -= 1;
-                return String::new();
-            }
-            let symbol = buffer[(x, y)].symbol();
-            continuation_cells = unicode_width::UnicodeWidthStr::width(symbol).saturating_sub(1);
-            symbol.to_owned()
+    pub(super) fn range(&self) -> Option<TextRange> {
+        self.range.or_else(|| {
+            self.pending.map(|point| TextRange {
+                anchor: point.span,
+                head: point.span,
+            })
         })
-        .collect()
-}
-
-#[derive(Clone, Copy)]
-struct SelectedRow {
-    y: u16,
-    start: u16,
-    end: u16,
-}
-
-fn positions(range: Range, area: Rect) -> impl Iterator<Item = Position> {
-    selected_rows(range, area)
-        .flat_map(|row| (row.start..=row.end).map(move |x| Position::new(x, row.y)))
-}
-
-fn selected_rows(range: Range, area: Rect) -> impl Iterator<Item = SelectedRow> {
-    let (start, end) = ordered(range.anchor.position, range.head.position);
-    (start.y..=end.y).map(move |y| SelectedRow {
-        y,
-        start: if y == start.y { start.x } else { area.x },
-        end: if y == end.y {
-            end.x
-        } else {
-            area.right().saturating_sub(1)
-        },
-    })
-}
-
-fn ordered(left: Position, right: Position) -> (Position, Position) {
-    if (left.y, left.x) <= (right.y, right.x) {
-        (left, right)
-    } else {
-        (right, left)
     }
-}
 
-fn clamp(position: Position, area: Rect) -> Position {
-    Position::new(
-        position.x.clamp(area.x, area.right().saturating_sub(1)),
-        position.y.clamp(area.y, area.bottom().saturating_sub(1)),
-    )
+    pub(super) fn take_range(&mut self) -> Option<TextRange> {
+        self.pending = None;
+        self.surface = None;
+        self.range.take()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Selection, Surface};
-    use ratatui::{
-        buffer::Buffer,
-        layout::{Position, Rect},
-        style::{Color, Modifier, Style},
-    };
+    use super::{Selection, Surface, TextSpan};
 
     #[test]
-    fn selection_extracts_forward_and_reverse_visual_ranges() {
-        for (anchor, head) in [
-            (Position::new(1, 0), Position::new(2, 1)),
-            (Position::new(2, 1), Position::new(1, 0)),
-        ] {
-            let area = Rect::new(0, 0, 5, 2);
-            let mut buffer = Buffer::empty(area);
-            buffer.set_string(0, 0, "alpha", Style::default());
-            buffer.set_string(0, 1, "beta ", Style::default());
-            let mut selection = Selection::default();
-            selection.begin(Surface::Transcript, anchor);
-            selection.drag(head, area);
-            selection.capture_and_render(&mut buffer, area);
+    fn semantic_ranges_are_ordered_and_span_whole_intermediate_blocks() {
+        let mut selection = Selection::default();
+        selection.begin(Surface::Transcript, TextSpan::new(3, 4, 5));
+        selection.drag(TextSpan::new(1, 2, 3));
+        let range = selection.range().unwrap();
 
-            assert_eq!(selection.take_text().as_deref(), Some("lpha\nbet"));
-        }
+        assert_eq!(range.source_range(1, 10), Some(2..10));
+        assert_eq!(range.source_range(2, 10), Some(0..10));
+        assert_eq!(range.source_range(3, 10), Some(0..5));
+        assert_eq!(range.source_range(4, 10), None);
     }
 
     #[test]
-    fn pending_click_does_not_create_copyable_text() {
+    fn pending_click_does_not_create_a_range() {
         let mut selection = Selection::default();
-        selection.begin(Surface::Composer, Position::new(1, 1));
+        let span = TextSpan::new(0, 1, 2);
+        selection.begin(Surface::Composer, span);
 
-        assert!(selection.is_pending());
-        assert!(!selection.finish(Position::new(1, 1), Rect::new(0, 0, 3, 3)));
-        assert!(selection.take_text().is_none());
-    }
-
-    #[test]
-    fn displaced_release_finishes_without_a_drag_event() {
-        let area = Rect::new(0, 0, 7, 1);
-        let mut buffer = Buffer::empty(area);
-        buffer.set_string(0, 0, "copy me", Style::default());
-        let mut selection = Selection::default();
-        selection.begin(Surface::Composer, Position::new(0, 0));
-        selection.capture_and_render(&mut buffer, area);
-
-        assert!(selection.finish(Position::new(6, 0), area));
-        assert_eq!(selection.take_text().as_deref(), Some("copy me"));
-    }
-
-    #[test]
-    fn wide_graphemes_do_not_add_continuation_spaces() {
-        let area = Rect::new(0, 0, 4, 1);
-        let mut buffer = Buffer::empty(area);
-        buffer.set_string(0, 0, "a界b", Style::default());
-        let mut selection = Selection::default();
-        selection.begin(Surface::Composer, Position::new(0, 0));
-        selection.drag(Position::new(3, 0), area);
-        selection.capture_and_render(&mut buffer, area);
-
-        assert_eq!(selection.take_text().as_deref(), Some("a界b"));
-    }
-
-    #[test]
-    fn selection_is_always_black_on_yellow() {
-        let area = Rect::new(0, 0, 4, 1);
-        let mut buffer = Buffer::empty(area);
-        buffer.set_string(
-            0,
-            0,
-            "text",
-            Style::default()
-                .fg(Color::Red)
-                .bg(Color::Blue)
-                .add_modifier(Modifier::BOLD),
-        );
-        let mut selection = Selection::default();
-        selection.begin(Surface::Transcript, Position::new(1, 0));
-        selection.drag(Position::new(2, 0), area);
-
-        selection.capture_and_render(&mut buffer, area);
-
-        for x in 1..=2 {
-            assert_eq!(buffer[(x, 0)].fg, Color::Black);
-            assert_eq!(buffer[(x, 0)].bg, Color::Yellow);
-            assert!(buffer[(x, 0)].modifier.is_empty());
-        }
-        assert_eq!(buffer[(0, 0)].fg, Color::Red);
-        assert_eq!(buffer[(0, 0)].bg, Color::Blue);
+        assert!(!selection.finish(span));
+        assert!(selection.take_range().is_none());
     }
 }

--- a/src/tui/components/transcript/markdown.rs
+++ b/src/tui/components/transcript/markdown.rs
@@ -4,7 +4,7 @@ use ratatui::{
     style::{Modifier, Style},
     text::{Line, Span},
 };
-use std::sync::Arc;
+use std::{ops::Range, sync::Arc};
 use syntect::easy::HighlightLines;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
@@ -12,6 +12,20 @@ use unicode_width::UnicodeWidthStr;
 pub(super) struct Layout {
     pub(super) lines: Vec<Line<'static>>,
     pub(super) links: Vec<Vec<LinkSpan>>,
+    pub(super) selections: Vec<Vec<SourceSpan>>,
+    pub(super) envelopes: Vec<SourceEnvelope>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SourceSpan {
+    pub(super) columns: Range<u16>,
+    pub(super) source: Range<usize>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SourceEnvelope {
+    pub(super) content: Range<usize>,
+    pub(super) source: Range<usize>,
 }
 
 #[derive(Clone)]
@@ -26,6 +40,8 @@ pub(super) fn render(markdown: &str, width: u16, theme: &Theme) -> Layout {
         return Layout {
             lines: Vec::new(),
             links: Vec::new(),
+            selections: Vec::new(),
+            envelopes: Vec::new(),
         };
     }
     let options = Options::ENABLE_TABLES
@@ -50,7 +66,17 @@ pub(super) fn render(markdown: &str, width: u16, theme: &Theme) -> Layout {
             event => renderer.event(event),
         }
     }
-    renderer.finish()
+    let (mut layout, selection_exclusions) = renderer.finish();
+    let (selections, envelopes) =
+        markdown_selection_spans(markdown, &layout.lines, options, &selection_exclusions);
+    layout.selections = selections;
+    layout.envelopes = envelopes;
+    layout
+}
+
+pub(super) fn plain_selection_spans(source: &str, lines: &[Line<'static>]) -> Vec<Vec<SourceSpan>> {
+    let graphemes = source_graphemes(source, source, 0..source.len());
+    align_source_graphemes(&graphemes, lines, &[])
 }
 
 pub(super) fn wrap_plain(text: &str, width: u16, style: Style) -> Vec<Line<'static>> {
@@ -89,6 +115,7 @@ struct Renderer<'a> {
     quote_depth: usize,
     links: Vec<LinkState>,
     rendered_links: Vec<(usize, LinkSpan)>,
+    selection_exclusions: Vec<Vec<Range<u16>>>,
     image: Option<ImageState>,
 }
 
@@ -123,6 +150,7 @@ impl<'a> Renderer<'a> {
             quote_depth: 0,
             links: Vec::new(),
             rendered_links: Vec::new(),
+            selection_exclusions: Vec::new(),
             image: None,
         }
     }
@@ -414,11 +442,13 @@ impl<'a> Renderer<'a> {
         );
         let syntax_theme = super::highlight::theme(self.theme);
         let mut highlighter = HighlightLines::new(syntax, &syntax_theme);
+        let header = self.lines.len();
         self.lines.push(code_block_header(
             language.as_deref(),
             self.width,
             self.theme,
         ));
+        self.exclude_from_selection(header, 0..self.width);
         let content_width = self.width.saturating_sub(4).max(1);
         for source_line in code.trim_end_matches('\n').split('\n') {
             let highlighted =
@@ -441,9 +471,19 @@ impl<'a> Renderer<'a> {
                 body.extend(spans);
                 body.push(Span::raw(" ".repeat(padding)));
                 body.push(Span::styled(" │", border));
+                let line = self.lines.len();
                 self.lines.push(Line::from(body));
+                self.exclude_from_selection(line, 0..2);
+                if index > 0 {
+                    self.exclude_from_selection(line, 2..4);
+                }
+                let content_end = 2_u16
+                    .saturating_add(u16::try_from(used).unwrap_or(u16::MAX))
+                    .min(self.width);
+                self.exclude_from_selection(line, content_end..self.width);
             }
         }
+        let footer = self.lines.len();
         self.lines.push(Line::from(Span::styled(
             format!(
                 "╰{}╯",
@@ -451,6 +491,7 @@ impl<'a> Renderer<'a> {
             ),
             border,
         )));
+        self.exclude_from_selection(footer, 0..self.width);
         self.blank();
     }
 
@@ -470,7 +511,9 @@ impl<'a> Renderer<'a> {
             for spans in super::highlight::wrap(highlighted, content_width) {
                 let mut line = vec![Span::styled("┃ ", gutter)];
                 line.extend(spans);
+                let line_index = self.lines.len();
                 self.lines.push(Line::from(line));
+                self.exclude_from_selection(line_index, 0..2);
             }
         }
     }
@@ -588,7 +631,14 @@ impl<'a> Renderer<'a> {
         self.lines.push(Line::default());
     }
 
-    fn finish(mut self) -> Layout {
+    fn exclude_from_selection(&mut self, line: usize, columns: Range<u16>) {
+        if self.selection_exclusions.len() <= line {
+            self.selection_exclusions.resize_with(line + 1, Vec::new);
+        }
+        self.selection_exclusions[line].push(columns);
+    }
+
+    fn finish(mut self) -> (Layout, Vec<Vec<Range<u16>>>) {
         self.flush();
         while self.lines.last().is_some_and(|line| line.width() == 0) {
             self.lines.pop();
@@ -599,11 +649,252 @@ impl<'a> Renderer<'a> {
                 line_links.push(link);
             }
         }
-        Layout {
-            lines: self.lines,
-            links,
+        (
+            Layout {
+                lines: self.lines,
+                links,
+                selections: Vec::new(),
+                envelopes: Vec::new(),
+            },
+            self.selection_exclusions,
+        )
+    }
+}
+
+#[derive(Clone)]
+struct SourceGrapheme {
+    text: String,
+    source: Range<usize>,
+}
+
+fn markdown_selection_spans(
+    markdown: &str,
+    lines: &[Line<'static>],
+    options: Options,
+    exclusions: &[Vec<Range<u16>>],
+) -> (Vec<Vec<SourceSpan>>, Vec<SourceEnvelope>) {
+    let mut graphemes = Vec::<SourceGrapheme>::new();
+    let mut envelopes = Vec::<(TagEnd, Range<usize>, usize, bool)>::new();
+    let mut source_envelopes = Vec::new();
+    for (event, range) in Parser::new_ext(markdown, options).into_offset_iter() {
+        match event {
+            Event::Start(tag) => {
+                let preserve_delimiters = !matches!(tag, Tag::CodeBlock(_));
+                envelopes.push((tag.to_end(), range, graphemes.len(), preserve_delimiters));
+            }
+            Event::End(end) => {
+                let Some(index) = envelopes.iter().rposition(|(tag, ..)| *tag == end) else {
+                    continue;
+                };
+                let (_, range, first, preserve_delimiters) = envelopes.remove(index);
+                if !preserve_delimiters || first == graphemes.len() {
+                    continue;
+                }
+                source_envelopes.push(SourceEnvelope {
+                    content: graphemes[first].source.start
+                        ..graphemes
+                            .last()
+                            .expect("the envelope has content")
+                            .source
+                            .end,
+                    source: range,
+                });
+            }
+            Event::Text(text) | Event::Code(text) | Event::Html(text) | Event::InlineHtml(text) => {
+                graphemes.extend(source_graphemes(markdown, &sanitize(&text), range));
+            }
+            Event::InlineMath(math) => {
+                graphemes.extend(source_graphemes(
+                    markdown,
+                    &format!("${}$", sanitize(&math)),
+                    range,
+                ));
+            }
+            Event::DisplayMath(math) => {
+                graphemes.extend(source_graphemes(
+                    markdown,
+                    &format!("$${}$$", sanitize(&math)),
+                    range,
+                ));
+            }
+            Event::FootnoteReference(reference) => {
+                graphemes.extend(source_graphemes(
+                    markdown,
+                    &format!("[{}]", sanitize(&reference)),
+                    range,
+                ));
+            }
+            Event::SoftBreak => graphemes.push(SourceGrapheme {
+                text: " ".to_owned(),
+                source: range,
+            }),
+            Event::HardBreak => graphemes.push(SourceGrapheme {
+                text: "\n".to_owned(),
+                source: range,
+            }),
+            Event::TaskListMarker(checked) => {
+                graphemes.extend(source_graphemes(
+                    markdown,
+                    if checked { "✓ " } else { "□ " },
+                    range,
+                ));
+            }
+            Event::Rule => {}
         }
     }
+    (
+        align_source_graphemes(&graphemes, lines, exclusions),
+        source_envelopes,
+    )
+}
+
+fn source_graphemes(raw: &str, rendered: &str, source: Range<usize>) -> Vec<SourceGrapheme> {
+    let raw_fragment = raw.get(source.clone()).unwrap_or_default();
+    if raw_fragment == rendered {
+        return rendered
+            .grapheme_indices(true)
+            .map(|(offset, text)| SourceGrapheme {
+                text: text.to_owned(),
+                source: source.start + offset..source.start + offset + text.len(),
+            })
+            .collect();
+    }
+    rendered
+        .graphemes(true)
+        .map(|text| SourceGrapheme {
+            text: text.to_owned(),
+            source: source.clone(),
+        })
+        .collect()
+}
+
+struct RenderedGrapheme {
+    line: usize,
+    column: u16,
+    text: String,
+    width: u16,
+}
+
+fn align_source_graphemes(
+    source: &[SourceGrapheme],
+    lines: &[Line<'static>],
+    exclusions: &[Vec<Range<u16>>],
+) -> Vec<Vec<SourceSpan>> {
+    let rendered = rendered_graphemes(lines, exclusions);
+    let mut matches = vec![None; source.len()];
+    let mut next_rendered = 0;
+    for (source_index, grapheme) in source.iter().enumerate() {
+        if grapheme.text.chars().all(char::is_whitespace) {
+            continue;
+        }
+        let Some(offset) = rendered[next_rendered..]
+            .iter()
+            .position(|candidate| candidate.text == grapheme.text)
+        else {
+            continue;
+        };
+        let rendered_index = next_rendered + offset;
+        matches[source_index] = Some(rendered_index);
+        next_rendered = rendered_index + 1;
+    }
+
+    let mut line_start = 0;
+    while line_start < source.len() {
+        let line_end = source[line_start..]
+            .iter()
+            .position(|grapheme| grapheme.text == "\n")
+            .map_or(source.len(), |offset| line_start + offset);
+        let first_content = (line_start..line_end).find(|index| {
+            !source[*index].text.chars().all(char::is_whitespace) && matches[*index].is_some()
+        });
+        if let Some(first_content) = first_content {
+            let leading = first_content.saturating_sub(line_start);
+            let first_rendered =
+                matches[first_content].expect("matched content has a rendered cell");
+            if leading <= first_rendered {
+                let candidates = first_rendered - leading..first_rendered;
+                let same_line = candidates
+                    .clone()
+                    .all(|index| rendered[index].line == rendered[first_rendered].line);
+                let whitespace = candidates
+                    .clone()
+                    .all(|index| rendered[index].text.chars().all(char::is_whitespace));
+                if same_line && whitespace {
+                    for (source_index, rendered_index) in
+                        (line_start..first_content).zip(candidates)
+                    {
+                        matches[source_index] = Some(rendered_index);
+                    }
+                }
+            }
+        }
+        line_start = line_end.saturating_add(1);
+    }
+
+    for source_index in 1..source.len().saturating_sub(1) {
+        if !source[source_index].text.chars().all(char::is_whitespace) {
+            continue;
+        }
+        let Some(previous) = matches[..source_index].iter().rposition(Option::is_some) else {
+            continue;
+        };
+        let Some(next_offset) = matches[source_index + 1..].iter().position(Option::is_some) else {
+            continue;
+        };
+        let next = source_index + 1 + next_offset;
+        let (Some(previous_rendered), Some(next_rendered)) = (matches[previous], matches[next])
+        else {
+            continue;
+        };
+        if next_rendered == previous_rendered + 2
+            && rendered[previous_rendered + 1]
+                .text
+                .chars()
+                .all(char::is_whitespace)
+        {
+            matches[source_index] = Some(previous_rendered + 1);
+        }
+    }
+
+    let mut selections = vec![Vec::new(); lines.len()];
+    for (grapheme, rendered_index) in source.iter().zip(matches) {
+        let Some(rendered) = rendered_index.and_then(|index| rendered.get(index)) else {
+            continue;
+        };
+        selections[rendered.line].push(SourceSpan {
+            columns: rendered.column..rendered.column.saturating_add(rendered.width),
+            source: grapheme.source.clone(),
+        });
+    }
+    selections
+}
+
+fn rendered_graphemes(
+    lines: &[Line<'static>],
+    exclusions: &[Vec<Range<u16>>],
+) -> Vec<RenderedGrapheme> {
+    let mut rendered = Vec::new();
+    for (line_index, line) in lines.iter().enumerate() {
+        let mut column = 0_u16;
+        for span in &line.spans {
+            for text in span.content.graphemes(true) {
+                let width = u16::try_from(UnicodeWidthStr::width(text)).unwrap_or(u16::MAX);
+                let excluded = exclusions
+                    .get(line_index)
+                    .is_some_and(|ranges| ranges.iter().any(|range| range.contains(&column)));
+                if width > 0 && !excluded {
+                    rendered.push(RenderedGrapheme {
+                        line: line_index,
+                        column,
+                        text: text.to_owned(),
+                        width,
+                    });
+                }
+                column = column.saturating_add(width);
+            }
+        }
+    }
+    rendered
 }
 
 fn is_diff_language(language: &str) -> bool {
@@ -1056,6 +1347,31 @@ mod tests {
             .expect("Rust keywords should be syntax-highlighted separately");
         assert_ne!(keyword.style.fg, Some(Theme::default().code_text()));
         assert!(lines[1].spans.iter().all(|span| span.style.bg.is_none()));
+    }
+
+    #[test]
+    fn code_selection_excludes_language_labels_and_borders() {
+        let markdown = "```rust\nrust\n│ value\n```";
+        let layout = render(markdown, 32, &Theme::default());
+        let code_start = markdown.find("\nrust\n").unwrap() + 1;
+        let pipe = markdown.find('│').unwrap();
+
+        assert!(layout.selections[0].is_empty());
+        assert!(
+            layout.selections[1].iter().any(|span| {
+                span.columns == (2..3) && span.source == (code_start..code_start + 1)
+            })
+        );
+        assert!(
+            layout.selections[2]
+                .iter()
+                .any(|span| span.columns == (2..3) && span.source == (pipe..pipe + '│'.len_utf8()))
+        );
+        assert!(
+            layout.selections[2]
+                .iter()
+                .all(|span| !span.columns.contains(&0))
+        );
     }
 
     #[test]

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -7,7 +7,10 @@ mod markdown;
 mod message;
 mod tool;
 
-use super::node::{Component, ComponentUpdate, RenderRequest};
+use super::{
+    node::{Component, ComponentUpdate, RenderRequest},
+    selection::{TextRange, TextSpan},
+};
 use crate::{
     app::config::ReasoningEffort,
     core::extensions::subagents::{AgentMessageUpdate, MessageSender},
@@ -24,13 +27,15 @@ use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, 
 use empty::EmptyLogo;
 use ratatui::{
     Frame,
-    layout::Rect,
+    buffer::Buffer,
+    layout::{Position, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Clear, Widget},
 };
 use std::{
     collections::{HashMap, hash_map::Entry},
+    ops::Range,
     sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -73,7 +78,9 @@ pub(crate) struct Transcript {
     selected_expandable: Option<EntryId>,
     expandable_hits: Vec<ExpandableHitRegion>,
     link_hits: Vec<LinkHitRegion>,
+    selection_rows: Vec<(u16, Anchor)>,
     transcript_y: u16,
+    transcript_x: u16,
     pending_expandable_anchor: Option<PendingExpandableAnchor>,
     empty_logo: EmptyLogo,
     effort: ReasoningEffort,
@@ -87,6 +94,8 @@ struct CachedEntry {
     tool_summary_lines: usize,
     lines: Vec<Line<'static>>,
     links: Vec<Vec<markdown::LinkSpan>>,
+    selections: Vec<Vec<markdown::SourceSpan>>,
+    envelopes: Vec<markdown::SourceEnvelope>,
 }
 
 #[derive(Default)]
@@ -194,7 +203,9 @@ impl Transcript {
             selected_expandable: None,
             expandable_hits: Vec::new(),
             link_hits: Vec::new(),
+            selection_rows: Vec::new(),
             transcript_y: 0,
+            transcript_x: 0,
             pending_expandable_anchor: None,
             empty_logo: EmptyLogo::new(Instant::now()),
             effort,
@@ -449,6 +460,110 @@ impl Transcript {
             .iter()
             .find(|hit| hit.row == mouse.row && (hit.start..hit.end).contains(&mouse.column))
             .map(|hit| Arc::clone(&hit.destination))
+    }
+
+    pub(super) fn selection_span(&self, position: Position) -> Option<TextSpan> {
+        self.selection_span_with_fallback(position, false)
+    }
+
+    pub(super) fn selection_span_nearest(&self, position: Position) -> Option<TextSpan> {
+        self.selection_span_with_fallback(position, true)
+    }
+
+    fn selection_span_with_fallback(
+        &self,
+        position: Position,
+        across_entries: bool,
+    ) -> Option<TextSpan> {
+        let exact = self
+            .selection_rows
+            .iter()
+            .find(|(row, _)| *row == position.y)
+            .map(|(_, anchor)| *anchor);
+        let exact = match exact {
+            Some(exact) => exact,
+            None if across_entries => self
+                .selection_rows
+                .iter()
+                .min_by_key(|(row, _)| row.abs_diff(position.y))
+                .map(|(_, anchor)| *anchor)?,
+            None => return None,
+        };
+        let anchor = if self.cache.selections(exact).is_empty() {
+            if !across_entries {
+                selection_source(self.model.entry(exact.entry)?)?;
+            }
+            self.selection_rows
+                .iter()
+                .filter(|(_, anchor)| {
+                    (across_entries || anchor.entry == exact.entry)
+                        && !self.cache.selections(*anchor).is_empty()
+                })
+                .min_by_key(|(row, _)| row.abs_diff(position.y))
+                .map(|(_, anchor)| *anchor)?
+        } else {
+            exact
+        };
+        let spans = self.cache.selections(anchor);
+        let column = position.x.saturating_sub(self.transcript_x);
+        let source = spans
+            .iter()
+            .find(|span| span.columns.contains(&column))
+            .or_else(|| {
+                spans.iter().min_by_key(|span| {
+                    if column < span.columns.start {
+                        span.columns.start - column
+                    } else {
+                        column.saturating_sub(span.columns.end.saturating_sub(1))
+                    }
+                })
+            })?;
+        Some(TextSpan::new(
+            anchor.entry.index(),
+            source.source.start,
+            source.source.end,
+        ))
+    }
+
+    pub(super) fn selection_text(&self, range: TextRange) -> Option<String> {
+        let (start, end) = range.bounds();
+        let mut fragments = Vec::new();
+        for entry in self.model.entries() {
+            let block = entry.id.index();
+            if block < start.block || block > end.block {
+                continue;
+            }
+            let Some(source) = selection_source(entry) else {
+                continue;
+            };
+            let Some(selected) = range.source_range(block, source.len()) else {
+                continue;
+            };
+            let selected = self.cache.expand_selection(entry.id, selected);
+            if let Some(fragment) = source.get(selected)
+                && !fragment.is_empty()
+            {
+                fragments.push(fragment);
+            }
+        }
+        (!fragments.is_empty()).then(|| fragments.join("\n\n"))
+    }
+
+    pub(super) fn render_selection(&self, buffer: &mut Buffer, range: TextRange) {
+        let selected = Style::reset().fg(Color::Black).bg(Color::Yellow);
+        for (row, anchor) in &self.selection_rows {
+            for span in self.cache.selections(*anchor) {
+                if !range.includes(anchor.entry.index(), &span.source) {
+                    continue;
+                }
+                for column in span.columns.clone() {
+                    let column = self.transcript_x.saturating_add(column);
+                    if let Some(cell) = buffer.cell_mut(Position::new(column, *row)) {
+                        cell.set_style(selected);
+                    }
+                }
+            }
+        }
     }
 
     pub(super) const fn expandables_focused(&self) -> bool {
@@ -986,6 +1101,32 @@ impl LayoutCache {
             .and_then(|cached| cached.links.get(anchor.line))
             .map_or(&[], Vec::as_slice)
     }
+
+    fn selections(&self, anchor: Anchor) -> &[markdown::SourceSpan] {
+        self.entries
+            .get(&anchor.entry)
+            .and_then(|cached| cached.selections.get(anchor.line))
+            .map_or(&[], Vec::as_slice)
+    }
+
+    fn expand_selection(&self, entry: EntryId, mut selected: Range<usize>) -> Range<usize> {
+        let Some(cached) = self.entries.get(&entry) else {
+            return selected;
+        };
+        loop {
+            let previous = selected.clone();
+            for envelope in &cached.envelopes {
+                if selected.start <= envelope.content.start && selected.end >= envelope.content.end
+                {
+                    selected.start = selected.start.min(envelope.source.start);
+                    selected.end = selected.end.max(envelope.source.end);
+                }
+            }
+            if selected == previous {
+                return selected;
+            }
+        }
+    }
 }
 
 impl CachedEntry {
@@ -1011,6 +1152,8 @@ impl CachedEntry {
             tool_summary_lines,
             lines: layout.lines,
             links: layout.links,
+            selections: layout.selections,
+            envelopes: layout.envelopes,
         }
     }
 
@@ -1028,6 +1171,10 @@ impl CachedEntry {
         let summary_len = summary.len();
         self.lines.splice(0..self.tool_summary_lines, summary);
         self.links.splice(
+            0..self.tool_summary_lines,
+            std::iter::repeat_with(Vec::new).take(summary_len),
+        );
+        self.selections.splice(
             0..self.tool_summary_lines,
             std::iter::repeat_with(Vec::new).take(summary_len),
         );
@@ -1063,8 +1210,10 @@ impl Component for Transcript {
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
         self.viewport_height = area.height;
         self.transcript_y = area.y;
+        self.transcript_x = area.x;
         self.expandable_hits.clear();
         self.link_hits.clear();
+        self.selection_rows.clear();
         Clear.render(area, frame.buffer_mut());
         if self.is_empty() {
             self.empty_logo.render(frame, area, theme, self.effort);
@@ -1086,6 +1235,7 @@ impl Component for Transcript {
                     start: area.x.saturating_add(link.start),
                     end: area.x.saturating_add(link.end).min(area.right()),
                 }));
+            self.selection_rows.push((y, anchor));
             if anchor.line == 0
                 && let Some(entry) = self.model.entry(anchor.entry)
             {
@@ -1157,7 +1307,7 @@ fn render_entry(
     expanded: bool,
 ) -> markdown::Layout {
     let mut layout = match &entry.kind {
-        EntryKind::User { text, .. } => layout_without_links(render_user(text, width, theme)),
+        EntryKind::User { text, .. } => render_user(text, width, theme),
         EntryKind::Assistant { text, .. } => markdown::render(text, width, theme),
         EntryKind::Reasoning { text } => {
             let mut layout = markdown::render(text, width.saturating_sub(2), theme);
@@ -1256,28 +1406,63 @@ fn render_entry(
     };
     layout.lines.push(Line::default());
     layout.links.push(Vec::new());
+    layout.selections.push(Vec::new());
     layout
+}
+
+fn selection_source(entry: &TranscriptEntry) -> Option<&str> {
+    match &entry.kind {
+        EntryKind::User { text }
+        | EntryKind::Assistant { text, .. }
+        | EntryKind::Reasoning { text } => Some(text),
+        _ => None,
+    }
 }
 
 fn layout_without_links(lines: Vec<Line<'static>>) -> markdown::Layout {
     let links = vec![Vec::new(); lines.len()];
-    markdown::Layout { lines, links }
+    let selections = vec![Vec::new(); lines.len()];
+    markdown::Layout {
+        lines,
+        links,
+        selections,
+        envelopes: Vec::new(),
+    }
 }
 
-fn render_user(text: &str, width: u16, theme: &Theme) -> Vec<Line<'static>> {
+fn render_user(text: &str, width: u16, theme: &Theme) -> markdown::Layout {
     let color = theme.thinking_medium();
     let content_width = width.saturating_sub(2).max(1);
     let mut lines = Vec::new();
+    let mut selections = Vec::new();
+    let mut source_offset = 0;
     for logical in text.split('\n') {
-        for line in markdown::wrap_plain(logical, content_width, Style::default().fg(color)) {
+        let wrapped = markdown::wrap_plain(logical, content_width, Style::default().fg(color));
+        let wrapped_selections = markdown::plain_selection_spans(logical, &wrapped);
+        for (line, mut line_selections) in wrapped.into_iter().zip(wrapped_selections) {
+            for selection in &mut line_selections {
+                selection.columns.start = selection.columns.start.saturating_add(2);
+                selection.columns.end = selection.columns.end.saturating_add(2);
+                selection.source.start = selection.source.start.saturating_add(source_offset);
+                selection.source.end = selection.source.end.saturating_add(source_offset);
+            }
             lines.push(Line::from(
                 std::iter::once(Span::styled("┃ ", Style::default().fg(color)))
                     .chain(line.spans)
                     .collect::<Vec<_>>(),
             ));
+            selections.push(line_selections);
         }
+        source_offset = source_offset
+            .saturating_add(logical.len())
+            .saturating_add(1);
     }
-    lines
+    markdown::Layout {
+        links: vec![Vec::new(); lines.len()],
+        lines,
+        selections,
+        envelopes: Vec::new(),
+    }
 }
 
 fn line_width(text: &str) -> usize {
@@ -1302,7 +1487,7 @@ mod tests {
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
     use nanocodex::agent::events::{AgentEvent, AgentEventKind};
-    use ratatui::{Terminal, backend::TestBackend, style::Color};
+    use ratatui::{Terminal, backend::TestBackend, layout::Position, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{sync::Arc, time::Duration};
 
@@ -1433,6 +1618,34 @@ mod tests {
         assert_eq!(backend.buffer()[(2, 1)].symbol(), "h");
         assert_eq!(backend.buffer()[(0, 2)].symbol(), "┃");
         assert_eq!(backend.buffer()[(0, 0)].symbol(), " ");
+        assert!(transcript.selection_span(Position::new(0, 0)).is_none());
+        assert!(
+            transcript
+                .selection_span_nearest(Position::new(0, 0))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn active_selection_can_cross_an_unselectable_tool() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(user(1, "before")));
+        shell(&mut transcript, 2, "output");
+        transcript.update(TranscriptEvent::Record(user(4, "after")));
+
+        let backend = render(&mut transcript, 40, 12);
+        let tool_row = (0..backend.buffer().area.height)
+            .find(|&row| {
+                (0..backend.buffer().area.width)
+                    .map(|column| backend.buffer()[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("cargo test")
+            })
+            .expect("tool summary should be visible");
+        let position = Position::new(0, tool_row);
+
+        assert!(transcript.selection_span(position).is_none());
+        assert!(transcript.selection_span_nearest(position).is_some());
     }
 
     #[test]

--- a/src/tui/transcript/entry.rs
+++ b/src/tui/transcript/entry.rs
@@ -11,6 +11,10 @@ impl EntryId {
     pub(super) const fn from_index(index: usize) -> Self {
         Self(index)
     }
+
+    pub(crate) const fn index(self) -> usize {
+        self.0
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Overview

Improves select + copy semantics, allowing copying the raw markdown rather than the rendered markdown as well as scrolling selections.

closes #29 
closes #33 