### PR TITLE
chore(release): prepare 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary

- bump the Tact crate version from 0.3.1 to 0.3.2
- update the matching package version in Cargo.lock

## Stack

- #66 — prerequisite
- #67 — prerequisite
- #69 — this PR

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --all-features`
- `cargo test --test release_pipeline`