### PR TITLE
fix(tui): omit separator spaces after soft wraps

### DIFF
--- a/src/tui/components/transcript/markdown.rs
+++ b/src/tui/components/transcript/markdown.rs
@@ -1052,6 +1052,9 @@ fn wrap_visual_line(
     let mut lines = Vec::new();
     let mut start = 0_usize;
     while start < graphemes.len() {
+        if preserve_whitespace && start > 0 && graphemes[start].text == " " {
+            start += 1;
+        }
         if !preserve_whitespace {
             while start < graphemes.len() && graphemes[start].whitespace {
                 start += 1;

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -1711,6 +1711,29 @@ mod tests {
     }
 
     #[test]
+    fn user_soft_wrap_omits_the_separator_space_but_preserves_explicit_indentation() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(user(1, "alpha bravo\n bravo")));
+
+        let backend = render(&mut transcript, 12, 5);
+        let rows = (0..backend.buffer().area.height)
+            .map(|row| {
+                (0..backend.buffer().area.width)
+                    .map(|column| backend.buffer()[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(rows.iter().any(|row| row.starts_with("┃ bravo")));
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.starts_with("┃  bravo"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn active_selection_can_cross_an_unselectable_tool() {
         let mut transcript = Transcript::new();
         transcript.update(TranscriptEvent::Record(user(1, "before")));


### PR DESCRIPTION
## Summary

- omit the separator space consumed at a user-message soft-wrap boundary
- preserve explicit indentation at real line boundaries
- add a regression test covering both behaviors

## Stack

- #66 — prerequisite
- #67 — this PR
- #69 — depends on this PR

## Testing

- `cargo test user_soft_wrap_omits_the_separator_space_but_preserves_explicit_indentation`