### PR TITLE
fix(tui): restore cursor after focus changes

### DIFF
--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -748,9 +748,10 @@ impl RootNode {
             return update;
         }
         if let Some(destination) = self.transcript.component().link_destination(&event) {
+            self.focus_composer();
             return ComponentUpdate {
                 effects: vec![RootEffect::OpenLink(destination.to_string())],
-                render: RenderRequest::None,
+                render: RenderRequest::Immediate,
             };
         }
         if let Event::Mouse(mouse) = &event
@@ -784,18 +785,16 @@ impl RootNode {
             return ComponentUpdate::render(RenderRequest::Immediate);
         }
         if is_left_click_in(&event, self.composer_area) {
-            let queue_was_focused = self.queue.component().focused();
-            self.queue.component_mut().set_focused(false);
-            if self.transcript.component().expandables_focused() {
-                return self.update_transcript(TranscriptEvent::BlurExpandables);
-            }
-            if queue_was_focused {
-                return ComponentUpdate::render(RenderRequest::Immediate);
-            }
+            self.focus_composer();
+            return ComponentUpdate::render(RenderRequest::Immediate);
         }
         if let Some(command) = self.transcript.component().expandable_command(&event) {
             self.queue.component_mut().set_focused(false);
             return self.update_transcript(TranscriptEvent::Expandable(command));
+        }
+        if is_left_click(&event) {
+            self.focus_composer();
+            return ComponentUpdate::render(RenderRequest::Immediate);
         }
         if self.queue.component().focused() {
             return self.update_queue(event);
@@ -1660,6 +1659,14 @@ impl RootNode {
         })
     }
 
+    fn focus_composer(&mut self) {
+        self.queue.component_mut().set_focused(false);
+        let _ = self
+            .transcript
+            .component_mut()
+            .update(TranscriptEvent::BlurExpandables);
+    }
+
     fn update_queue(&mut self, event: Event) -> ComponentUpdate<RootEffect> {
         let update = self.queue.update(QueueEvent::Terminal(event));
         let mut effects = Vec::new();
@@ -2396,11 +2403,20 @@ fn is_focus_toggle(event: &Event) -> bool {
 }
 
 fn is_left_click_in(event: &Event, area: Rect) -> bool {
-    let Event::Mouse(mouse) = event else {
+    if !is_left_click(event) {
         return false;
+    }
+    let Event::Mouse(mouse) = event else {
+        unreachable!("left click helper only accepts mouse events");
     };
-    mouse.kind == MouseEventKind::Down(MouseButton::Left)
-        && area.contains(ratatui::layout::Position::new(mouse.column, mouse.row))
+    area.contains(ratatui::layout::Position::new(mouse.column, mouse.row))
+}
+
+fn is_left_click(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Mouse(mouse) if mouse.kind == MouseEventKind::Down(MouseButton::Left)
+    )
 }
 
 fn is_control_c(event: &Event) -> bool {
@@ -2987,6 +3003,8 @@ mod tests {
             },
         );
         root.update(super::RootEvent::Transcript(Arc::new(record)));
+        root.queue.component_mut().push("queued".to_owned());
+        root.queue.component_mut().set_focused(true);
         terminal
             .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
             .unwrap();
@@ -3010,6 +3028,7 @@ mod tests {
             up.effects,
             [RootEffect::OpenLink("https://example.com".to_owned())]
         );
+        assert!(!root.queue.component().focused());
     }
 
     #[test]
@@ -3638,6 +3657,45 @@ mod tests {
 
         assert!(!root.queue.component().focused());
         assert_eq!(down.render.max(up.render), super::RenderRequest::Immediate);
+    }
+
+    #[test]
+    fn clicking_the_queue_keeps_focus_on_the_queue() {
+        let backend = TestBackend::new(60, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.queue.component_mut().push("queued".to_owned());
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+
+        let update = root.update(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            root.queue_area.x + 2,
+            root.queue_area.y + 1,
+        ));
+
+        assert!(root.queue.component().focused());
+        assert_eq!(update.render, super::RenderRequest::Immediate);
+    }
+
+    #[test]
+    fn clicking_empty_transcript_space_returns_focus_to_the_composer() {
+        let backend = TestBackend::new(60, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.in_flight_turns = 1;
+        root.queue.component_mut().push("queued".to_owned());
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        root.update(key(KeyCode::Tab, KeyModifiers::NONE));
+        assert!(root.queue.component().focused());
+
+        let update = root.update(mouse(MouseEventKind::Down(MouseButton::Left), 10, 2));
+
+        assert!(!root.queue.component().focused());
+        assert_eq!(update.render, super::RenderRequest::Immediate);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -53,7 +53,7 @@ use crate::{
         worker::{AuxiliaryError, WorkerCommand, WorkerEvent},
     },
 };
-use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
 use futures_util::StreamExt;
 use std::{
     collections::HashMap,
@@ -639,13 +639,24 @@ pub(crate) async fn run(
                         io::ErrorKind::UnexpectedEof,
                         "terminal input closed",
                     )))?;
-                let update = if is_image_paste(&event)
+                let refresh_cursor = matches!(&event, Event::FocusGained)
+                    || matches!(
+                        &event,
+                        Event::Mouse(mouse) if matches!(mouse.kind, MouseEventKind::Down(_))
+                    );
+                if refresh_cursor {
+                    terminal.invalidate_cursor_visibility();
+                }
+                let mut update = if is_image_paste(&event)
                     && let Some(data_url) = clipboard::image_data_url()
                 {
                     app.update(AppEvent::PasteImage(data_url))
                 } else {
                     app.update(AppEvent::Terminal(event))
                 };
+                if refresh_cursor {
+                    update.render = update.render.max(RenderRequest::Immediate);
+                }
                 apply_app_update!(update);
             }
             Some(scheme) = system_theme_updates.recv(), if !stopping => {

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -4,8 +4,9 @@ use crossterm::{
     clipboard::CopyToClipboard,
     cursor::{Hide, Show},
     event::{
-        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute, queue,
     terminal::{
@@ -33,19 +34,30 @@ type TuiTerminal = Terminal<StableCursorBackend<CrosstermBackend<Stdout>>>;
 /// Avoids restarting the terminal's cursor blink cycle on every rendered frame.
 struct StableCursorBackend<B> {
     inner: B,
-    cursor_visible: bool,
+    cursor_visibility: CursorVisibility,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CursorVisibility {
+    Hidden,
+    Visible,
+    Unknown,
 }
 
 impl<B> StableCursorBackend<B> {
     const fn hidden(inner: B) -> Self {
         Self {
             inner,
-            cursor_visible: false,
+            cursor_visibility: CursorVisibility::Hidden,
         }
     }
 
     const fn assume_cursor_hidden(&mut self) {
-        self.cursor_visible = false;
+        self.cursor_visibility = CursorVisibility::Hidden;
+    }
+
+    const fn invalidate_cursor_visibility(&mut self) {
+        self.cursor_visibility = CursorVisibility::Unknown;
     }
 }
 
@@ -74,18 +86,20 @@ impl<B: Backend> Backend for StableCursorBackend<B> {
     }
 
     fn hide_cursor(&mut self) -> Result<(), Self::Error> {
-        if self.cursor_visible {
-            self.inner.hide_cursor()?;
-            self.cursor_visible = false;
+        if self.cursor_visibility == CursorVisibility::Hidden {
+            return Ok(());
         }
+        self.inner.hide_cursor()?;
+        self.cursor_visibility = CursorVisibility::Hidden;
         Ok(())
     }
 
     fn show_cursor(&mut self) -> Result<(), Self::Error> {
-        if !self.cursor_visible {
-            self.inner.show_cursor()?;
-            self.cursor_visible = true;
+        if self.cursor_visibility == CursorVisibility::Visible {
+            return Ok(());
         }
+        self.inner.show_cursor()?;
+        self.cursor_visibility = CursorVisibility::Visible;
         Ok(())
     }
 
@@ -228,6 +242,10 @@ impl TerminalSession {
         draw.and(end)
     }
 
+    pub(crate) fn invalidate_cursor_visibility(&mut self) {
+        self.terminal.backend_mut().invalidate_cursor_visibility();
+    }
+
     pub(crate) fn copy_to_clipboard(&mut self, text: &str) -> io::Result<()> {
         copy_to_clipboard(self.terminal.backend_mut(), text)
     }
@@ -293,6 +311,7 @@ fn activate_commands(output: &mut impl Write) -> io::Result<()> {
         output,
         EnterAlternateScreen,
         EnableBracketedPaste,
+        EnableFocusChange,
         EnableMouseCapture,
         Hide
     )?;
@@ -319,6 +338,7 @@ fn restore_commands(output: &mut impl Write) {
         EndSynchronizedUpdate,
         Show,
         PopKeyboardEnhancementFlags,
+        DisableFocusChange,
         DisableMouseCapture,
         DisableBracketedPaste,
         LeaveAlternateScreen
@@ -348,8 +368,8 @@ fn install_panic_hook() {
 #[cfg(test)]
 mod tests {
     use super::{
-        MeasuredBackend, StableCursorBackend, begin_synchronized_update, copy_to_clipboard,
-        end_synchronized_update, reset_after_resume, restore_commands,
+        MeasuredBackend, StableCursorBackend, activate_commands, begin_synchronized_update,
+        copy_to_clipboard, end_synchronized_update, reset_after_resume, restore_commands,
     };
     use crate::{
         app::config::ReasoningEffort,
@@ -372,6 +392,15 @@ mod tests {
     }
 
     #[test]
+    fn activation_requests_terminal_focus_changes() {
+        let mut output = Vec::new();
+
+        activate_commands(&mut output).unwrap();
+
+        assert!(output.windows(8).any(|window| window == b"\x1b[?1004h"));
+    }
+
+    #[test]
     fn restoration_ends_sync_and_restores_input_modes() {
         let mut output = Vec::new();
 
@@ -379,6 +408,7 @@ mod tests {
 
         assert!(output.starts_with(b"\x1b[?2026l\x1b[?25h"));
         assert!(output.windows(5).any(|window| window == b"\x1b[<1u"));
+        assert!(output.windows(8).any(|window| window == b"\x1b[?1004l"));
         assert!(output.windows(8).any(|window| window == b"\x1b[?1000l"));
         assert!(output.windows(8).any(|window| window == b"\x1b[?2004l"));
         assert!(output.ends_with(b"\x1b[?1049l"));
@@ -452,6 +482,37 @@ mod tests {
         terminal.draw(|_| {}).unwrap();
 
         assert_eq!(terminal.backend().inner.cursor_shows, 1);
+        assert_eq!(terminal.backend().inner.cursor_hides, 1);
+    }
+
+    #[test]
+    fn invalidated_cursor_visibility_is_reasserted_once() {
+        let measured = MeasuredBackend {
+            inner: TestBackend::new(10, 2),
+            changed_cells: 0,
+            cursor_reads: 0,
+            cursor_hides: 0,
+            cursor_shows: 0,
+        };
+        let backend = StableCursorBackend::hidden(measured);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| frame.set_cursor_position(Position::new(0, 0)))
+            .unwrap();
+        terminal.backend_mut().invalidate_cursor_visibility();
+        terminal
+            .draw(|frame| frame.set_cursor_position(Position::new(1, 0)))
+            .unwrap();
+        terminal
+            .draw(|frame| frame.set_cursor_position(Position::new(2, 0)))
+            .unwrap();
+
+        terminal.backend_mut().invalidate_cursor_visibility();
+        terminal.draw(|_| {}).unwrap();
+        terminal.draw(|_| {}).unwrap();
+
+        assert_eq!(terminal.backend().inner.cursor_shows, 2);
         assert_eq!(terminal.backend().inner.cursor_hides, 1);
     }
 }


### PR DESCRIPTION
## Summary

- focus the composer after otherwise-unhandled left clicks while preserving queue, transcript expandable, overlay, link, selection, and composer chrome behavior
- track cursor visibility as hidden, visible, or unknown so focus changes can reassert the intended state once
- refresh cursor state on focus gain and mouse-down without restoring per-frame show or hide commands
- enable terminal focus reporting and leave native unfocused cursor rendering to the terminal or tmux

## Stack

1. #78
2. #79
3. **This PR**

Base: `cl/truncate-shell-summaries`

## Testing

- `cargo check --all-features`
- `just check-fmt`
- `just clippy`
- `just test` — 710 tests passed