### PR TITLE
feat(transcript): use terminal syntax colors

### DIFF
--- a/src/tui/components/transcript/diff.rs
+++ b/src/tui/components/transcript/diff.rs
@@ -5,15 +5,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
-use std::{path::Path, str::FromStr, sync::OnceLock};
-use syntect::{
-    easy::HighlightLines,
-    highlighting::{
-        Color as SyntectColor, FontStyle, ScopeSelectors, StyleModifier, Theme as SyntaxTheme,
-        ThemeItem, ThemeSettings,
-    },
-    parsing::SyntaxSet,
-};
+use syntect::{easy::HighlightLines, highlighting::Theme as SyntaxTheme, parsing::SyntaxSet};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -23,7 +15,7 @@ pub(super) fn render(source: &str, width: u16, theme: &Theme) -> Vec<Line<'stati
     }
 
     let files = parse(source);
-    let syntax_theme = syntax_theme(theme);
+    let syntax_theme = super::highlight::theme();
     let mut rendered = Vec::new();
     for file in files {
         if !rendered.is_empty() {
@@ -316,8 +308,8 @@ fn render_file(
     }
 
     rendered.push(component_header(&label, width, theme));
-    let assets = highlighting_assets();
-    let syntax = syntax_for_path(&assets.syntaxes, &file.path);
+    let assets = super::highlight::assets();
+    let syntax = super::highlight::syntax_for_path(&assets.syntaxes, &file.path);
     let code_width = width.saturating_sub(body_overhead).max(1);
     for hunk in &file.hunks {
         rendered.push(hunk_divider(&hunk_label(hunk), width, theme));
@@ -329,9 +321,11 @@ fn render_file(
                 &mut old_highlighter,
                 &mut new_highlighter,
                 &assets.syntaxes,
-                theme,
             );
-            for (index, code) in wrap_spans(spans, code_width).into_iter().enumerate() {
+            for (index, code) in super::highlight::wrap(spans, code_width)
+                .into_iter()
+                .enumerate()
+            {
                 rendered.push(component_body(
                     line,
                     code,
@@ -391,7 +385,7 @@ fn render_narrow_file(
             for text in hard_wrap(&line.text, code_width) {
                 rendered.push(Line::from(vec![
                     Span::styled(&marker(line.kind)[..1], marker_style(line.kind, theme)),
-                    Span::styled(text, code_style(theme)),
+                    Span::styled(text, super::highlight::code_style()),
                 ]));
             }
         }
@@ -480,7 +474,10 @@ fn component_body(
         spans.push(Span::styled("↪ ", Style::default().fg(theme.muted())));
     }
     spans.extend(code);
-    spans.push(Span::styled(" ".repeat(padding), code_style(theme)));
+    spans.push(Span::styled(
+        " ".repeat(padding),
+        super::highlight::code_style(),
+    ));
     spans.push(Span::styled(" │", Style::default().fg(theme.border())));
     Line::from(spans)
 }
@@ -518,258 +515,25 @@ fn marker_style(kind: DiffLineKind, theme: &Theme) -> Style {
     Style::default().fg(color).add_modifier(Modifier::BOLD)
 }
 
-fn code_style(theme: &Theme) -> Style {
-    Style::default().fg(theme.code_text())
-}
-
-struct HighlightingAssets {
-    syntaxes: SyntaxSet,
-}
-
-fn highlighting_assets() -> &'static HighlightingAssets {
-    static ASSETS: OnceLock<HighlightingAssets> = OnceLock::new();
-    ASSETS.get_or_init(|| HighlightingAssets {
-        syntaxes: SyntaxSet::load_defaults_newlines(),
-    })
-}
-
-fn syntax_theme(theme: &Theme) -> SyntaxTheme {
-    SyntaxTheme {
-        name: Some("tact".to_owned()),
-        settings: ThemeSettings {
-            foreground: Some(syntect_color(theme.code_text())),
-            background: Some(syntect_color(theme.code_background())),
-            accent: Some(syntect_color(theme.accent())),
-            ..ThemeSettings::default()
-        },
-        scopes: vec![
-            syntax_rule("comment", theme.muted(), Some(FontStyle::ITALIC)),
-            syntax_rule("string", theme.thinking_medium(), None),
-            syntax_rule(
-                "constant.numeric, constant.language, constant.character",
-                theme.thinking_xhigh(),
-                None,
-            ),
-            syntax_rule("keyword, storage", theme.accent(), Some(FontStyle::BOLD)),
-            syntax_rule(
-                "entity.name.function, support.function",
-                theme.thinking_high(),
-                None,
-            ),
-            syntax_rule(
-                "entity.name.type, entity.name.class, support.type, storage.type",
-                theme.thinking_max(),
-                None,
-            ),
-            syntax_rule(
-                "variable.parameter",
-                theme.thinking_medium(),
-                Some(FontStyle::ITALIC),
-            ),
-            syntax_rule(
-                "invalid",
-                theme.thinking_xhigh(),
-                Some(FontStyle::UNDERLINE),
-            ),
-        ],
-        ..SyntaxTheme::default()
-    }
-}
-
-fn syntax_rule(scope: &str, color: Color, font_style: Option<FontStyle>) -> ThemeItem {
-    ThemeItem {
-        scope: ScopeSelectors::from_str(scope).expect("built-in syntax scopes should be valid"),
-        style: StyleModifier {
-            foreground: Some(syntect_color(color)),
-            background: None,
-            font_style,
-        },
-    }
-}
-
-fn syntect_color(color: Color) -> SyntectColor {
-    let (r, g, b) = terminal_rgb(color);
-    SyntectColor { r, g, b, a: 0xff }
-}
-
-fn terminal_rgb(color: Color) -> (u8, u8, u8) {
-    match color {
-        Color::Reset => (0xd7, 0xd7, 0xd7),
-        Color::Black => (0x00, 0x00, 0x00),
-        Color::Red => (0xcd, 0x31, 0x31),
-        Color::Green => (0x0d, 0xbc, 0x79),
-        Color::Yellow => (0xe5, 0xe5, 0x10),
-        Color::Blue => (0x24, 0x72, 0xc8),
-        Color::Magenta => (0xbc, 0x3f, 0xbc),
-        Color::Cyan => (0x11, 0xa8, 0xcd),
-        Color::Gray => (0xe5, 0xe5, 0xe5),
-        Color::DarkGray => (0x66, 0x66, 0x66),
-        Color::LightRed => (0xf1, 0x4c, 0x4c),
-        Color::LightGreen => (0x23, 0xd1, 0x8b),
-        Color::LightYellow => (0xf5, 0xf5, 0x43),
-        Color::LightBlue => (0x3b, 0x8e, 0xd0),
-        Color::LightMagenta => (0xd6, 0x70, 0xd6),
-        Color::LightCyan => (0x29, 0xb8, 0xdb),
-        Color::White => (0xff, 0xff, 0xff),
-        Color::Rgb(r, g, b) => (r, g, b),
-        Color::Indexed(index) => indexed_rgb(index),
-    }
-}
-
-fn indexed_rgb(index: u8) -> (u8, u8, u8) {
-    const ANSI: [(u8, u8, u8); 16] = [
-        (0x00, 0x00, 0x00),
-        (0x80, 0x00, 0x00),
-        (0x00, 0x80, 0x00),
-        (0x80, 0x80, 0x00),
-        (0x00, 0x00, 0x80),
-        (0x80, 0x00, 0x80),
-        (0x00, 0x80, 0x80),
-        (0xc0, 0xc0, 0xc0),
-        (0x80, 0x80, 0x80),
-        (0xff, 0x00, 0x00),
-        (0x00, 0xff, 0x00),
-        (0xff, 0xff, 0x00),
-        (0x00, 0x00, 0xff),
-        (0xff, 0x00, 0xff),
-        (0x00, 0xff, 0xff),
-        (0xff, 0xff, 0xff),
-    ];
-    if index < 16 {
-        return ANSI[usize::from(index)];
-    }
-    if index >= 232 {
-        let gray = 8_u8.saturating_add(index.saturating_sub(232).saturating_mul(10));
-        return (gray, gray, gray);
-    }
-    let cube = index - 16;
-    let level = |value: u8| if value == 0 { 0 } else { 55 + value * 40 };
-    (level(cube / 36), level((cube % 36) / 6), level(cube % 6))
-}
-
-fn syntax_for_path<'a>(
-    syntaxes: &'a SyntaxSet,
-    path: &str,
-) -> &'a syntect::parsing::SyntaxReference {
-    let path = Path::new(path);
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .and_then(|extension| syntaxes.find_syntax_by_extension(extension))
-        .or_else(|| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .and_then(|name| syntaxes.find_syntax_by_extension(name))
-        })
-        .unwrap_or_else(|| syntaxes.find_syntax_plain_text())
-}
-
 fn highlighted_diff_line(
     line: &DiffLine,
     old: &mut HighlightLines<'_>,
     new: &mut HighlightLines<'_>,
     syntaxes: &SyntaxSet,
-    theme: &Theme,
 ) -> Vec<Span<'static>> {
     match line.kind {
         DiffLineKind::Context => {
-            let highlighted = highlight_line(old, &line.text, syntaxes, theme);
-            let _ = highlight_line(new, &line.text, syntaxes, theme);
+            let highlighted = super::highlight::line(old, &line.text, syntaxes);
+            let _ = super::highlight::line(new, &line.text, syntaxes);
             highlighted
         }
-        DiffLineKind::Addition => highlight_line(new, &line.text, syntaxes, theme),
-        DiffLineKind::Deletion => highlight_line(old, &line.text, syntaxes, theme),
+        DiffLineKind::Addition => super::highlight::line(new, &line.text, syntaxes),
+        DiffLineKind::Deletion => super::highlight::line(old, &line.text, syntaxes),
     }
-}
-
-fn highlight_line(
-    highlighter: &mut HighlightLines<'_>,
-    text: &str,
-    syntaxes: &SyntaxSet,
-    theme: &Theme,
-) -> Vec<Span<'static>> {
-    let line = format!("{text}\n");
-    let Ok(regions) = highlighter.highlight_line(&line, syntaxes) else {
-        return vec![Span::styled(text.to_owned(), code_style(theme))];
-    };
-    let mut spans = Vec::new();
-    for (style, region) in regions {
-        let region = region.trim_end_matches('\n');
-        if region.is_empty() {
-            continue;
-        }
-        let mut modifier = Modifier::empty();
-        if style.font_style.contains(FontStyle::BOLD) {
-            modifier.insert(Modifier::BOLD);
-        }
-        if style.font_style.contains(FontStyle::ITALIC) {
-            modifier.insert(Modifier::ITALIC);
-        }
-        if style.font_style.contains(FontStyle::UNDERLINE) {
-            modifier.insert(Modifier::UNDERLINED);
-        }
-        spans.push(Span::styled(
-            region.to_owned(),
-            Style::default()
-                .fg(Color::Rgb(
-                    style.foreground.r,
-                    style.foreground.g,
-                    style.foreground.b,
-                ))
-                .add_modifier(modifier),
-        ));
-    }
-    if spans.is_empty() {
-        spans.push(Span::styled(String::new(), code_style(theme)));
-    }
-    spans
-}
-
-fn wrap_spans(spans: Vec<Span<'static>>, width: u16) -> Vec<Vec<Span<'static>>> {
-    let mut lines = vec![Vec::<Span<'static>>::new()];
-    let mut used = 0_u16;
-    for span in spans {
-        for grapheme in span.content.graphemes(true) {
-            let grapheme_width =
-                u16::try_from(UnicodeWidthStr::width(grapheme)).unwrap_or(u16::MAX);
-            if grapheme_width > width {
-                if used > 0 {
-                    lines.push(Vec::new());
-                }
-                push_grapheme(
-                    lines.last_mut().expect("a line always exists"),
-                    "�",
-                    span.style,
-                );
-                used = 1;
-                continue;
-            }
-            if used.saturating_add(grapheme_width) > width && used > 0 {
-                lines.push(Vec::new());
-                used = 0;
-            }
-            push_grapheme(
-                lines.last_mut().expect("a line always exists"),
-                grapheme,
-                span.style,
-            );
-            used = used.saturating_add(grapheme_width);
-        }
-    }
-    lines
-}
-
-fn push_grapheme(spans: &mut Vec<Span<'static>>, grapheme: &str, style: Style) {
-    if let Some(last) = spans.last_mut()
-        && last.style == style
-    {
-        last.content.to_mut().push_str(grapheme);
-        return;
-    }
-    spans.push(Span::styled(grapheme.to_owned(), style));
 }
 
 fn hard_wrap(text: &str, width: u16) -> Vec<String> {
-    let spans = wrap_spans(vec![Span::raw(text.to_owned())], width);
+    let spans = super::highlight::wrap(vec![Span::raw(text.to_owned())], width);
     spans
         .into_iter()
         .map(|line| line.into_iter().map(|span| span.content).collect())
@@ -889,7 +653,7 @@ mod tests {
     }
 
     #[test]
-    fn syntax_colors_come_from_the_configured_theme() {
+    fn syntax_colors_ignore_configured_hex_colors() {
         let theme = toml::from_str::<Theme>(
             "mode = \"dark\"\naccent = \"#123456\"\ncode_background = \"#010203\"\n",
         )
@@ -905,7 +669,7 @@ mod tests {
             .find(|span| span.content == "pub")
             .expect("Rust keyword should be highlighted");
 
-        assert_eq!(keyword.style.fg, Some(Color::Rgb(0x12, 0x34, 0x56)));
+        assert_eq!(keyword.style.fg, Some(Color::Blue));
         assert_eq!(keyword.style.bg, None);
     }
 

--- a/src/tui/components/transcript/highlight.rs
+++ b/src/tui/components/transcript/highlight.rs
@@ -1,11 +1,10 @@
 //! Shared, cached syntax highlighting for transcript code.
 
-use crate::tui::theme::Theme;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::Span,
 };
-use std::{str::FromStr, sync::OnceLock};
+use std::{path::Path, str::FromStr, sync::OnceLock};
 use syntect::{
     easy::HighlightLines,
     highlighting::{
@@ -28,43 +27,31 @@ pub(super) fn assets() -> &'static Assets {
     })
 }
 
-pub(super) fn theme(theme: &Theme) -> SyntaxTheme {
+pub(super) fn theme() -> SyntaxTheme {
     SyntaxTheme {
         name: Some("tact".to_owned()),
         settings: ThemeSettings {
-            foreground: Some(syntect_color(theme.code_text())),
-            accent: Some(syntect_color(theme.accent())),
+            foreground: Some(syntect_color(Color::Reset)),
+            accent: Some(syntect_color(Color::Blue)),
             ..ThemeSettings::default()
         },
         scopes: vec![
-            rule("comment", theme.muted(), Some(FontStyle::ITALIC)),
-            rule("string", theme.thinking_medium(), None),
+            rule("comment", Color::DarkGray, Some(FontStyle::ITALIC)),
+            rule("string", Color::Green, None),
             rule(
                 "constant.numeric, constant.language, constant.character",
-                theme.thinking_xhigh(),
+                Color::Magenta,
                 None,
             ),
-            rule("keyword, storage", theme.accent(), Some(FontStyle::BOLD)),
+            rule("keyword, storage", Color::Blue, Some(FontStyle::BOLD)),
+            rule("entity.name.function, support.function", Color::Cyan, None),
             rule(
-                "entity.name.function, support.function",
-                theme.thinking_high(),
+                "entity.name.type, entity.name.class, entity.name.struct, entity.name.enum, entity.name.trait, support.type",
+                Color::Yellow,
                 None,
             ),
-            rule(
-                "entity.name.type, entity.name.class, support.type, storage.type",
-                theme.thinking_max(),
-                None,
-            ),
-            rule(
-                "variable.parameter",
-                theme.thinking_medium(),
-                Some(FontStyle::ITALIC),
-            ),
-            rule(
-                "invalid",
-                theme.thinking_xhigh(),
-                Some(FontStyle::UNDERLINE),
-            ),
+            rule("variable.parameter", Color::Reset, Some(FontStyle::ITALIC)),
+            rule("invalid", Color::Red, Some(FontStyle::UNDERLINE)),
         ],
         ..SyntaxTheme::default()
     }
@@ -79,15 +66,27 @@ pub(super) fn syntax_for_token<'a>(syntaxes: &'a SyntaxSet, token: &str) -> &'a 
         .unwrap_or_else(|| syntaxes.find_syntax_plain_text())
 }
 
+pub(super) fn syntax_for_path<'a>(syntaxes: &'a SyntaxSet, path: &str) -> &'a SyntaxReference {
+    let path = Path::new(path);
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .and_then(|extension| syntaxes.find_syntax_by_extension(extension))
+        .or_else(|| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| syntaxes.find_syntax_by_extension(name))
+        })
+        .unwrap_or_else(|| syntaxes.find_syntax_plain_text())
+}
+
 pub(super) fn line(
     highlighter: &mut HighlightLines<'_>,
     text: &str,
     syntaxes: &SyntaxSet,
-    theme: &Theme,
 ) -> Vec<Span<'static>> {
     let line = format!("{text}\n");
     let Ok(regions) = highlighter.highlight_line(&line, syntaxes) else {
-        return vec![Span::styled(text.to_owned(), code_style(theme))];
+        return vec![Span::styled(text.to_owned(), code_style())];
     };
     let mut spans = Vec::new();
     for (style, region) in regions {
@@ -108,22 +107,18 @@ pub(super) fn line(
         spans.push(Span::styled(
             region.to_owned(),
             Style::default()
-                .fg(Color::Rgb(
-                    style.foreground.r,
-                    style.foreground.g,
-                    style.foreground.b,
-                ))
+                .fg(terminal_color(style.foreground))
                 .add_modifier(modifier),
         ));
     }
     if spans.is_empty() {
-        spans.push(Span::styled(String::new(), code_style(theme)));
+        spans.push(Span::styled(String::new(), code_style()));
     }
     spans
 }
 
-pub(super) fn code_style(theme: &Theme) -> Style {
-    Style::default().fg(theme.code_text())
+pub(super) fn code_style() -> Style {
+    Style::default().fg(Color::Reset)
 }
 
 pub(super) fn wrap(spans: Vec<Span<'static>>, width: u16) -> Vec<Vec<Span<'static>>> {
@@ -182,61 +177,32 @@ fn rule(scope: &str, color: Color, font_style: Option<FontStyle>) -> ThemeItem {
 }
 
 fn syntect_color(color: Color) -> SyntectColor {
-    let (r, g, b) = terminal_rgb(color);
-    SyntectColor { r, g, b, a: 0xff }
-}
-
-fn terminal_rgb(color: Color) -> (u8, u8, u8) {
-    match color {
+    // Syntect accepts only RGB colors. These values are internal identifiers that are converted
+    // back to named Ratatui colors before rendering, leaving the terminal palette authoritative.
+    let (r, g, b) = match color {
         Color::Reset => (0xd7, 0xd7, 0xd7),
-        Color::Black => (0x00, 0x00, 0x00),
         Color::Red => (0xcd, 0x31, 0x31),
         Color::Green => (0x0d, 0xbc, 0x79),
         Color::Yellow => (0xe5, 0xe5, 0x10),
         Color::Blue => (0x24, 0x72, 0xc8),
         Color::Magenta => (0xbc, 0x3f, 0xbc),
         Color::Cyan => (0x11, 0xa8, 0xcd),
-        Color::Gray => (0xe5, 0xe5, 0xe5),
         Color::DarkGray => (0x66, 0x66, 0x66),
-        Color::LightRed => (0xf1, 0x4c, 0x4c),
-        Color::LightGreen => (0x23, 0xd1, 0x8b),
-        Color::LightYellow => (0xf5, 0xf5, 0x43),
-        Color::LightBlue => (0x3b, 0x8e, 0xd0),
-        Color::LightMagenta => (0xd6, 0x70, 0xd6),
-        Color::LightCyan => (0x29, 0xb8, 0xdb),
-        Color::White => (0xff, 0xff, 0xff),
-        Color::Rgb(r, g, b) => (r, g, b),
-        Color::Indexed(index) => indexed_rgb(index),
-    }
+        _ => unreachable!("syntax themes use named terminal colors"),
+    };
+    SyntectColor { r, g, b, a: 0xff }
 }
 
-fn indexed_rgb(index: u8) -> (u8, u8, u8) {
-    const ANSI: [(u8, u8, u8); 16] = [
-        (0x00, 0x00, 0x00),
-        (0x80, 0x00, 0x00),
-        (0x00, 0x80, 0x00),
-        (0x80, 0x80, 0x00),
-        (0x00, 0x00, 0x80),
-        (0x80, 0x00, 0x80),
-        (0x00, 0x80, 0x80),
-        (0xc0, 0xc0, 0xc0),
-        (0x80, 0x80, 0x80),
-        (0xff, 0x00, 0x00),
-        (0x00, 0xff, 0x00),
-        (0xff, 0xff, 0x00),
-        (0x00, 0x00, 0xff),
-        (0xff, 0x00, 0xff),
-        (0x00, 0xff, 0xff),
-        (0xff, 0xff, 0xff),
-    ];
-    if index < 16 {
-        return ANSI[usize::from(index)];
+fn terminal_color(color: SyntectColor) -> Color {
+    match (color.r, color.g, color.b) {
+        (0xd7, 0xd7, 0xd7) => Color::Reset,
+        (0xcd, 0x31, 0x31) => Color::Red,
+        (0x0d, 0xbc, 0x79) => Color::Green,
+        (0xe5, 0xe5, 0x10) => Color::Yellow,
+        (0x24, 0x72, 0xc8) => Color::Blue,
+        (0xbc, 0x3f, 0xbc) => Color::Magenta,
+        (0x11, 0xa8, 0xcd) => Color::Cyan,
+        (0x66, 0x66, 0x66) => Color::DarkGray,
+        _ => Color::Reset,
     }
-    if index >= 232 {
-        let gray = 8_u8.saturating_add(index.saturating_sub(232).saturating_mul(10));
-        return (gray, gray, gray);
-    }
-    let cube = index - 16;
-    let level = |value: u8| if value == 0 { 0 } else { 55 + value * 40 };
-    (level(cube / 36), level((cube % 36) / 6), level(cube % 6))
 }

--- a/src/tui/components/transcript/markdown.rs
+++ b/src/tui/components/transcript/markdown.rs
@@ -462,7 +462,7 @@ impl<'a> Renderer<'a> {
             || assets.syntaxes.find_syntax_plain_text(),
             |language| super::highlight::syntax_for_token(&assets.syntaxes, language),
         );
-        let syntax_theme = super::highlight::theme(self.theme);
+        let syntax_theme = super::highlight::theme();
         let mut highlighter = HighlightLines::new(syntax, &syntax_theme);
         let header = self.lines.len();
         self.lines.push(code_block_header(
@@ -474,7 +474,7 @@ impl<'a> Renderer<'a> {
         let content_width = self.width.saturating_sub(4).max(1);
         for source_line in code.trim_end_matches('\n').split('\n') {
             let highlighted =
-                super::highlight::line(&mut highlighter, source_line, &assets.syntaxes, self.theme);
+                super::highlight::line(&mut highlighter, source_line, &assets.syntaxes);
             for (index, mut spans) in
                 super::highlight::wrap(highlighted, content_width.saturating_sub(2).max(1))
                     .into_iter()
@@ -524,12 +524,12 @@ impl<'a> Renderer<'a> {
             || assets.syntaxes.find_syntax_plain_text(),
             |language| super::highlight::syntax_for_token(&assets.syntaxes, language),
         );
-        let syntax_theme = super::highlight::theme(self.theme);
+        let syntax_theme = super::highlight::theme();
         let mut highlighter = HighlightLines::new(syntax, &syntax_theme);
         let content_width = self.width.saturating_sub(2).max(1);
         for source_line in code.trim_end_matches('\n').split('\n') {
             let highlighted =
-                super::highlight::line(&mut highlighter, source_line, &assets.syntaxes, self.theme);
+                super::highlight::line(&mut highlighter, source_line, &assets.syntaxes);
             for spans in super::highlight::wrap(highlighted, content_width) {
                 let mut line = vec![Span::styled("┃ ", gutter)];
                 line.extend(spans);
@@ -1403,8 +1403,36 @@ mod tests {
             .iter()
             .find(|span| span.content == "pub")
             .expect("Rust keywords should be syntax-highlighted separately");
-        assert_ne!(keyword.style.fg, Some(Theme::default().code_text()));
+        assert_eq!(keyword.style.fg, Some(Color::Blue));
         assert!(lines[1].spans.iter().all(|span| span.style.bg.is_none()));
+    }
+
+    #[test]
+    fn rust_keywords_types_and_parameters_use_distinct_terminal_colors() {
+        let lines = render(
+            "```rust\npub struct Widget;\npub fn choose(input: &str) { let value = if input.is_empty() { 1 } else { 2 }; }\n```",
+            100,
+            &Theme::default(),
+        )
+        .lines;
+        let spans = lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .collect::<Vec<_>>();
+        let style = |token| {
+            spans
+                .iter()
+                .find(|span| span.content == token)
+                .unwrap_or_else(|| panic!("{token} should have its own syntax span"))
+                .style
+        };
+
+        for keyword in ["pub", "struct", "fn", "let", "if"] {
+            assert_eq!(style(keyword).fg, Some(Color::Blue));
+        }
+        assert_eq!(style("Widget").fg, Some(Color::Yellow));
+        assert_eq!(style("input").fg, Some(Color::Reset));
+        assert!(style("input").add_modifier.contains(Modifier::ITALIC));
     }
 
     #[test]
@@ -1446,7 +1474,7 @@ mod tests {
             .find(|span| span.content == "const")
             .expect("JavaScript keywords should be syntax-highlighted separately");
 
-        assert_ne!(keyword.style.fg, Some(Theme::default().code_text()));
+        assert_eq!(keyword.style.fg, Some(Color::Blue));
     }
 
     #[test]
@@ -1490,8 +1518,7 @@ mod tests {
 
         assert!(rendered.contains("src/lib.rs"));
         assert!(rendered.contains("-10,2 → +10,3"));
-        assert_ne!(keyword.style.fg, Some(Color::Green));
-        assert_ne!(keyword.style.fg, Some(Color::Red));
+        assert_eq!(keyword.style.fg, Some(Color::Blue));
     }
 
     #[test]

--- a/src/tui/components/transcript/tool.rs
+++ b/src/tui/components/transcript/tool.rs
@@ -518,7 +518,7 @@ mod tests {
             );
             assert!(keywords.iter().all(|keyword| {
                 keyword.style.add_modifier.contains(Modifier::BOLD)
-                    && keyword.style.fg != Some(Color::Yellow)
+                    && keyword.style.fg == Some(Color::Blue)
             }));
         }
     }

--- a/src/tui/components/transcript/tool.rs
+++ b/src/tui/components/transcript/tool.rs
@@ -440,7 +440,7 @@ mod tests {
         theme::Theme,
         transcript::{ToolEntry, ToolState},
     };
-    use ratatui::style::Color;
+    use ratatui::style::{Color, Modifier};
     use serde_json::json;
 
     fn tool(name: &str, arguments: serde_json::Value) -> ToolEntry {
@@ -482,6 +482,45 @@ mod tests {
             .find(|span| span.content == "✓ ")
             .expect("successful tool should render a checkmark");
         assert_eq!(checkmark.style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn shell_commands_use_prompt_and_syntax_colors() {
+        let shell = tool(
+            "exec_command",
+            json!({"cmd": "if test \"$HOME\"; then echo ok; fi"}),
+        );
+        let theme = Theme::default();
+
+        for (lines, expected_commands) in [
+            (render(&shell, 80, &theme), 1),
+            (render_expanded(&shell, 80, &theme), 2),
+        ] {
+            let spans = lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .collect::<Vec<_>>();
+            let prompts = spans
+                .iter()
+                .filter(|span| span.content == "$ ")
+                .collect::<Vec<_>>();
+            let keywords = spans
+                .iter()
+                .filter(|span| span.content.contains("if"))
+                .collect::<Vec<_>>();
+
+            assert_eq!(prompts.len(), expected_commands);
+            assert_eq!(keywords.len(), expected_commands);
+            assert!(
+                prompts
+                    .iter()
+                    .all(|prompt| prompt.style.fg == Some(Color::Yellow))
+            );
+            assert!(keywords.iter().all(|keyword| {
+                keyword.style.add_modifier.contains(Modifier::BOLD)
+                    && keyword.style.fg != Some(Color::Yellow)
+            }));
+        }
     }
 
     #[test]

--- a/src/tui/components/transcript/tool/shell.rs
+++ b/src/tui/components/transcript/tool/shell.rs
@@ -1,8 +1,12 @@
 use super::{Presentation, format_bytes};
 use crate::tui::{format::shorten_home, theme::Theme, transcript::ToolEntry};
-use ratatui::style::Style;
+use ratatui::{
+    style::{Color, Style},
+    text::Span,
+};
 use serde_json::Value;
 use std::path::Path;
+use syntect::easy::HighlightLines;
 
 pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
     if tool.name == "write_stdin" {
@@ -13,7 +17,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         .get("cmd")
         .and_then(Value::as_str)
         .unwrap_or("<command unavailable>");
-    let mut presentation = Presentation::new("Shell", format!("$ {command}"));
+    let mut presentation = Presentation::styled_subject("Shell", command_spans(command, theme));
     if let Some(outcome) = shell_outcome(tool.result.as_ref()) {
         presentation = presentation.outcome(outcome);
     }
@@ -29,13 +33,14 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
             Style::default().fg(theme.muted()),
         ));
     }
-    details.extend(super::super::markdown::wrap_plain(
-        &format!("$ {command}"),
-        width,
-        Style::default()
-            .fg(theme.code_text())
-            .bg(theme.code_background()),
-    ));
+    let command = command_spans(command, theme)
+        .into_iter()
+        .map(|mut span| {
+            span.style = span.style.bg(theme.code_background());
+            span
+        })
+        .collect::<Vec<_>>();
+    details.extend(super::super::markdown::wrap_spans(&command, width, true));
     for substep in &tool.substeps {
         details.extend(super::super::markdown::wrap_plain(
             &format!("↳ {substep}"),
@@ -62,6 +67,28 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         "{line_count} {line_label} · {}",
         format_bytes(output.len())
     ))
+}
+
+fn command_spans(command: &str, theme: &Theme) -> Vec<Span<'static>> {
+    let command = super::super::markdown::sanitize(command);
+    let assets = super::super::highlight::assets();
+    let syntax = super::super::highlight::syntax_for_token(&assets.syntaxes, "sh");
+    let syntax_theme = super::super::highlight::theme(theme);
+    let mut highlighter = HighlightLines::new(syntax, &syntax_theme);
+    let mut spans = vec![Span::styled("$ ", Style::default().fg(Color::Yellow))];
+
+    for (index, line) in command.split('\n').enumerate() {
+        if index > 0 {
+            spans.push(Span::raw("\n"));
+        }
+        spans.extend(super::super::highlight::line(
+            &mut highlighter,
+            line,
+            &assets.syntaxes,
+            theme,
+        ));
+    }
+    spans
 }
 
 fn stdin(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {

--- a/src/tui/components/transcript/tool/shell.rs
+++ b/src/tui/components/transcript/tool/shell.rs
@@ -17,7 +17,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         .get("cmd")
         .and_then(Value::as_str)
         .unwrap_or("<command unavailable>");
-    let mut presentation = Presentation::styled_subject("Shell", command_spans(command, theme));
+    let mut presentation = Presentation::styled_subject("Shell", command_spans(command));
     if let Some(outcome) = shell_outcome(tool.result.as_ref()) {
         presentation = presentation.outcome(outcome);
     }
@@ -33,7 +33,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
             Style::default().fg(theme.muted()),
         ));
     }
-    let command = command_spans(command, theme)
+    let command = command_spans(command)
         .into_iter()
         .map(|mut span| {
             span.style = span.style.bg(theme.code_background());
@@ -69,11 +69,11 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
     ))
 }
 
-fn command_spans(command: &str, theme: &Theme) -> Vec<Span<'static>> {
+fn command_spans(command: &str) -> Vec<Span<'static>> {
     let command = super::super::markdown::sanitize(command);
     let assets = super::super::highlight::assets();
     let syntax = super::super::highlight::syntax_for_token(&assets.syntaxes, "sh");
-    let syntax_theme = super::super::highlight::theme(theme);
+    let syntax_theme = super::super::highlight::theme();
     let mut highlighter = HighlightLines::new(syntax, &syntax_theme);
     let mut spans = vec![Span::styled("$ ", Style::default().fg(Color::Yellow))];
 
@@ -85,7 +85,6 @@ fn command_spans(command: &str, theme: &Theme) -> Vec<Span<'static>> {
             &mut highlighter,
             line,
             &assets.syntaxes,
-            theme,
         ));
     }
     spans


### PR DESCRIPTION
## Summary

- syntax-highlight shell commands in collapsed summaries and expanded details
- centralize highlighting shared by Markdown code blocks, diffs, and shell tools
- emit named terminal colors instead of configured RGB colors
- render keyword and storage scopes blue, named types yellow, and parameters as reset italic

## Stack

1. **This PR**
2. #79
3. #80

Base: `main`

## Testing

- `cargo check --all-features`
- `just check-fmt`
- `just clippy`
- `just test`