### PR TITLE
feat(transcript): render code mode workflows

### DIFF
--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -42,6 +42,7 @@ use std::{
 
 const EXPANDABLE_FOCUS_HINTS: [&str; 2] =
     ["↑↓ item · Enter toggle · Esc back", "↑↓ item · Enter · Esc"];
+const NESTED_TOOL_INDENT: u16 = 4;
 
 pub(crate) enum TranscriptEvent {
     Record(Arc<TranscriptRecord>),
@@ -1140,7 +1141,7 @@ impl CachedEntry {
         let layout = render_entry(entry, live_duration_ns, width, theme, expanded);
         let tool_summary_lines = match (&entry.kind, live_duration_ns) {
             (EntryKind::Tool(tool), Some(duration_ns)) => {
-                tool::render_live_summary(tool, duration_ns, width, theme, expanded).len()
+                render_live_tool_summary(entry, tool, duration_ns, width, theme, expanded).len()
             }
             _ => 0,
         };
@@ -1167,7 +1168,7 @@ impl CachedEntry {
             return;
         };
         let summary =
-            tool::render_live_summary(tool, duration_ns, self.width, theme, self.expanded);
+            render_live_tool_summary(entry, tool, duration_ns, self.width, theme, self.expanded);
         let summary_len = summary.len();
         self.lines.splice(0..self.tool_summary_lines, summary);
         self.links.splice(
@@ -1253,14 +1254,20 @@ impl Component for Transcript {
                         if tool.state == crate::tui::transcript::ToolState::Running
                 ) && let Some(spinner) = self.tool_spinner
                 {
-                    frame.buffer_mut().set_string(
-                        area.x.saturating_add(4),
-                        y,
-                        spinner.symbol(),
-                        Style::default()
-                            .fg(theme.accent())
-                            .add_modifier(Modifier::BOLD),
-                    );
+                    let spinner_x = area
+                        .x
+                        .saturating_add(4)
+                        .saturating_add(nested_tool_indent(entry, area.width));
+                    if spinner_x < area.right() {
+                        frame.buffer_mut().set_string(
+                            spinner_x,
+                            y,
+                            spinner.symbol(),
+                            Style::default()
+                                .fg(theme.accent())
+                                .add_modifier(Modifier::BOLD),
+                        );
+                    }
                 }
                 if self.expandables_focused && self.selected_expandable == Some(anchor.entry) {
                     frame.buffer_mut().set_string(
@@ -1323,13 +1330,16 @@ fn render_entry(
             layout
         }
         EntryKind::Tool(tool) => {
-            let lines = if let Some(duration_ns) = live_duration_ns {
-                tool::render_live(tool, duration_ns, width, theme, expanded)
+            let indent = nested_tool_indent(entry, width);
+            let tool_width = width.saturating_sub(indent);
+            let mut lines = if let Some(duration_ns) = live_duration_ns {
+                tool::render_live(tool, duration_ns, tool_width, theme, expanded)
             } else if expanded {
-                tool::render_expanded(tool, width, theme)
+                tool::render_expanded(tool, tool_width, theme)
             } else {
-                tool::render(tool, width, theme)
+                tool::render(tool, tool_width, theme)
             };
+            indent_nested_tool(indent, &mut lines, theme);
             layout_without_links(lines)
         }
         EntryKind::DirectedMessage(thread) => {
@@ -1404,10 +1414,58 @@ fn render_entry(
             Style::default().fg(theme.thinking_xhigh()),
         )),
     };
-    layout.lines.push(Line::default());
-    layout.links.push(Vec::new());
-    layout.selections.push(Vec::new());
+    if entry.trailing_spacer {
+        layout.lines.push(Line::default());
+        layout.links.push(Vec::new());
+        layout.selections.push(Vec::new());
+    }
     layout
+}
+
+fn render_live_tool_summary(
+    entry: &TranscriptEntry,
+    tool: &crate::tui::transcript::ToolEntry,
+    duration_ns: u64,
+    width: u16,
+    theme: &Theme,
+    expanded: bool,
+) -> Vec<Line<'static>> {
+    let indent = nested_tool_indent(entry, width);
+    let tool_width = width.saturating_sub(indent);
+    let mut lines = tool::render_live_summary(tool, duration_ns, tool_width, theme, expanded);
+    indent_nested_tool(indent, &mut lines, theme);
+    lines
+}
+
+const fn nested_tool_indent(entry: &TranscriptEntry, width: u16) -> u16 {
+    if entry.parent.is_some() {
+        let available = width.saturating_sub(1);
+        if available < NESTED_TOOL_INDENT {
+            available
+        } else {
+            NESTED_TOOL_INDENT
+        }
+    } else {
+        0
+    }
+}
+
+fn indent_nested_tool(indent: u16, lines: &mut [Line<'static>], theme: &Theme) {
+    let markers = match indent {
+        0 => return,
+        1 => ("├", "│"),
+        2 => ("├─", "│ "),
+        3 => (" ├─", " │ "),
+        _ => ("  ├─", "  │ "),
+    };
+    if lines.is_empty() {
+        return;
+    }
+    for (index, line) in lines.iter_mut().enumerate() {
+        let marker = if index == 0 { markers.0 } else { markers.1 };
+        line.spans
+            .insert(0, Span::styled(marker, Style::default().fg(theme.border())));
+    }
 }
 
 fn selection_source(entry: &TranscriptEntry) -> Option<&str> {
@@ -2343,6 +2401,164 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(completed.contains("2.5s"));
+    }
+
+    #[test]
+    fn single_code_workflow_child_renders_as_a_standalone_expandable_tool() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            1,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "arguments": "await tools.exec_command({cmd: 'cargo test'})",
+            }),
+        )));
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            2,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "arguments": {"cmd": "cargo test"},
+            }),
+        )));
+
+        let backend = render(&mut transcript, 80, 5);
+        let rows = backend
+            .buffer()
+            .content()
+            .chunks(80)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>();
+        let running = rows.join("");
+        assert!(!running.contains("Batch"));
+        assert!(running.contains("Shell"));
+        let child_row = rows.iter().position(|row| row.contains("Shell")).unwrap();
+        assert!(rows[child_row + 1].trim().is_empty());
+
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            3,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "status": "completed",
+                "duration_ns": 10_u64,
+                "result": {"output": "ok", "exit_code": 0},
+                "metadata": null,
+            }),
+        )));
+        let completed = render(&mut transcript, 80, 5)
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(completed.contains("▶ ✓ Shell"));
+        assert!(!completed.contains("├─"));
+        assert_eq!(transcript.model.entries().len(), 2);
+
+        transcript.focus_expandables();
+        transcript.update(TranscriptEvent::Expandable(ExpandableCommand::Toggle));
+        let expanded = render(&mut transcript, 80, 8)
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(expanded.contains("ok"));
+    }
+
+    #[test]
+    fn code_workflow_promotes_a_standalone_tool_when_the_second_child_arrives() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            1,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "arguments": "await tools.exec_command({cmd: 'cargo test'})",
+            }),
+        )));
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            2,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "arguments": {"cmd": "cargo test"},
+            }),
+        )));
+
+        let single = render(&mut transcript, 80, 5)
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(single.contains("Shell"));
+        assert!(!single.contains("Batch"));
+        assert!(!single.contains("├─"));
+
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            3,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-2",
+                "tool": "memory",
+                "arguments": {"operation": "scan", "query": "test"},
+            }),
+        )));
+
+        let backend = render(&mut transcript, 80, 8);
+        let rows = backend
+            .buffer()
+            .content()
+            .chunks(80)
+            .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>();
+        let batch = rows.join("");
+        assert!(batch.contains("Batch"));
+        assert_eq!(batch.matches("├─").count(), 2);
+        let batch_row = rows.iter().position(|row| row.contains("Batch")).unwrap();
+        assert!(rows[batch_row + 1].contains("├─"));
+        assert!(rows[batch_row + 2].contains("├─"));
+        assert!(rows[batch_row + 3].trim().is_empty());
+    }
+
+    #[test]
+    fn code_workflow_children_remain_visible_at_narrow_widths() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            1,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "arguments": "await tools.exec_command({cmd: 'pwd'})",
+            }),
+        )));
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            2,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "arguments": {"cmd": "pwd"},
+            }),
+        )));
+        let child = transcript.model.entries()[1].clone();
+
+        for width in 1..=8 {
+            let lines = transcript.cache.layout(&child, width, &Theme::default());
+            assert!(!lines.is_empty());
+            assert!(lines[0].width() > 0);
+            assert!(lines.iter().all(|line| line.width() <= usize::from(width)));
+        }
     }
 
     #[test]

--- a/src/tui/components/transcript/tool.rs
+++ b/src/tui/components/transcript/tool.rs
@@ -439,6 +439,7 @@ mod tests {
             result: None,
             metadata: None,
             substeps: Vec::new(),
+            child_count: 0,
         }
     }
 
@@ -467,6 +468,20 @@ mod tests {
             .find(|span| span.content == "✓ ")
             .expect("successful tool should render a checkmark");
         assert_eq!(checkmark.style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn code_workflow_uses_the_compact_workflow_label() {
+        let mut workflow = tool(
+            "exec",
+            json!("await tools.exec_command({cmd: \"cargo test\"})"),
+        );
+        workflow.child_count = 2;
+
+        let lines = render(&workflow, 80, &Theme::default());
+
+        assert_eq!(lines[0].to_string(), "  ▶ ✓ Batch  2 tools · 1.2s");
+        assert!(lines.iter().all(|line| line.width() <= 80));
     }
 
     #[test]

--- a/src/tui/components/transcript/tool/code.rs
+++ b/src/tui/components/transcript/tool/code.rs
@@ -18,12 +18,18 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         .as_ref()
         .and_then(Value::as_array)
         .map_or(0, Vec::len);
-    let subject = if emitted == 1 {
+    let child_count = tool.child_count;
+    let subject = if child_count == 1 {
+        "1 tool".to_owned()
+    } else if child_count > 1 {
+        format!("{child_count} tools")
+    } else if emitted == 1 {
         "1 emitted item".to_owned()
     } else {
         format!("{emitted} emitted items")
     };
-    let presentation = Presentation::new("Code", subject);
+    let title = if child_count == 0 { "Code" } else { "Batch" };
+    let presentation = Presentation::new(title, subject);
     if !expanded {
         return presentation;
     }

--- a/src/tui/components/transcript/tool/memory.rs
+++ b/src/tui/components/transcript/tool/memory.rs
@@ -465,6 +465,7 @@ mod tests {
             result,
             metadata: None,
             substeps: Vec::new(),
+            child_count: 0,
         }
     }
 

--- a/src/tui/components/transcript/tool/send_message.rs
+++ b/src/tui/components/transcript/tool/send_message.rs
@@ -106,6 +106,7 @@ mod tests {
             })),
             metadata: None,
             substeps: Vec::new(),
+            child_count: 0,
         };
 
         let collapsed = present(&tool, 80, &Theme::default(), false);

--- a/src/tui/transcript/entry.rs
+++ b/src/tui/transcript/entry.rs
@@ -37,6 +37,8 @@ pub(crate) struct TranscriptEntry {
     pub(crate) revision: u64,
     pub(crate) kind: EntryKind,
     pub(crate) hidden: bool,
+    pub(crate) parent: Option<EntryId>,
+    pub(crate) trailing_spacer: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -102,6 +104,7 @@ pub(crate) struct ToolEntry {
     pub(crate) result: Option<Value>,
     pub(crate) metadata: Option<Value>,
     pub(crate) substeps: Vec<String>,
+    pub(crate) child_count: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -49,6 +49,8 @@ pub(crate) struct TranscriptModel {
     reasoning: HashMap<u32, EntryId>,
     tools: HashMap<String, EntryId>,
     shell_sessions: HashMap<i64, EntryId>,
+    shell_followups: HashMap<String, EntryId>,
+    code_children: HashMap<EntryId, Vec<EntryId>>,
     local_shells: HashMap<ShellId, EntryId>,
     message_threads: HashMap<ThreadId, EntryId>,
     message_order: VecDeque<ThreadId>,
@@ -326,6 +328,7 @@ impl TranscriptModel {
             result: None,
             metadata: None,
             substeps: Vec::new(),
+            child_count: 0,
         }));
         self.local_shells.insert(payload.id, id);
         self.running_tools.insert(id);
@@ -528,37 +531,42 @@ impl TranscriptModel {
             tool,
             arguments,
         } = record.decode_payload::<ToolCallPayload>()?;
+        let parent = self.code_parent(&call_id);
         if tool == "write_stdin"
             && let Some(session_id) = arguments.get("session_id").and_then(Value::as_i64)
             && let Some(id) = self.shell_sessions.get(&session_id).copied()
         {
-            let substep = arguments
-                .get("chars")
-                .and_then(Value::as_str)
-                .filter(|chars| !chars.is_empty())
-                .map_or_else(
-                    || "polled process".to_owned(),
-                    |chars| format!("sent {chars:?}"),
-                );
-            self.update(id, |kind| {
-                if let EntryKind::Tool(tool) = kind {
-                    tool.state = ToolState::Running;
-                    tool.substeps.push(substep);
-                }
-            });
-            self.tools.insert(call_id, id);
-            self.running_tools.insert(id);
-            self.transient = Some(TransientStatus::Tool("Shell".to_owned()));
-            return Ok(true);
+            if parent.is_some() {
+                self.shell_followups.insert(call_id.clone(), id);
+            } else {
+                let substep = arguments
+                    .get("chars")
+                    .and_then(Value::as_str)
+                    .filter(|chars| !chars.is_empty())
+                    .map_or_else(
+                        || "polled process".to_owned(),
+                        |chars| format!("sent {chars:?}"),
+                    );
+                self.update(id, |kind| {
+                    if let EntryKind::Tool(tool) = kind {
+                        tool.state = ToolState::Running;
+                        tool.substeps.push(substep);
+                    }
+                });
+                self.tools.insert(call_id, id);
+                self.running_tools.insert(id);
+                self.transient = Some(TransientStatus::Tool("Shell".to_owned()));
+                return Ok(true);
+            }
         }
-        let hidden = tool == "wait";
+        let displayed_parent = parent.and_then(|parent| self.next_code_child_parent(parent));
+        let hidden = tool == "wait" && parent.is_none();
         let transient = if hidden {
             TransientStatus::WaitingForBackgroundWork
         } else {
-            self.hide_exec_parent(&call_id);
             TransientStatus::Tool(humanize_tool(&tool))
         };
-        let id = self.push_with_visibility(
+        let id = self.push_with_parent(
             EntryKind::Tool(ToolEntry {
                 name: tool,
                 arguments,
@@ -568,9 +576,14 @@ impl TranscriptModel {
                 result: None,
                 metadata: None,
                 substeps: Vec::new(),
+                child_count: 0,
             }),
             hidden,
+            displayed_parent,
         );
+        if let Some(parent) = parent {
+            self.register_code_child(parent, id);
+        }
         self.tools.insert(call_id, id);
         self.running_tools.insert(id);
         self.transient = Some(transient);
@@ -579,9 +592,16 @@ impl TranscriptModel {
 
     fn tool_result(&mut self, record: &TranscriptRecord) -> Result<bool, serde_json::Error> {
         let payload = record.decode_payload::<ToolResultPayload>()?;
+        let resumed_shell = self.shell_followups.remove(&payload.call_id);
         let shell_followup = payload.tool == "write_stdin";
         let result = normalize_result(payload.result);
+        let resumed_result = resumed_shell.map(|_| result.clone());
         let state = tool_result_state(&payload.tool, &payload.status, &result);
+        let entry_state = if resumed_shell.is_some() && state == ToolState::Running {
+            ToolState::Succeeded
+        } else {
+            state
+        };
         let shell_session = (payload.tool == "exec_command")
             .then(|| tool_session_id(&result))
             .flatten();
@@ -590,22 +610,33 @@ impl TranscriptModel {
             .get(&payload.call_id)
             .copied()
             .unwrap_or_else(|| {
-                let id = self.push(EntryKind::Tool(ToolEntry {
-                    name: payload.tool.clone(),
-                    arguments: Value::Null,
-                    started_at_unix_ms: record.recorded_at_unix_ms(),
-                    state: ToolState::Running,
-                    duration_ns: None,
-                    result: None,
-                    metadata: None,
-                    substeps: Vec::new(),
-                }));
+                let parent = self.code_parent(&payload.call_id);
+                let displayed_parent =
+                    parent.and_then(|parent| self.next_code_child_parent(parent));
+                let id = self.push_with_parent(
+                    EntryKind::Tool(ToolEntry {
+                        name: payload.tool.clone(),
+                        arguments: Value::Null,
+                        started_at_unix_ms: record.recorded_at_unix_ms(),
+                        state: ToolState::Running,
+                        duration_ns: None,
+                        result: None,
+                        metadata: None,
+                        substeps: Vec::new(),
+                        child_count: 0,
+                    }),
+                    false,
+                    displayed_parent,
+                );
+                if let Some(parent) = parent {
+                    self.register_code_child(parent, id);
+                }
                 self.tools.insert(payload.call_id.clone(), id);
                 id
             });
         self.update(id, |kind| {
             if let EntryKind::Tool(tool) = kind {
-                tool.state = state;
+                tool.state = entry_state;
                 tool.duration_ns = Some(if shell_followup {
                     elapsed_nanoseconds(tool.started_at_unix_ms, record.recorded_at_unix_ms())
                         .max(payload.duration_ns)
@@ -618,18 +649,32 @@ impl TranscriptModel {
                     result
                 });
                 tool.metadata = payload.metadata;
-                if tool.name == "wait" && state == ToolState::Succeeded {
-                    // Successful wait wrappers do not add historical noise.
-                }
             }
         });
+        if let Some(shell) = resumed_shell {
+            let resumed_result = resumed_result.expect("resumed shell result was retained");
+            self.update(shell, |kind| {
+                if let EntryKind::Tool(tool) = kind {
+                    tool.state = state;
+                    tool.duration_ns = Some(
+                        elapsed_nanoseconds(tool.started_at_unix_ms, record.recorded_at_unix_ms())
+                            .max(payload.duration_ns),
+                    );
+                    tool.result = Some(merge_shell_result(tool.result.take(), resumed_result));
+                }
+            });
+            if state != ToolState::Running {
+                self.shell_sessions.retain(|_, entry| *entry != shell);
+                self.running_tools.remove(&shell);
+            }
+        }
         if payload.tool == "wait"
             && state == ToolState::Failed
             && let Some(index) = self.index_of(id)
         {
             self.entries[index].hidden = false;
         }
-        if state == ToolState::Running {
+        if entry_state == ToolState::Running {
             if let Some(session_id) = shell_session {
                 self.shell_sessions.insert(session_id, id);
             }
@@ -794,26 +839,6 @@ impl TranscriptModel {
         self.push(EntryKind::ContextCompactionFailed { message });
     }
 
-    fn hide_exec_parent(&mut self, call_id: &str) {
-        let parent = call_id
-            .match_indices('/')
-            .rev()
-            .find_map(|(separator, _)| self.tools.get(&call_id[..separator]).copied());
-        let Some(parent) = parent else {
-            return;
-        };
-        let Some(index) = self.index_of(parent) else {
-            return;
-        };
-        let EntryKind::Tool(tool) = &self.entries[index].kind else {
-            return;
-        };
-        if tool.name == "exec" {
-            self.entries[index].hidden = true;
-            self.entries[index].revision = self.entries[index].revision.saturating_add(1);
-        }
-    }
-
     fn projection_error(
         &mut self,
         record: &TranscriptRecord,
@@ -844,6 +869,18 @@ impl TranscriptModel {
     }
 
     fn push_with_visibility(&mut self, kind: EntryKind, hidden: bool) -> EntryId {
+        self.push_with_parent(kind, hidden, None)
+    }
+
+    fn push_with_parent(
+        &mut self,
+        kind: EntryKind,
+        hidden: bool,
+        parent: Option<EntryId>,
+    ) -> EntryId {
+        if let Some(parent) = parent {
+            self.join_workflow(parent);
+        }
         let id = EntryId::from_index(self.next_entry_id);
         self.next_entry_id = self.next_entry_id.saturating_add(1);
         self.entry_indices.insert(id, self.entries.len());
@@ -852,8 +889,70 @@ impl TranscriptModel {
             revision: 1,
             kind,
             hidden,
+            parent,
+            trailing_spacer: true,
         });
         id
+    }
+
+    fn join_workflow(&mut self, parent: EntryId) {
+        let Some(previous) = self.entries.iter_mut().rev().find(|entry| !entry.hidden) else {
+            return;
+        };
+        if previous.id != parent && previous.parent != Some(parent) {
+            return;
+        }
+        previous.trailing_spacer = false;
+        previous.revision = previous.revision.saturating_add(1);
+    }
+
+    fn code_parent(&self, call_id: &str) -> Option<EntryId> {
+        let (parent_call_id, child) = call_id.rsplit_once("/code-")?;
+        child.parse::<u64>().ok()?;
+        let parent = self.tools.get(parent_call_id).copied()?;
+        let entry = self.entry(parent)?;
+        matches!(&entry.kind, EntryKind::Tool(tool) if tool.name == "exec").then_some(parent)
+    }
+
+    fn next_code_child_parent(&self, parent: EntryId) -> Option<EntryId> {
+        self.code_children
+            .get(&parent)
+            .is_some_and(|children| !children.is_empty())
+            .then_some(parent)
+    }
+
+    fn register_code_child(&mut self, parent: EntryId, child: EntryId) {
+        self.update(parent, |kind| {
+            if let EntryKind::Tool(tool) = kind {
+                tool.child_count = tool.child_count.saturating_add(1);
+            }
+        });
+        let children = self.code_children.entry(parent).or_default();
+        children.push(child);
+        let child_count = children.len();
+        let children = children.clone();
+
+        if child_count == 1 {
+            let index = self.index_of(parent).expect("code parent is retained");
+            self.entries[index].hidden = true;
+            self.entries[index].revision = self.entries[index].revision.saturating_add(1);
+            return;
+        }
+        if child_count > 2 {
+            return;
+        }
+
+        let parent_index = self.index_of(parent).expect("code parent is retained");
+        self.entries[parent_index].hidden = false;
+        self.entries[parent_index].trailing_spacer = false;
+        self.entries[parent_index].revision = self.entries[parent_index].revision.saturating_add(1);
+        for (index, child) in children.iter().enumerate() {
+            let child_index = self.index_of(*child).expect("code child is retained");
+            self.entries[child_index].parent = Some(parent);
+            self.entries[child_index].trailing_spacer = index + 1 == children.len();
+            self.entries[child_index].revision =
+                self.entries[child_index].revision.saturating_add(1);
+        }
     }
 
     fn trim_message_history(&mut self) -> Option<EntryId> {
@@ -1804,6 +1903,118 @@ mod tests {
     }
 
     #[test]
+    fn code_mode_shell_followups_remain_visible_workflow_children() {
+        let mut model = TranscriptModel::default();
+        model.apply(&agent_at(
+            1_000,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "arguments": "await tools.exec_command({cmd: 'cargo test'})",
+            }),
+        ));
+        model.apply(&agent_at(
+            2_000,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "arguments": {"cmd": "cargo test"},
+            }),
+        ));
+        model.apply(&agent_at(
+            3_000,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "status": "completed",
+                "duration_ns": 1_u64,
+                "result": {"output": "running", "session_id": 7},
+                "metadata": null,
+            }),
+        ));
+
+        model.apply(&agent_at(
+            4_000,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-2",
+                "tool": "write_stdin",
+                "arguments": {"session_id": 7},
+            }),
+        ));
+
+        assert_eq!(model.entries().len(), 3);
+        assert_eq!(model.entries()[2].parent, Some(model.entries()[0].id));
+        assert!(matches!(
+            &model.entries()[2].kind,
+            EntryKind::Tool(tool)
+                if tool.name == "write_stdin" && tool.state == ToolState::Running
+        ));
+
+        model.apply(&agent_at(
+            5_000,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow/code-2",
+                "tool": "write_stdin",
+                "status": "completed",
+                "duration_ns": 2_u64,
+                "result": {"output": " still", "session_id": 7},
+                "metadata": null,
+            }),
+        ));
+
+        assert!(matches!(
+            &model.entries()[1].kind,
+            EntryKind::Tool(tool) if tool.state == ToolState::Running
+        ));
+        assert!(matches!(
+            &model.entries()[2].kind,
+            EntryKind::Tool(tool) if tool.state == ToolState::Succeeded
+        ));
+
+        model.apply(&agent_at(
+            6_000,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-3",
+                "tool": "write_stdin",
+                "arguments": {"session_id": 7},
+            }),
+        ));
+        model.apply(&agent_at(
+            7_000,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow/code-3",
+                "tool": "write_stdin",
+                "status": "completed",
+                "duration_ns": 2_u64,
+                "result": {"output": " done", "exit_code": 0},
+                "metadata": null,
+            }),
+        ));
+
+        for entry in &model.entries()[1..] {
+            assert!(matches!(
+                &entry.kind,
+                EntryKind::Tool(tool) if tool.state == ToolState::Succeeded
+            ));
+        }
+        assert!(model.shell_sessions.is_empty());
+        let EntryKind::Tool(shell) = &model.entries()[1].kind else {
+            panic!("original shell should remain a tool entry");
+        };
+        assert_eq!(
+            shell.result.as_ref().unwrap()["output"],
+            "running still done"
+        );
+    }
+
+    #[test]
     fn killed_shell_result_resolves_as_failed() {
         let mut model = TranscriptModel::default();
         model.apply(&agent(
@@ -1856,5 +2067,172 @@ mod tests {
                     && tool.result.as_ref().and_then(|result| result["error"].as_str())
                         == Some("tool call ended without a terminal result")
         ));
+    }
+
+    #[test]
+    fn code_mode_tools_promote_into_nested_chronological_entries() {
+        let mut model = TranscriptModel::default();
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "arguments": "await tools.exec_command({cmd: 'cargo test'})",
+            }),
+        ));
+        let parent_revision = model.entries()[0].revision;
+
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "arguments": {"cmd": "cargo test"},
+            }),
+        ));
+
+        assert_eq!(model.entries().len(), 2);
+        assert!(model.entries()[0].hidden);
+        let EntryKind::Tool(workflow) = &model.entries()[0].kind else {
+            panic!("code workflow should remain a tool entry");
+        };
+        assert_eq!(workflow.child_count, 1);
+        assert!(model.entries()[0].revision > parent_revision);
+        assert!(model.entries()[0].trailing_spacer);
+        assert_eq!(model.entries()[1].parent, None);
+        assert!(model.entries()[1].trailing_spacer);
+        assert!(matches!(
+            &model.entries()[1].kind,
+            EntryKind::Tool(tool)
+                if tool.name == "exec_command" && tool.state == ToolState::Running
+        ));
+
+        model.apply(&agent(
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "exec_command",
+                "status": "completed",
+                "duration_ns": 10,
+                "result": {"output": "ok", "exit_code": 0},
+                "metadata": null,
+            }),
+        ));
+
+        assert!(matches!(
+            &model.entries()[1].kind,
+            EntryKind::Tool(tool)
+                if tool.state == ToolState::Succeeded
+                    && tool.result.as_ref().unwrap()["output"] == "ok"
+        ));
+
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-2",
+                "tool": "memory",
+                "arguments": {"operation": "scan", "query": "test"},
+            }),
+        ));
+
+        let EntryKind::Tool(workflow) = &model.entries()[0].kind else {
+            panic!("code workflow should remain a tool entry");
+        };
+        assert_eq!(workflow.child_count, 2);
+        assert!(!model.entries()[0].hidden);
+        assert!(!model.entries()[0].trailing_spacer);
+        assert_eq!(model.entries()[1].parent, Some(model.entries()[0].id));
+        assert_eq!(model.entries()[2].parent, Some(model.entries()[0].id));
+        assert!(!model.entries()[1].trailing_spacer);
+        assert!(model.entries()[2].trailing_spacer);
+    }
+
+    #[test]
+    fn resumed_single_code_child_keeps_its_workflow_association_and_timeline_position() {
+        let mut model = TranscriptModel::default();
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({"call_id": "workflow", "tool": "exec", "arguments": "text('start')"}),
+        ));
+        let parent = model.entries()[0].id;
+        model.apply(&agent(
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "status": "completed",
+                "duration_ns": 10,
+                "result": [{"text": "Script running"}],
+                "metadata": null,
+            }),
+        ));
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({"call_id": "wait-1", "tool": "wait", "arguments": {"cell_id": "1"}}),
+        ));
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-2",
+                "tool": "apply_patch",
+                "arguments": "*** Begin Patch\n*** End Patch",
+            }),
+        ));
+
+        assert_eq!(model.entries().len(), 3);
+        assert!(model.entries()[1].hidden);
+        assert_eq!(model.entries()[2].parent, None);
+        assert_eq!(model.code_children[&parent], vec![model.entries()[2].id]);
+        assert!(matches!(
+            &model.entries()[2].kind,
+            EntryKind::Tool(tool) if tool.name == "apply_patch"
+        ));
+    }
+
+    #[test]
+    fn only_canonical_code_child_ids_are_nested() {
+        let mut model = TranscriptModel::default();
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({"call_id": "workflow", "tool": "exec", "arguments": "text('start')"}),
+        ));
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/not-code-1",
+                "tool": "memory",
+                "arguments": {"operation": "scan", "query": "test"},
+            }),
+        ));
+
+        assert_eq!(model.entries()[1].parent, None);
+        let EntryKind::Tool(workflow) = &model.entries()[0].kind else {
+            panic!("workflow should remain a tool entry");
+        };
+        assert_eq!(workflow.child_count, 0);
+    }
+
+    #[test]
+    fn code_mode_waits_remain_visible_workflow_children() {
+        let mut model = TranscriptModel::default();
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({"call_id": "workflow", "tool": "exec", "arguments": "await tools.wait({})"}),
+        ));
+        model.apply(&agent(
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/code-1",
+                "tool": "wait",
+                "arguments": {"cell_id": "cell-1"},
+            }),
+        ));
+
+        assert!(!model.entries()[1].hidden);
+        assert_eq!(model.entries()[1].parent, None);
+        assert_eq!(
+            model.code_children[&model.entries()[0].id],
+            vec![model.entries()[1].id]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Render a code-mode workflow with one child as a standalone tool, then promote it in place to a compact `Batch` entry when additional children arrive.
- Keep canonical `/code-N` tools chronological and independently expandable beneath the batch, with consistent indentation, spinner placement, spacing, and narrow-width behavior.
- Preserve visible code-mode waits and shell follow-ups while reconciling resumed shell state and accumulated output with the original entry.

## Testing

- Added transcript model coverage for standalone-to-batch promotion, canonical child IDs, waits, resumed workflows, and shell follow-ups.
- Added rendering coverage for expansion, spacing, spinner placement, and narrow terminals.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>