### PR TITLE
fix(core): identify the agent as Tact

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -53,6 +53,12 @@ const TOOL_ORCHESTRATION_INSTRUCTIONS: &str = concat!(
     "result requires model judgment, user input, or a progress update."
 );
 
+const TACT_INSTRUCTIONS: &str = concat!(
+    "You are Tact, not Codex. When the user asks about your configuration or asks you to edit it, ",
+    "they mean Tact's configuration. Use `tact config path` to locate the active configuration ",
+    "file before reading or changing it."
+);
+
 const MEMORY_INSTRUCTIONS: &str = concat!(
     "Global memory is available through the explicit `memory` tool. At the beginning of every ",
     "substantial task, use code mode to scan memory before planning or delegating. Await the scan ",
@@ -376,6 +382,7 @@ fn session_instructions(
         },
         |(instructions, catalog_present)| {
             let instructions = reconcile_memory_instructions(instructions, false);
+            let instructions = reconcile_tact_instructions(instructions);
             let instructions = reconcile_tool_orchestration_instructions(instructions);
             let instructions = reconcile_subagent_instructions(instructions, subagents_enabled);
             let instructions = reconcile_memory_instructions(instructions, memory_enabled);
@@ -432,6 +439,7 @@ fn fresh_instructions_with_catalog(
     let mut instructions = custom
         .map(str::to_owned)
         .unwrap_or_else(|| ResponsesServiceConfig::default().system_prompt.to_string());
+    instructions = reconcile_tact_instructions(instructions);
     instructions = reconcile_tool_orchestration_instructions(instructions);
     if subagents_enabled {
         instructions.push_str("\n\n");
@@ -446,6 +454,25 @@ fn fresh_instructions_with_catalog(
         .map_or(instructions.clone(), |skill_instructions| {
             format!("{instructions}\n\n{skill_instructions}")
         })
+}
+
+fn reconcile_tact_instructions(mut instructions: String) -> String {
+    if let Some(rest) = instructions.strip_prefix("You are Codex") {
+        let rest = rest.trim_start_matches([',', '.']);
+        instructions = format!("You are Tact,{rest}");
+        instructions = instructions.replacen("As Codex,", "As Tact,", 1);
+    }
+
+    let separator_and_instructions = format!("\n\n{TACT_INSTRUCTIONS}");
+    let occurrences = instructions.matches(&separator_and_instructions).count();
+    if occurrences == 1 {
+        return instructions;
+    }
+    if occurrences > 1 {
+        instructions = instructions.replace(&separator_and_instructions, "");
+    }
+    instructions.push_str(&separator_and_instructions);
+    instructions
 }
 
 fn reconcile_tool_orchestration_instructions(mut instructions: String) -> String {
@@ -492,7 +519,8 @@ impl Cancellation {
 mod tests {
     use super::{
         ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT, SUBAGENT_INSTRUCTIONS,
-        TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions, session_instructions,
+        TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions,
+        reconcile_tact_instructions, session_instructions,
     };
     use crate::{
         app::{
@@ -559,7 +587,9 @@ mod tests {
     #[test]
     fn fresh_instructions_include_the_default_append() {
         let disabled = SkillsConfig::from_roots(false, Vec::new());
-        let default = ResponsesServiceConfig::default().system_prompt;
+        let default = reconcile_tact_instructions(
+            ResponsesServiceConfig::default().system_prompt.to_string(),
+        );
 
         assert_eq!(
             fresh_instructions(None, None, &disabled),
@@ -568,15 +598,44 @@ mod tests {
         assert_eq!(
             fresh_instructions(Some("Custom instructions."), None, &disabled),
             format!(
-                "Custom instructions.\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}"
+                "Custom instructions.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}"
             )
         );
     }
 
     #[test]
+    fn default_instructions_identify_tact_and_resolve_its_config() {
+        let skills = SkillsConfig::from_roots(false, Vec::new());
+        let fresh = session_instructions(None, None, &skills, None, false, false);
+
+        assert!(fresh.text.starts_with("You are Tact,"));
+        assert!(!fresh.text.contains("You are Codex"));
+        assert!(fresh.text.contains(TACT_INSTRUCTIONS));
+        assert!(fresh.text.contains("`tact config path`"));
+
+        let restored = session_instructions(
+            None,
+            None,
+            &skills,
+            Some((
+                "You are Codex. Stored instructions.".to_owned(),
+                Some(false),
+            )),
+            false,
+            false,
+        );
+
+        assert!(restored.text.starts_with("You are Tact,"));
+        assert!(!restored.text.contains("You are Codex"));
+        assert!(restored.text.contains(TACT_INSTRUCTIONS));
+    }
+
+    #[test]
     fn appended_instructions_extend_the_default_or_replacement() {
         let disabled = SkillsConfig::from_roots(false, Vec::new());
-        let default = ResponsesServiceConfig::default().system_prompt;
+        let default = reconcile_tact_instructions(
+            ResponsesServiceConfig::default().system_prompt.to_string(),
+        );
 
         let instructions = fresh_instructions(None, Some("Project instructions."), &disabled);
         assert_eq!(
@@ -592,7 +651,7 @@ mod tests {
                 &disabled
             ),
             format!(
-                "Replacement.\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions."
+                "Replacement.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions."
             )
         );
     }
@@ -611,9 +670,11 @@ mod tests {
         let enabled = SkillsConfig::from_roots(true, vec![directory.path().to_path_buf()]);
 
         let instructions = fresh_instructions(None, None, &enabled);
-        let default = ResponsesServiceConfig::default().system_prompt;
+        let default = reconcile_tact_instructions(
+            ResponsesServiceConfig::default().system_prompt.to_string(),
+        );
 
-        assert!(instructions.starts_with(default.as_ref()));
+        assert!(instructions.starts_with(&default));
         assert!(instructions.contains("Review code carefully."));
         assert!(
             instructions.contains(&fs::canonicalize(skill_path).unwrap().display().to_string())
@@ -642,7 +703,7 @@ mod tests {
         let instructions = fresh_instructions(Some("Keep this first."), None, &enabled);
 
         assert!(instructions.starts_with(&format!(
-            "Keep this first.\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\n## Available local skills"
+            "Keep this first.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\n## Available local skills"
         )));
         assert!(instructions.contains("Run focused tests."));
         assert!(!instructions.contains("SECRET-BODY"));
@@ -701,7 +762,7 @@ mod tests {
             )
             .text
             .as_ref(),
-            format!("{stored}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!("{stored}\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
         );
         let restored = session_instructions(
             None,
@@ -713,7 +774,7 @@ mod tests {
         );
         assert_eq!(
             restored.text.as_ref(),
-            format!("{stored}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!("{stored}\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
         );
         assert_eq!(
             restored.skills.as_ref(),
@@ -781,7 +842,7 @@ mod tests {
             )
             .text
             .as_ref(),
-            format!("Old default.\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!("Old default.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
         );
         assert_eq!(
             session_instructions(
@@ -794,7 +855,7 @@ mod tests {
             )
             .text
             .as_ref(),
-            format!("Old custom.\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!("Old custom.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
         );
     }
 
@@ -849,7 +910,7 @@ mod tests {
         );
         assert_eq!(
             restored_disabled.text.as_ref(),
-            format!("Stored.\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!("Stored.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
         );
     }
 


### PR DESCRIPTION
## Summary

- rewrite the default Codex identity to Tact when constructing session instructions
- tell the agent that requests about its configuration refer to Tact
- direct configuration discovery through `tact config path`
- reconcile both fresh and restored session instructions without duplicating guidance

## Testing

- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test`

## Stack

- Depends on: #85
- Next: #87