### PR TITLE
fix(config): render every effective config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,20 @@ The configuration file is optional. Tact reads `$TACT_HOME/config.toml`, or
 `~/.tact/config.toml` when `TACT_HOME` is unset. Select another file with `--config PATH` or
 `TACT_CONFIG`.
 
-These commands show which file is selected and the complete effective configuration, including
-defaults:
+Use `config show` to discover every available field and inspect the complete effective
+configuration after file, environment, command-line, and default values have been applied:
 
 ```sh
 tact config path
 tact config show
 ```
 
-A typical configuration looks like this:
+The default effective configuration looks like this (paths depend on your environment):
 
 ```toml
 [auth]
 mode = "auto" # auto, chatgpt, or api-key
-# file = "/path/to/.codex/auth.json"
+file = "/path/to/.codex/auth.json"
 
 [agent]
 workspace = "/path/to/workspace"
@@ -114,14 +114,18 @@ thinking = "medium" # low, medium, high, xhigh, or max
 reasoning_mode = "standard" # standard or pro
 fast_mode = false
 max_subagents = 32
+instructions = ""
+append_instructions = ""
 web_search = true
 image_generation = true
-# instructions = "Replace the standard Nanocodex instructions"
-# append_instructions = "Append after Tact's built-in instructions"
+websocket_url = ""
+api_base_url = ""
+
+[mcp_servers]
 
 [skills]
 enabled = false
-# roots = ["skills", "/path/to/shared-skills"]
+roots = []
 
 [memory]
 enabled = false
@@ -131,6 +135,32 @@ enabled = true
 
 [theme]
 mode = "auto" # auto, light, or dark
+
+[theme.light]
+text = "reset"
+border = "dark-gray"
+muted = "dark-gray"
+accent = "blue"
+code_text = "#262626"
+code_background = "#EEEEEE"
+thinking_low = "dark-gray"
+thinking_medium = "#007878"
+thinking_high = "#9A6700"
+thinking_xhigh = "red"
+thinking_max = "magenta"
+
+[theme.dark]
+text = "reset"
+border = "dark-gray"
+muted = "dark-gray"
+accent = "blue"
+code_text = "#D7D7D7"
+code_background = "#262626"
+thinking_low = "gray"
+thinking_medium = "cyan"
+thinking_high = "yellow"
+thinking_xhigh = "red"
+thinking_max = "magenta"
 ```
 
 The workspace defaults to the directory where tact starts. Relative paths in the configuration are

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -85,7 +85,6 @@ pub(crate) struct Config {
     codex_home: Option<PathBuf>,
     auth: AuthConfig,
     agent: AgentConfig,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     mcp_servers: BTreeMap<String, McpServerConfig>,
     skills: SkillsConfig,
     memory: MemoryConfig,
@@ -144,11 +143,15 @@ pub(crate) struct AgentConfig {
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
     max_subagents: usize,
+    #[serde(serialize_with = "serialize_optional_string")]
     instructions: Option<String>,
+    #[serde(serialize_with = "serialize_optional_string")]
     append_instructions: Option<String>,
     web_search: bool,
     image_generation: bool,
+    #[serde(serialize_with = "serialize_optional_string")]
     websocket_url: Option<String>,
+    #[serde(serialize_with = "serialize_optional_string")]
     api_base_url: Option<String>,
 }
 
@@ -377,10 +380,12 @@ impl Config {
                     .max_subagents
                     .or(file.agent.max_subagents)
                     .unwrap_or(DEFAULT_MAX_SUBAGENTS),
-                instructions: overrides.instructions.or(file.agent.instructions),
-                append_instructions: overrides
-                    .append_instructions
-                    .or(file.agent.append_instructions),
+                instructions: optional_string(overrides.instructions.or(file.agent.instructions)),
+                append_instructions: optional_string(
+                    overrides
+                        .append_instructions
+                        .or(file.agent.append_instructions),
+                ),
                 web_search: overrides
                     .web_search
                     .or(file.agent.web_search)
@@ -389,8 +394,10 @@ impl Config {
                     .image_generation
                     .or(file.agent.image_generation)
                     .unwrap_or(true),
-                websocket_url: overrides.websocket_url.or(file.agent.websocket_url),
-                api_base_url: overrides.api_base_url.or(file.agent.api_base_url),
+                websocket_url: optional_string(
+                    overrides.websocket_url.or(file.agent.websocket_url),
+                ),
+                api_base_url: optional_string(overrides.api_base_url.or(file.agent.api_base_url)),
             },
             mcp_servers,
             skills,
@@ -841,6 +848,20 @@ where
     map.end()
 }
 
+fn serialize_optional_string<S>(
+    value: &Option<String>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(value.as_deref().unwrap_or_default())
+}
+
+fn optional_string(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
 impl ConfigReload {
     pub(crate) fn into_parts(self) -> (Config, bool) {
         (self.config, self.workspace_changed)
@@ -1139,6 +1160,14 @@ mod tests {
         )
     }
 
+    fn assert_table_fields(value: &toml::Value, expected: &[&str]) {
+        let table = value.as_table().expect("expected a TOML table");
+        assert_eq!(table.len(), expected.len());
+        for field in expected {
+            assert!(table.contains_key(*field), "missing `{field}`");
+        }
+    }
+
     #[test]
     fn missing_default_file_materializes_all_defaults() {
         let directory = tempdir().unwrap();
@@ -1166,6 +1195,55 @@ mod tests {
         assert_eq!(config.theme.border(), Color::DarkGray);
 
         let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+        assert_table_fields(
+            &rendered,
+            &[
+                "auth",
+                "agent",
+                "mcp_servers",
+                "skills",
+                "memory",
+                "subagents",
+                "theme",
+            ],
+        );
+        assert_table_fields(&rendered["auth"], &["mode", "file"]);
+        assert_table_fields(
+            &rendered["agent"],
+            &[
+                "workspace",
+                "thinking",
+                "reasoning_mode",
+                "fast_mode",
+                "max_subagents",
+                "instructions",
+                "append_instructions",
+                "web_search",
+                "image_generation",
+                "websocket_url",
+                "api_base_url",
+            ],
+        );
+        assert_table_fields(&rendered["mcp_servers"], &[]);
+        assert_table_fields(&rendered["skills"], &["enabled", "roots"]);
+        assert_table_fields(&rendered["memory"], &["enabled"]);
+        assert_table_fields(&rendered["subagents"], &["enabled"]);
+        assert_table_fields(&rendered["theme"], &["mode", "light", "dark"]);
+        let palette_fields = [
+            "text",
+            "border",
+            "muted",
+            "accent",
+            "code_text",
+            "code_background",
+            "thinking_low",
+            "thinking_medium",
+            "thinking_high",
+            "thinking_xhigh",
+            "thinking_max",
+        ];
+        assert_table_fields(&rendered["theme"]["light"], &palette_fields);
+        assert_table_fields(&rendered["theme"]["dark"], &palette_fields);
         assert_eq!(rendered["auth"]["mode"].as_str(), Some("auto"));
         assert_eq!(
             rendered["auth"]["file"].as_str(),
@@ -1178,8 +1256,26 @@ mod tests {
         assert_eq!(rendered["agent"]["thinking"].as_str(), Some("medium"));
         assert_eq!(rendered["agent"]["fast_mode"].as_bool(), Some(false));
         assert_eq!(rendered["agent"]["max_subagents"].as_integer(), Some(32));
+        for field in [
+            "instructions",
+            "append_instructions",
+            "websocket_url",
+            "api_base_url",
+        ] {
+            assert_eq!(rendered["agent"][field].as_str(), Some(""), "{field}");
+        }
+        assert_eq!(
+            rendered["mcp_servers"].as_table().map(|table| table.len()),
+            Some(0)
+        );
         assert_eq!(rendered["theme"]["mode"].as_str(), Some("auto"));
         assert_eq!(rendered["theme"]["dark"]["accent"].as_str(), Some("blue"));
+
+        let reloaded = load_config(&config.to_toml().unwrap()).unwrap();
+        assert!(reloaded.agent.instructions.is_none());
+        assert!(reloaded.agent.append_instructions.is_none());
+        assert!(reloaded.agent.websocket_url.is_none());
+        assert!(reloaded.agent.api_base_url.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- render every user-facing effective configuration field, including unset optional strings and empty sections
- preserve unset semantics when the rendered TOML is loaded again
- document the complete default effective configuration and how to inspect it

## Testing

- `just test`
- `just check-fmt`
- `cargo check --all-features`

## Stack

- Bottom of stack #72
- Followed by #71