### PR TITLE
feat(config): allow disabling subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ enabled = false
 [memory]
 enabled = false
 
+[subagents]
+enabled = true
+
 [theme]
 mode = "auto" # auto, light, or dark
 ```
@@ -135,8 +138,9 @@ resolved from the configuration file's directory; relative command-line paths ar
 current directory. Command-line options take precedence over environment variables, which take
 precedence over the file.
 
-New sessions append concise built-in guidance for delegating and orchestrating sub-agents after the
-standard or replacement instructions. Configured `append_instructions` follow that guidance.
+When subagents are enabled, new sessions append concise built-in guidance for delegation and
+orchestration after the standard or replacement instructions. Configured `append_instructions`
+follow that guidance.
 
 Tact loads global instructions from `AGENTS.override.md` or `AGENTS.md` in `CODEX_HOME`, which
 defaults to `~/.codex`, followed by project instructions from the Git repository root through the
@@ -152,6 +156,20 @@ The `/subagents` panel shows the current concurrency limit. Use `-` and `+` ther
 Use **Reload config** in the Actions menu after editing the file. Theme changes apply immediately.
 Most agent settings apply when a session starts or is restored, while effort and fast mode can also
 be changed during a session. Workspace changes require restarting tact.
+
+### Subagents
+
+Subagents are enabled by default. Disable their tools and built-in delegation instructions with:
+
+```toml
+[subagents]
+enabled = false
+```
+
+This setting applies when a session starts or is restored. Reloading the configuration does not
+change the tool surface of an already-running session. `agent.max_subagents` controls concurrency
+when the feature is enabled; setting it does not enable or disable subagents. See the
+[subagent design](docs/subagents.md) for the tool, lifecycle, messaging, and authority contracts.
 
 ### Themes
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -1,0 +1,214 @@
+# Subagents
+
+This document specifies Tact's subagent runtime. The feature lets one agent delegate focused work
+to clean child sessions, coordinate a task tree, and collect typed results without sharing the
+parent's conversation history.
+
+## Product contract
+
+Subagents are enabled by default. They can be disabled explicitly:
+
+```toml
+[subagents]
+enabled = false
+```
+
+Disabling the feature removes all subagent tools and Tact's built-in delegation instructions from
+new and restored sessions. It does not disable memory, skills, MCP servers, or ordinary code-mode
+tools.
+
+The setting applies when an agent runtime is created. Reloading configuration does not mutate the
+tool surface or instructions of an existing runtime. A later new or restored session uses the
+reloaded setting.
+
+`agent.max_subagents` is independent of the enable switch:
+
+```toml
+[agent]
+max_subagents = 32
+```
+
+The limit bounds concurrent active subagent turns when subagents are enabled. It does not enable
+or disable the feature. The default limit is 32. The TUI can change the limit while turns are
+active. Lowering it does not cancel existing work; it prevents new reservations until active work
+falls below the new limit.
+
+## Tool surface
+
+An enabled runtime installs seven tools:
+
+| Tool | Contract |
+| --- | --- |
+| `spawn_agent` | Create a clean child session with a role, focused task, and required output schema. |
+| `submit_result` | Submit the current subagent turn's final JSON value. The value must satisfy its output schema and use the current turn token. |
+| `send_agent_message` | Send a bounded directed message within the current task tree. |
+| `list_agents` | List visible agents, their status, topology, and the caller's messaging and management authority. |
+| `wait_agent` | Wait until any selected agent becomes terminal, with a bounded timeout. |
+| `interrupt_agent` | Stop an agent's active turn and active descendants while keeping their sessions reusable. |
+| `close_agent` | Close an agent and its descendant subtree. Closed agents remain inspectable but cannot be reused. |
+
+The tools are installed for root and child agents. This lets children delegate independent
+subtasks and coordinate with peers. Authorization is enforced by the runtime, not only by prompt
+text.
+
+`submit_result` is usable only by a registered child during an active turn. Root sessions and
+user-created forks are not registered as children. Conversely, memory mutation uses the same
+registry to preserve root-only authority even when subagent tools are disabled. The memory tool is
+therefore installed independently of the subagent tool group.
+
+## Clean sessions and output contracts
+
+`spawn_agent` creates a new Nanocodex session through the calling agent's spawn handle. The child
+does not inherit the caller's conversation. Its initial prompt contains:
+
+- the assigned role and task;
+- its agent ID and place in the task tree;
+- coordination rules for peers and descendants; and
+- the required structured-output contract.
+
+The caller supplies a JSON Schema for the result. Tact compiles that schema before creating the
+child. A successful turn must call `submit_result` exactly once with a value that validates against
+the schema. Tact reports at most four validation errors for an invalid submission so the child can
+correct it.
+
+Each active turn has a monotonically changing token. `submit_result` must provide the current
+token. Steering rotates the token, so output from the superseded turn cannot satisfy the new turn.
+A successful model turn without an accepted submission is a failed subagent turn.
+
+The parent receives structured status and the validated JSON output. Tact does not require a
+free-form prose result and does not parse a child's final answer to infer completion.
+
+## Task tree and authority
+
+Every root session owns an isolated task tree. Agent IDs are local to that tree. Messages, waits,
+interrupts, closes, and directory queries cannot cross root-session boundaries.
+
+The tree records each child's parent. Management authority follows ancestry:
+
+- the root can manage every descendant;
+- an agent can manage its descendants;
+- an agent cannot manage siblings, ancestors, or agents in another root tree; and
+- messaging is broader than management: agents in the same tree may send ordinary coordination
+  messages to one another, subject to routing rules.
+
+Closing and interruption operate on subtrees. Descendants are stopped before their parent. Closing
+is terminal for those child sessions. Interruption preserves the sessions for later messages or
+delegation.
+
+## Directed messages
+
+`send_agent_message` attaches typed routing metadata to a message:
+
+| Field | Values | Meaning |
+| --- | --- | --- |
+| `priority` | `deferred`, `urgent` | Deferred delivery preserves turn boundaries. Urgent delivery steers a running turn at its next safe boundary. |
+| `purpose` | `delegate`, `coordinate`, `finding`, `question`, `reply` | Describes intent. Only `delegate` changes the recipient's assigned task. |
+| `in_reply_to` | message ID | Continues an existing two-party thread. Only the original recipient may reply, and the reply direction must reverse the original message. |
+
+Message bodies are limited to 2 KiB of UTF-8. Empty messages are rejected. The runtime retains at
+most 256 completed message records per root tree while preserving pending records until they reach
+a terminal delivery state.
+
+Deferred delivery starts an idle recipient or queues behind its active turn. A queued sender must
+finish its own turn before the queued message can be delivered. This prevents an agent from waiting
+inside the turn whose completion is needed to release the recipient.
+
+Urgent delivery steers an active turn. Ordinary coordination messages add context but do not
+replace the task. A `delegate` message replaces the recipient's assigned task only when the sender
+has management authority. The recipient keeps its original output schema.
+
+The runtime reports message admission and delivery separately. A message may be started, queued,
+or steered. Failed or interrupted delivery is surfaced explicitly rather than treated as success.
+
+## Waiting and lifecycle
+
+`wait_agent` accepts one or more agent IDs and returns when any selected agent reaches a terminal
+status. Its default timeout is 30 seconds and its maximum timeout is 300 seconds. A timeout returns
+current summaries with `timed_out = true`; it does not cancel the agents.
+
+`interrupt_agent` cancels active model and tool work for the selected subtree and waits for cleanup.
+The sessions remain reusable. `close_agent` additionally closes those sessions and prevents later
+turns. Both operations have a bounded internal stop deadline of 30 seconds.
+
+Tact closes every remaining child before its root runtime shuts down or is replaced. Runtime-owned
+tasks and event forwarders are awaited so child work does not outlive the owning session.
+
+## Capacity and backpressure
+
+Capacity is reserved per active subagent turn, not per child object. A completed, failed,
+interrupted, or closed turn releases its reservation. Idle reusable children consume no turn
+capacity.
+
+The limit is shared by the complete root tree, including grandchildren. Reservations are checked
+atomically. When the limit is reached, spawning or starting another turn fails with an explicit
+capacity error; Tact does not silently queue unbounded model work.
+
+Message delivery also uses bounded command channels. Deferred and urgent messages have distinct
+admission behavior so urgent steering cannot be trapped behind an unlimited deferred queue.
+
+## Runtime and TUI boundary
+
+The registry emits typed updates for agent creation, status changes, events, and message delivery.
+Each update carries a runtime ID and root-session ID. The TUI discards updates from replaced
+runtimes, which prevents stale child events from appearing in a new session that occupies the same
+pane.
+
+The `/subagents` panel renders the current tree, statuses, tasks, messages, and child transcripts.
+It is an observation and control surface for the live runtime. Changing configuration does not
+rewrite the state of an already-running tree.
+
+Subagent registry state is process-local. Restoring a root model session creates a new empty
+subagent runtime; prior child sessions are not resumed as live children. Tool calls already present
+in the root transcript remain ordinary historical transcript records.
+
+## Failure model
+
+The runtime treats these as explicit failures:
+
+- invalid output schemas or submitted values;
+- stale turn tokens and duplicate submissions;
+- cross-tree access, self-messaging, or unauthorized management;
+- invalid reply direction or unknown message IDs;
+- capacity exhaustion and bounded-channel exhaustion;
+- a model turn that ends without `submit_result`;
+- child model, tool, event-forwarding, or shutdown errors; and
+- messages interrupted before terminal delivery.
+
+Failures update the affected agent or message state and are returned through the tool boundary.
+They do not silently produce a successful result. A completed agent remains inspectable and may be
+started again by a later deferred message. A closed agent does not.
+
+## Security and trust boundaries
+
+Subagents run with the same configured model provider, workspace, base tool selection, and process
+authority as the root runtime. They are an execution and coordination boundary, not a security
+sandbox. A clean conversation reduces accidental context sharing but does not restrict filesystem
+or network access granted to their tools.
+
+The shared workspace means concurrent agents can observe one another's file changes. Tact instructs
+agents to treat concurrent changes as owned by their authors, but the filesystem does not enforce
+disjoint write scopes. The root remains responsible for assigning separable tasks, resolving
+overlap, reviewing results, and validating the final state.
+
+Directed message metadata is trusted runtime context. Message bodies remain agent-authored content.
+Delegate authority, reply routing, root scoping, output validation, and lifecycle permissions are
+checked in code.
+
+## Design invariants
+
+The implementation preserves these invariants:
+
+- disabling subagents removes both their tools and their fixed delegation instructions;
+- memory remains independent from the subagent enable switch;
+- every child starts with clean conversation context and a caller-supplied output contract;
+- task-tree scope prevents cross-root access;
+- management follows ancestry while coordination can cross sibling branches;
+- one active turn consumes one shared capacity reservation;
+- successful completion requires a schema-valid `submit_result` with the current turn token;
+- queued delivery cannot require the sender to remain inside the blocking turn;
+- interruption is reusable, closure is terminal, and shutdown closes all descendants; and
+- stale runtime updates cannot attach to a replacement TUI session.
+
+These constraints are deliberately narrower than a general distributed workflow engine. Durable
+job queues, remote workers, cross-process recovery, independent credentials, filesystem isolation,
+and restoration of live child trees are out of scope.

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -89,6 +89,7 @@ pub(crate) struct Config {
     mcp_servers: BTreeMap<String, McpServerConfig>,
     skills: SkillsConfig,
     memory: MemoryConfig,
+    subagents: SubagentsConfig,
     theme: Theme,
     #[serde(skip)]
     reload: ReloadSource,
@@ -168,6 +169,12 @@ pub(crate) struct MemoryConfig {
     enabled: bool,
 }
 
+/// Effective subagent configuration.
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct SubagentsConfig {
+    enabled: bool,
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ConfigOverrides {
     pub(crate) path: Option<PathBuf>,
@@ -206,6 +213,7 @@ struct ConfigFile {
     mcp_servers: BTreeMap<String, McpServerConfigFile>,
     skills: SkillsConfigFile,
     memory: MemoryConfigFile,
+    subagents: SubagentsConfigFile,
     theme: Theme,
 }
 
@@ -220,6 +228,12 @@ struct SkillsConfigFile {
 #[serde(default, deny_unknown_fields)]
 struct MemoryConfigFile {
     enabled: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct SubagentsConfigFile {
+    enabled: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -383,6 +397,9 @@ impl Config {
             memory: MemoryConfig {
                 enabled: file.memory.enabled,
             },
+            subagents: SubagentsConfig {
+                enabled: file.subagents.enabled.unwrap_or(true),
+            },
             theme: file.theme,
             reload,
         })
@@ -445,6 +462,10 @@ impl Config {
 
     pub(crate) const fn memory(&self) -> &MemoryConfig {
         &self.memory
+    }
+
+    pub(crate) const fn subagents(&self) -> &SubagentsConfig {
+        &self.subagents
     }
 
     pub(crate) fn memory_path(&self) -> PathBuf {
@@ -933,6 +954,12 @@ impl MemoryConfig {
     }
 }
 
+impl SubagentsConfig {
+    pub(crate) const fn enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
 impl ReasoningEffort {
     pub(crate) const ALL: [Self; 5] = [Self::Low, Self::Medium, Self::High, Self::Xhigh, Self::Max];
 
@@ -1094,6 +1121,24 @@ mod tests {
     use tempfile::tempdir;
     use zeroize::Zeroize;
 
+    fn load_config(contents: &str) -> crate::app::error::Result<Config> {
+        let directory = tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        fs::write(&config_path, contents).unwrap();
+
+        Config::load_with(
+            ConfigOverrides {
+                path: Some(config_path),
+                ..ConfigOverrides::default()
+            },
+            Environment {
+                codex_home: Some(directory.path().join("codex")),
+                ..Environment::default()
+            },
+            directory.path(),
+        )
+    }
+
     #[test]
     fn missing_default_file_materializes_all_defaults() {
         let directory = tempdir().unwrap();
@@ -1180,6 +1225,33 @@ mod tests {
 
         let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
         assert_eq!(rendered["memory"]["enabled"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn subagents_are_enabled_by_default() {
+        for contents in ["", "[subagents]\n"] {
+            let config = load_config(contents).unwrap();
+
+            assert!(config.subagents().enabled());
+            let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+            assert_eq!(rendered["subagents"]["enabled"].as_bool(), Some(true));
+        }
+    }
+
+    #[test]
+    fn subagents_can_be_disabled_from_the_config_file() {
+        let config = load_config("[subagents]\nenabled = false\n").unwrap();
+
+        assert!(!config.subagents().enabled());
+        let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+        assert_eq!(rendered["subagents"]["enabled"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn unknown_subagent_fields_are_rejected() {
+        let error = load_config("[subagents]\nenabled = true\nlimit = 4\n").unwrap_err();
+
+        assert!(matches!(error, Error::Config(ConfigError::Parse { .. })));
     }
 
     #[test]

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -496,33 +496,36 @@ pub(crate) fn install_tools(
     parent: AgentHandle,
     registry: Arc<Registry>,
     memory: Option<MemoryStore>,
+    subagents_enabled: bool,
 ) -> Result<Tools, ToolsBuildError> {
-    let mut tools = tools
-        .into_builder()
-        .tool(SpawnAgent {
-            parent,
-            registry: Arc::downgrade(&registry),
-        })
-        .tool(SubmitResult {
-            registry: Arc::downgrade(&registry),
-        })
-        .tool(SendAgentMessage {
-            registry: Arc::downgrade(&registry),
-        })
-        .tool(ListAgents {
-            registry: Arc::downgrade(&registry),
-        })
-        .tool(WaitAgent {
-            registry: Arc::downgrade(&registry),
-        })
-        .tool(ChangeAgentLifecycle {
-            registry: Arc::downgrade(&registry),
-            operation: LifecycleOperation::Interrupt,
-        })
-        .tool(ChangeAgentLifecycle {
-            registry: Arc::downgrade(&registry),
-            operation: LifecycleOperation::Close,
-        });
+    let mut tools = tools.into_builder();
+    if subagents_enabled {
+        tools = tools
+            .tool(SpawnAgent {
+                parent,
+                registry: Arc::downgrade(&registry),
+            })
+            .tool(SubmitResult {
+                registry: Arc::downgrade(&registry),
+            })
+            .tool(SendAgentMessage {
+                registry: Arc::downgrade(&registry),
+            })
+            .tool(ListAgents {
+                registry: Arc::downgrade(&registry),
+            })
+            .tool(WaitAgent {
+                registry: Arc::downgrade(&registry),
+            })
+            .tool(ChangeAgentLifecycle {
+                registry: Arc::downgrade(&registry),
+                operation: LifecycleOperation::Interrupt,
+            })
+            .tool(ChangeAgentLifecycle {
+                registry: Arc::downgrade(&registry),
+                operation: LifecycleOperation::Close,
+            });
+    }
     if let Some(store) = memory {
         tools = tools.tool(MemoryTool::new(store, RootAgentGuard::new(&registry)));
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -31,7 +31,7 @@ use std::{
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-const DEFAULT_APPEND_INSTRUCTIONS: &str = concat!(
+const SUBAGENT_INSTRUCTIONS: &str = concat!(
     "For larger tasks, delegate meaningful, separable work to subagents; handle trivial or tightly ",
     "coupled work directly. Use code mode to build multi-agent pipelines: map independent subtasks ",
     "across agents in parallel, await and reduce their results, then dispatch dependent stages. Do ",
@@ -159,6 +159,7 @@ impl ConfiguredAgent {
         }
         let tools = tools.build().map_err(NanocodexError::from)?;
         let memory_enabled = config.memory().enabled();
+        let subagents_enabled = config.subagents().enabled();
         let memory = memory_enabled.then(|| MemoryStore::new(config.memory_path()));
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
@@ -173,6 +174,7 @@ impl ConfiguredAgent {
                     agent,
                     Arc::clone(&subagents),
                     memory.clone(),
+                    subagents_enabled,
                 )
             });
         if let Some(codex_home) = config.codex_home() {
@@ -192,6 +194,7 @@ impl ConfiguredAgent {
             agent_config.append_instructions(),
             config.skills(),
             restored_instructions,
+            subagents_enabled,
             memory_enabled,
         );
         builder = builder.instructions(Arc::clone(&instructions));
@@ -338,6 +341,7 @@ fn session_instructions(
     appended: Option<&str>,
     skills: &SkillsConfig,
     restored: Option<(String, Option<bool>)>,
+    subagents_enabled: bool,
     memory_enabled: bool,
 ) -> SessionInstructions {
     restored.map_or_else(
@@ -348,7 +352,8 @@ fn session_instructions(
                 .map(SkillCatalog::available_in)
                 .unwrap_or_default()
                 .into();
-            let mut instructions = fresh_instructions_with_catalog(custom, appended, &catalog);
+            let mut instructions =
+                fresh_instructions_with_catalog(custom, appended, &catalog, subagents_enabled);
             if memory_enabled {
                 instructions.push_str("\n\n");
                 instructions.push_str(MEMORY_INSTRUCTIONS);
@@ -359,6 +364,8 @@ fn session_instructions(
             }
         },
         |(instructions, catalog_present)| {
+            let instructions = reconcile_memory_instructions(instructions, false);
+            let instructions = reconcile_subagent_instructions(instructions, subagents_enabled);
             let instructions = reconcile_memory_instructions(instructions, memory_enabled);
             let skills = if catalog_present.unwrap_or(true) {
                 SkillCatalog::available_in(&instructions).into()
@@ -401,19 +408,22 @@ fn fresh_instructions(
     skills: &SkillsConfig,
 ) -> String {
     let catalog = SkillCatalog::load(skills);
-    fresh_instructions_with_catalog(custom, appended, &catalog)
+    fresh_instructions_with_catalog(custom, appended, &catalog, true)
 }
 
 fn fresh_instructions_with_catalog(
     custom: Option<&str>,
     appended: Option<&str>,
     catalog: &SkillCatalog,
+    subagents_enabled: bool,
 ) -> String {
     let mut instructions = custom
         .map(str::to_owned)
         .unwrap_or_else(|| ResponsesServiceConfig::default().system_prompt.to_string());
-    instructions.push_str("\n\n");
-    instructions.push_str(DEFAULT_APPEND_INSTRUCTIONS);
+    if subagents_enabled {
+        instructions.push_str("\n\n");
+        instructions.push_str(SUBAGENT_INSTRUCTIONS);
+    }
     if let Some(appended) = appended {
         instructions.push_str("\n\n");
         instructions.push_str(appended);
@@ -423,6 +433,23 @@ fn fresh_instructions_with_catalog(
         .map_or(instructions.clone(), |skill_instructions| {
             format!("{instructions}\n\n{skill_instructions}")
         })
+}
+
+fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> String {
+    let separator_and_instructions = format!("\n\n{SUBAGENT_INSTRUCTIONS}");
+    if enabled {
+        if instructions.contains(&separator_and_instructions) {
+            return instructions;
+        }
+        instructions.push_str(&separator_and_instructions);
+        return instructions;
+    }
+
+    while let Some(start) = instructions.find(&separator_and_instructions) {
+        let end = start.saturating_add(separator_and_instructions.len());
+        instructions.replace_range(start..end, "");
+    }
+    instructions
 }
 
 impl Cancellation {
@@ -438,8 +465,8 @@ impl Cancellation {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfiguredAgent, DEFAULT_APPEND_INSTRUCTIONS, MEMORY_INSTRUCTIONS,
-        MEMORY_REVIEW_CHECKPOINT, fresh_instructions, session_instructions,
+        ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT, SUBAGENT_INSTRUCTIONS,
+        fresh_instructions, session_instructions,
     };
     use crate::{
         app::{
@@ -510,11 +537,11 @@ mod tests {
 
         assert_eq!(
             fresh_instructions(None, None, &disabled),
-            format!("{default}\n\n{DEFAULT_APPEND_INSTRUCTIONS}")
+            format!("{default}\n\n{SUBAGENT_INSTRUCTIONS}")
         );
         assert_eq!(
             fresh_instructions(Some("Custom instructions."), None, &disabled),
-            format!("Custom instructions.\n\n{DEFAULT_APPEND_INSTRUCTIONS}")
+            format!("Custom instructions.\n\n{SUBAGENT_INSTRUCTIONS}")
         );
     }
 
@@ -526,7 +553,7 @@ mod tests {
         let instructions = fresh_instructions(None, Some("Project instructions."), &disabled);
         assert_eq!(
             instructions,
-            format!("{default}\n\n{DEFAULT_APPEND_INSTRUCTIONS}\n\nProject instructions.")
+            format!("{default}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions.")
         );
         assert_eq!(
             fresh_instructions(
@@ -534,7 +561,7 @@ mod tests {
                 Some("Project instructions."),
                 &disabled
             ),
-            format!("Replacement.\n\n{DEFAULT_APPEND_INSTRUCTIONS}\n\nProject instructions.")
+            format!("Replacement.\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions.")
         );
     }
 
@@ -561,7 +588,7 @@ mod tests {
         );
         assert!(!instructions.contains("BODY-SENTINEL"));
 
-        let session = session_instructions(None, None, &enabled, None, false);
+        let session = session_instructions(None, None, &enabled, None, true, false);
         assert_eq!(
             session.skills.as_ref(),
             [Skill::new("review", "Review code carefully.")]
@@ -583,7 +610,7 @@ mod tests {
         let instructions = fresh_instructions(Some("Keep this first."), None, &enabled);
 
         assert!(instructions.starts_with(&format!(
-            "Keep this first.\n\n{DEFAULT_APPEND_INSTRUCTIONS}\n\n## Available local skills"
+            "Keep this first.\n\n{SUBAGENT_INSTRUCTIONS}\n\n## Available local skills"
         )));
         assert!(instructions.contains("Run focused tests."));
         assert!(!instructions.contains("SECRET-BODY"));
@@ -638,6 +665,7 @@ mod tests {
                 &disabled,
                 Some((stored.to_owned(), Some(true))),
                 false,
+                false,
             )
             .text
             .as_ref(),
@@ -649,14 +677,21 @@ mod tests {
             &enabled,
             Some((stored.to_owned(), Some(true))),
             false,
+            false,
         );
         assert_eq!(restored.text.as_ref(), stored);
         assert_eq!(
             restored.skills.as_ref(),
             [Skill::new("old-skill", "The original catalog entry.")]
         );
-        let legacy =
-            session_instructions(None, None, &enabled, Some((stored.to_owned(), None)), false);
+        let legacy = session_instructions(
+            None,
+            None,
+            &enabled,
+            Some((stored.to_owned(), None)),
+            false,
+            false,
+        );
         assert_eq!(legacy.skills, restored.skills);
     }
 
@@ -672,7 +707,7 @@ mod tests {
         );
         let disabled = SkillsConfig::from_roots(false, Vec::new());
 
-        let instructions = session_instructions(Some(custom), None, &disabled, None, false);
+        let instructions = session_instructions(Some(custom), None, &disabled, None, true, false);
 
         assert!(instructions.text.contains("not-discovered"));
         assert!(instructions.skills.is_empty());
@@ -682,6 +717,7 @@ mod tests {
             None,
             &disabled,
             Some((instructions.text.to_string(), Some(false))),
+            true,
             false,
         );
         assert!(restored.skills.is_empty());
@@ -706,6 +742,7 @@ mod tests {
                 &enabled,
                 Some(("Old default.".to_owned(), Some(false))),
                 false,
+                false,
             )
             .text
             .as_ref(),
@@ -718,6 +755,7 @@ mod tests {
                 &enabled,
                 Some(("Old custom.".to_owned(), Some(false))),
                 false,
+                false,
             )
             .text
             .as_ref(),
@@ -728,8 +766,8 @@ mod tests {
     #[test]
     fn memory_instructions_are_conditional_and_never_contain_records() {
         let skills = SkillsConfig::from_roots(false, Vec::new());
-        let disabled = session_instructions(None, None, &skills, None, false);
-        let enabled = session_instructions(None, None, &skills, None, true);
+        let disabled = session_instructions(None, None, &skills, None, true, false);
+        let enabled = session_instructions(None, None, &skills, None, true, true);
 
         assert!(!disabled.text.contains(MEMORY_INSTRUCTIONS));
         assert!(enabled.text.ends_with(MEMORY_INSTRUCTIONS));
@@ -762,6 +800,7 @@ mod tests {
             None,
             &skills,
             Some(("Stored.".to_owned(), Some(false))),
+            false,
             true,
         );
         assert!(restored_enabled.text.ends_with(MEMORY_INSTRUCTIONS));
@@ -771,21 +810,66 @@ mod tests {
             &skills,
             Some((format!("Stored.\n\n{MEMORY_INSTRUCTIONS}"), Some(false))),
             false,
+            false,
         );
         assert_eq!(restored_disabled.text.as_ref(), "Stored.");
     }
 
     #[test]
     fn delegation_instructions_prevent_hosts_from_repeating_delegated_work() {
-        assert!(DEFAULT_APPEND_INSTRUCTIONS.contains("wait for delegated work to finish"));
-        assert!(DEFAULT_APPEND_INSTRUCTIONS.contains("Do not repeat delegated work yourself"));
-        assert!(DEFAULT_APPEND_INSTRUCTIONS.contains("Double-check their results"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("wait for delegated work to finish"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("Do not repeat delegated work yourself"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("Double-check their results"));
+    }
+
+    #[test]
+    fn subagent_instructions_follow_the_config_for_fresh_and_restored_sessions() {
+        let skills = SkillsConfig::from_roots(false, Vec::new());
+        let enabled = session_instructions(None, None, &skills, None, true, false);
+        let disabled = session_instructions(None, None, &skills, None, false, false);
+
+        assert!(enabled.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(!disabled.text.contains(SUBAGENT_INSTRUCTIONS));
+
+        let restored_disabled = session_instructions(
+            None,
+            None,
+            &skills,
+            Some((enabled.text.to_string(), Some(false))),
+            false,
+            false,
+        );
+        assert!(!restored_disabled.text.contains(SUBAGENT_INSTRUCTIONS));
+
+        let duplicated =
+            format!("Stored.\n\n{SUBAGENT_INSTRUCTIONS}\n\nAppendix.\n\n{SUBAGENT_INSTRUCTIONS}");
+        let restored_duplicates = session_instructions(
+            None,
+            None,
+            &skills,
+            Some((duplicated, Some(false))),
+            false,
+            false,
+        );
+        assert!(!restored_duplicates.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(restored_duplicates.text.contains("Appendix."));
+
+        let restored_enabled = session_instructions(
+            None,
+            None,
+            &skills,
+            Some((disabled.text.to_string(), Some(false))),
+            true,
+            true,
+        );
+        assert!(restored_enabled.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(restored_enabled.text.ends_with(MEMORY_INSTRUCTIONS));
     }
 
     #[test]
     fn memory_instructions_require_repeated_scans_and_transcript_review() {
         let skills = SkillsConfig::from_roots(false, Vec::new());
-        let enabled = session_instructions(None, None, &skills, None, true);
+        let enabled = session_instructions(None, None, &skills, None, true, true);
 
         assert!(enabled.text.contains("Use separate, narrow scans"));
         assert!(enabled.text.contains("before each meaningful phase"));


### PR DESCRIPTION
## Summary

- Add a `[subagents]` configuration section with `enabled = true` by default.
- Omit subagent tools and built-in delegation instructions from new and restored sessions when subagents are disabled, while leaving memory tooling independent.
- Document the configuration switch and the subagent runtime contract, including lifecycle, messaging, capacity, authority, restoration, and security boundaries.

## Testing

- Added config coverage for defaults, explicit disabling, TOML rendering, and unknown fields.
- Added instruction coverage for enabled and disabled fresh and restored sessions, historical instruction cleanup, and memory coexistence.

## Stack

Depends on #58.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>