### PR TITLE
chore(release): prepare 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary

- bump the `tact` package version from `0.3.0` to `0.3.1`
- refresh the root package entry in `Cargo.lock`
- leave release notes to the tag-triggered `git-cliff` workflow

## Testing

- `cargo check --all-features --locked`
- `just check-fmt`
- `just clippy`
- `just test` (698 tests)
- `cargo package --locked --allow-dirty`