### PR TITLE
fix(tui): show retry backoff countdowns

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -25,11 +25,14 @@ use orchestration::{OrchestrationRecorder, RunOutcome};
 use std::{
     io,
     io::Write,
+    num::NonZeroU32,
     path::{Path, PathBuf},
     sync::Arc,
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+
+const RESPONSE_MAX_ATTEMPTS: NonZeroU32 = NonZeroU32::new(2_000).unwrap();
 
 const SUBAGENT_INSTRUCTIONS: &str = concat!(
     "For larger tasks, delegate meaningful, separable work to subagents; handle trivial or tightly ",
@@ -159,7 +162,7 @@ impl ConfiguredAgent {
         let mcp = mcp_provider(config)?;
         let auth = config.auth().load()?;
 
-        let mut openai = OpenAi::builder(auth);
+        let mut openai = OpenAi::builder(auth).max_attempts(RESPONSE_MAX_ATTEMPTS);
         if let Some(url) = agent_config.websocket_url() {
             openai = openai.websocket_url(url);
         }

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -44,6 +44,7 @@ const EXPANDABLE_FOCUS_HINTS: [&str; 2] =
     ["↑↓ item · Enter toggle · Esc back", "↑↓ item · Enter · Esc"];
 const NESTED_TOOL_INDENT: u16 = 4;
 const PINNED_PROMPT_MAX_HEIGHT: u16 = 3;
+const RETRY_COUNTDOWN_INTERVAL: Duration = Duration::from_millis(100);
 
 pub(crate) enum TranscriptEvent {
     Record(Arc<TranscriptRecord>),
@@ -77,6 +78,7 @@ pub(crate) struct Transcript {
     new_updates: u64,
     tool_spinner: Option<Spinner>,
     running_tool_timers: HashMap<EntryId, RunningToolTimer>,
+    retry_timer: Option<RetryTimer>,
     expandables_focused: bool,
     selected_expandable: Option<EntryId>,
     expandable_hits: Vec<ExpandableHitRegion>,
@@ -155,6 +157,13 @@ struct RunningToolTimer {
 }
 
 #[derive(Clone, Copy)]
+struct RetryTimer {
+    deadline: Instant,
+    remaining_ns: u64,
+    next_frame: Option<Instant>,
+}
+
+#[derive(Clone, Copy)]
 struct PinnedPrompt {
     entry: EntryId,
     area: Rect,
@@ -175,6 +184,26 @@ impl RunningToolTimer {
     fn elapsed(self, now: Instant) -> Duration {
         self.elapsed_at_observation
             .saturating_add(now.saturating_duration_since(self.observed_at))
+    }
+}
+
+impl RetryTimer {
+    fn new(now: Instant, delay_ns: u64) -> Self {
+        let deadline = now + Duration::from_nanos(delay_ns);
+        Self {
+            deadline,
+            remaining_ns: delay_ns,
+            next_frame: Some((now + RETRY_COUNTDOWN_INTERVAL).min(deadline)),
+        }
+    }
+
+    fn refresh(&mut self, now: Instant) -> bool {
+        let previous_tick = duration_display_tick(self.remaining_ns);
+        self.remaining_ns = u64::try_from(self.deadline.saturating_duration_since(now).as_nanos())
+            .unwrap_or(u64::MAX);
+        self.next_frame =
+            (self.remaining_ns > 0).then(|| (now + RETRY_COUNTDOWN_INTERVAL).min(self.deadline));
+        duration_display_tick(self.remaining_ns) != previous_tick
     }
 }
 
@@ -213,6 +242,7 @@ impl Transcript {
             new_updates: 0,
             tool_spinner: None,
             running_tool_timers: HashMap::new(),
+            retry_timer: None,
             expandables_focused: false,
             selected_expandable: None,
             expandable_hits: Vec::new(),
@@ -271,6 +301,7 @@ impl Transcript {
             .map(Spinner::deadline)
             .into_iter()
             .chain(empty)
+            .chain(self.retry_timer.and_then(|timer| timer.next_frame))
             .min()
     }
 
@@ -282,6 +313,13 @@ impl Transcript {
         let change = self.model.apply(&record);
         let activity = self.activity();
         let now = Instant::now();
+        if record.kind() == "model.attempt.retrying" {
+            if let Some(TransientStatus::Retrying(delay_ns)) = self.model.transient() {
+                self.retry_timer = Some(RetryTimer::new(now, *delay_ns));
+            }
+        } else if !matches!(self.model.transient(), Some(TransientStatus::Retrying(_))) {
+            self.retry_timer = None;
+        }
         self.sync_running_tool_timers(now);
         let tool_active = self.model.has_running_tools();
         if tool_active && self.tool_spinner.is_none() {
@@ -369,22 +407,42 @@ impl Transcript {
     fn activity(&self) -> TranscriptEffect {
         TranscriptEffect {
             active: self.model.is_active(),
-            status: self.model.transient().map(transient_label),
+            status: self.model.transient().map(|status| match status {
+                TransientStatus::Retrying(delay_ns) => {
+                    let remaining_ns = self
+                        .retry_timer
+                        .map_or(*delay_ns, |timer| timer.remaining_ns);
+                    format!("Retrying in {}…", format_duration(remaining_ns))
+                }
+                status => transient_label(status),
+            }),
         }
     }
 
     fn update_animation(&mut self, now: Instant) -> ComponentUpdate<TranscriptEffect> {
+        let previous_activity = self.activity();
+        let retry_changed = self
+            .retry_timer
+            .as_mut()
+            .is_some_and(|timer| timer.refresh(now));
         let timer_changed = self.refresh_running_tool_durations(now);
         let tool_changed = self
             .tool_spinner
             .as_mut()
             .is_some_and(|spinner| spinner.advance(now));
         let logo_changed = self.is_empty() && self.empty_logo.advance(now);
-        ComponentUpdate::render(if timer_changed || tool_changed || logo_changed {
-            RenderRequest::Streaming
-        } else {
-            RenderRequest::None
-        })
+        let activity = self.activity();
+        ComponentUpdate {
+            effects: (previous_activity != activity)
+                .then_some(activity)
+                .into_iter()
+                .collect(),
+            render: if retry_changed || timer_changed || tool_changed || logo_changed {
+                RenderRequest::Streaming
+            } else {
+                RenderRequest::None
+            },
+        }
     }
 
     fn sync_running_tool_timers(&mut self, now: Instant) {
@@ -1168,7 +1226,9 @@ fn transient_label(status: &TransientStatus) -> String {
         TransientStatus::WaitingForBackgroundWork => "Waiting for background work…".to_owned(),
         TransientStatus::Tool(tool) => format!("Running {tool}…"),
         TransientStatus::Compacting => "Compacting context…".to_owned(),
-        TransientStatus::Retrying(delay) => format!("Retrying in {delay}…"),
+        TransientStatus::Retrying(delay_ns) => {
+            format!("Retrying in {}…", format_duration(*delay_ns))
+        }
         TransientStatus::Connecting => "Connecting…".to_owned(),
         TransientStatus::Reconnecting => "Reconnecting…".to_owned(),
         TransientStatus::Error(error) => error.clone(),
@@ -2503,6 +2563,31 @@ mod tests {
         let populated = render(&mut transcript, 41, 14);
         assert_eq!(populated.buffer()[(5, 2)].symbol(), " ");
         assert!(transcript.animation_deadline().is_none());
+    }
+
+    #[test]
+    fn retry_status_counts_down_during_backoff() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(user(1, "hello")));
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            2,
+            AgentEventKind::ModelAttemptRetrying,
+            json!({"delay_ns": 2_000_000_000_u64, "error": "temporary"}),
+        )));
+
+        assert_eq!(
+            transcript.activity().status.as_deref(),
+            Some("Retrying in 2.0s…")
+        );
+        let deadline = transcript
+            .animation_deadline()
+            .expect("retry backoff should schedule countdown frames");
+        transcript.update(TranscriptEvent::AnimationFrame(deadline));
+
+        assert_ne!(
+            transcript.activity().status.as_deref(),
+            Some("Retrying in 2.0s…")
+        );
     }
 
     #[test]

--- a/src/tui/transcript/entry.rs
+++ b/src/tui/transcript/entry.rs
@@ -25,7 +25,7 @@ pub(crate) enum TransientStatus {
     WaitingForBackgroundWork,
     Tool(String),
     Compacting,
-    Retrying(String),
+    Retrying(u64),
     Connecting,
     Reconnecting,
     Error(String),

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -7,7 +7,7 @@ use crate::{
     core::extensions::subagents::{
         AgentMessageUpdate, MessageDeliveryState, MessageDisposition, MessageSender, ThreadId,
     },
-    tui::format::{format_duration, humanize_tool},
+    tui::format::humanize_tool,
 };
 use nanocodex::{
     agent::events::{
@@ -710,9 +710,8 @@ impl TranscriptModel {
 
     fn retrying(&mut self, record: &TranscriptRecord) -> Result<bool, serde_json::Error> {
         let payload = record.decode_payload::<RetryPayload>()?;
-        let delay = format_duration(payload.delay_ns);
         self.pending_error = Some(payload.error);
-        self.transient = Some(TransientStatus::Retrying(delay));
+        self.transient = Some(TransientStatus::Retrying(payload.delay_ns));
         Ok(true)
     }
 


### PR DESCRIPTION
## Summary

- increase Nanocodex's retry budget to 2,000 total attempts for long-lived recovery
- retain Nanocodex's typed retry classification and capped exponential backoff
- render retry delays as a live countdown in the transcript status
- clear transient retry state when the model advances or terminates

## Testing

- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test`

## Stack

- Depends on: #86
- Next: #88