### PR TITLE
chore(release): prepare 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
Bumps the Tact package version from 0.3.2 to 0.3.3.

Validation:
- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test` (701 passed)