### PR TITLE
feat(tui): add option-backspace word deletion

### DIFF
--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -650,6 +650,9 @@ impl Composer {
             KeyCode::Down => ComposerUpdate::from_change(self.move_down()),
             KeyCode::Home => ComposerUpdate::from_change(self.move_to_visual_edge(false)),
             KeyCode::End => ComposerUpdate::from_change(self.move_to_visual_edge(true)),
+            KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
+                ComposerUpdate::from_change(self.delete_word_before_cursor())
+            }
             KeyCode::Backspace => ComposerUpdate::from_change(self.backspace()),
             KeyCode::Delete => ComposerUpdate::from_change(self.delete()),
             _ => ComposerUpdate::unchanged(),
@@ -775,6 +778,40 @@ impl Composer {
             return false;
         };
         self.remove_range(previous..self.cursor);
+        true
+    }
+
+    fn delete_word_before_cursor(&mut self) -> bool {
+        let mut start = self.cursor;
+        while let Some((index, character)) = self.draft[..start].char_indices().next_back() {
+            if !character.is_whitespace() {
+                break;
+            }
+            start = index;
+        }
+        while let Some((index, character)) = self.draft[..start].char_indices().next_back() {
+            if character.is_whitespace() {
+                break;
+            }
+            start = index;
+        }
+        let end = self.cursor;
+        if let Some(image_start) = self
+            .images
+            .iter()
+            .filter(|image| image.range.start < end && start < image.range.end)
+            .map(|image| image.range.start)
+            .min()
+        {
+            start = image_start;
+        }
+        if start == end {
+            return false;
+        }
+
+        self.images
+            .retain(|image| image.range.end <= start || image.range.start >= end);
+        self.remove_range(start..end);
         true
     }
 
@@ -1759,6 +1796,32 @@ mod tests {
         composer.update(key(KeyCode::Backspace, KeyModifiers::NONE));
 
         assert!(composer.draft().is_empty());
+        assert!(composer.images.is_empty());
+    }
+
+    #[test]
+    fn option_backspace_deletes_the_previous_word() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("one two  ".to_owned());
+
+        let update = composer.update(key(KeyCode::Backspace, KeyModifiers::ALT));
+
+        assert!(update.changed);
+        assert_eq!(composer.draft(), "one ");
+        assert_eq!(composer.cursor(), composer.draft().len());
+    }
+
+    #[test]
+    fn option_backspace_removes_an_image_attachment_with_its_token() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::Terminal(Event::Paste("inspect ".to_owned())));
+        composer.update(ComposerEvent::PasteImage(
+            "data:image/png;base64,removed".to_owned(),
+        ));
+
+        composer.update(key(KeyCode::Backspace, KeyModifiers::ALT));
+
+        assert_eq!(composer.draft(), "inspect ");
         assert!(composer.images.is_empty());
     }
 

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 const FOOTER: [&str; 1] = ["esc close"];
-const BINDINGS: [(&str, &str); 19] = [
+const BINDINGS: [(&str, &str); 20] = [
     ("ctrl+s", "change reasoning effort"),
     ("ctrl+f", "fork session · when available"),
     ("ctrl+g", "edit prompt in $EDITOR"),
@@ -31,6 +31,7 @@ const BINDINGS: [(&str, &str); 19] = [
     ("esc esc", "interrupt the active response"),
     ("enter", "submit prompt"),
     ("shift+enter/ctrl+j", "insert newline"),
+    ("alt/option+backspace", "delete previous word"),
     ("↑/↓", "move cursor · prompt history at edge"),
     ("tab", "focus queue · when present"),
     ("/", "open actions · empty prompt only"),
@@ -73,7 +74,7 @@ impl Component for KeybindingsHelp {
 
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
         let layout =
-            Floating::new("Keyboard shortcuts", 72, 22, &FOOTER).render(frame, area, theme);
+            Floating::new("Keyboard shortcuts", 72, 23, &FOOTER).render(frame, area, theme);
         if layout.body.is_empty() {
             return;
         }
@@ -171,6 +172,8 @@ mod tests {
             "clear input · when composer is focused and nonempty",
             "split closes pane · else exit",
             "shift+enter/ctrl+j",
+            "alt/option+backspace",
+            "delete previous word",
             "prompt history at edge",
             "focus queue · when present",
             "open actions · empty prompt only",


### PR DESCRIPTION
Adds Option/Alt+Backspace support for deleting the previous word in the composer. Includes regression coverage.