### PR TITLE
chore(release): prepare 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary

- bump the Tact package version to 0.3.4
- refresh the root package entry in Cargo.lock

## Validation

- just check-fmt
- cargo check --all-features
- just clippy
- just test
- cargo package --locked --allow-dirty