### PR TITLE
feat(tui): add editable agent handoffs

### DIFF
--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -167,6 +167,8 @@ pub(crate) enum RuntimeError {
     FastModeUpdateTask(#[source] tokio::task::JoinError),
     #[error("the new-session task stopped unexpectedly: {0}")]
     NewSessionTask(#[source] tokio::task::JoinError),
+    #[error("the handoff task stopped unexpectedly: {0}")]
+    HandoffTask(#[source] tokio::task::JoinError),
     #[error("the session task stopped unexpectedly: {0}")]
     SessionTask(#[source] tokio::task::JoinError),
     #[error("the Nanocodex worker stopped before accepting a command")]

--- a/src/tui/components/actions.rs
+++ b/src/tui/components/actions.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const ACTIONS: [Action; 13] = [
+const ACTIONS: [Action; 14] = [
     Action::Effort,
     Action::FastMode,
     Action::Theme,
@@ -29,6 +29,7 @@ const ACTIONS: [Action; 13] = [
     Action::Memory,
     Action::Subagents,
     Action::DebugContext,
+    Action::Handoff,
     Action::Review,
 ];
 const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab open", "esc close"];
@@ -48,6 +49,7 @@ pub(super) struct ActionAvailability {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum Action {
+    Handoff,
     Review,
     Subagents,
     Effort,
@@ -254,7 +256,7 @@ impl ActionsMenu {
 
     const fn is_enabled(&self, action: Action) -> bool {
         match action {
-            Action::Review => self.availability.new_session,
+            Action::Handoff | Action::Review => self.availability.new_session,
             Action::Subagents => true,
             Action::Effort => true,
             Action::FastMode => true,
@@ -282,6 +284,9 @@ impl ActionsMenu {
             Action::Review if !self.availability.new_session => {
                 "Review changes · finish active work first"
             }
+            Action::Handoff if !self.availability.new_session => {
+                "Prepare handoff · finish active work first"
+            }
             Action::FastMode if self.availability.fast_mode => "Disable fast mode",
             Action::Memory if !self.availability.memory => {
                 "Memory · enable in config: memory.enabled = true"
@@ -294,6 +299,7 @@ impl ActionsMenu {
 impl Action {
     const fn label(self) -> &'static str {
         match self {
+            Self::Handoff => "Prepare handoff",
             Self::Review => "Review changes",
             Self::Subagents => "Subagents",
             Self::Effort => "Change effort",
@@ -312,6 +318,7 @@ impl Action {
 
     const fn alias(self) -> Option<&'static str> {
         match self {
+            Self::Handoff => Some("handoff"),
             Self::Review => Some("review"),
             Self::Subagents => Some("agents"),
             Self::Effort => Some("thinking"),
@@ -351,7 +358,7 @@ impl Component for ActionsMenu {
             return;
         }
 
-        let layout = Floating::new("Actions", 58, 17, &KEY_BINDINGS).render(frame, area, theme);
+        let layout = Floating::new("Actions", 58, 18, &KEY_BINDINGS).render(frame, area, theme);
         if layout.body.is_empty() {
             return;
         }
@@ -414,7 +421,7 @@ mod tests {
     }
 
     fn render(menu: &mut ActionsMenu) -> Terminal<TestBackend> {
-        let mut terminal = Terminal::new(TestBackend::new(60, 19)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
         terminal
             .draw(|frame| menu.render(frame, frame.area(), &Theme::default()))
             .unwrap();
@@ -491,14 +498,18 @@ mod tests {
         );
         assert_eq!(
             row_segment(&terminal, 15, 1, 58),
-            "│  Review changes (alias: review)                        │"
+            "│  Prepare handoff (alias: handoff)                      │"
         );
         assert_eq!(
             row_segment(&terminal, 16, 1, 58),
-            "│          ↑↓ move · enter/tab open · esc close          │"
+            "│  Review changes (alias: review)                        │"
         );
         assert_eq!(
             row_segment(&terminal, 17, 1, 58),
+            "│          ↑↓ move · enter/tab open · esc close          │"
+        );
+        assert_eq!(
+            row_segment(&terminal, 18, 1, 58),
             "╰────────────────────────────────────────────────────────╯"
         );
         assert_eq!(
@@ -551,6 +562,19 @@ mod tests {
         assert_eq!(
             menu.update(key(KeyCode::Tab)).effects,
             [ActionsEffect::Trigger(Action::FastMode)]
+        );
+    }
+
+    #[test]
+    fn handoff_alias_triggers_the_handoff_action() {
+        let mut menu = ActionsMenu::new(available());
+        for character in "handoff".chars() {
+            menu.update(key(KeyCode::Char(character)));
+        }
+
+        assert_eq!(
+            menu.update(key(KeyCode::Enter)).effects,
+            [ActionsEffect::Trigger(Action::Handoff)]
         );
     }
 

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -59,6 +59,19 @@ pub(crate) enum AppEvent {
         pane: PaneId,
         error: String,
     },
+    HandoffReady {
+        pane: PaneId,
+        prompt: String,
+        effort: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        fast_mode: bool,
+        skills: Arc<[Skill]>,
+    },
+    HandoffCancelled(PaneId),
+    HandoffFailed {
+        pane: PaneId,
+        error: String,
+    },
     QueueEditorFinished {
         pane: PaneId,
         index: usize,
@@ -226,6 +239,34 @@ impl AppNode {
             AppEvent::ReviewCancelled(pane) => self.update_root(pane, RootEvent::ReviewCancelled),
             AppEvent::ReviewFailed { pane, error } => {
                 self.update_root(pane, RootEvent::ReviewFailed(error))
+            }
+            AppEvent::HandoffReady {
+                pane,
+                prompt,
+                effort,
+                reasoning_mode,
+                fast_mode,
+                skills,
+            } => {
+                let workspace = self.workspace.clone();
+                {
+                    let Some(root) = self.pane_mut(pane) else {
+                        return ComponentUpdate::none();
+                    };
+                    root.component_mut().reset_session(
+                        &workspace,
+                        effort,
+                        reasoning_mode,
+                        reasoning_mode,
+                    );
+                    root.component_mut().set_fast_mode(fast_mode);
+                    root.component_mut().set_skills(skills);
+                }
+                self.update_root(pane, RootEvent::HandoffFinished(prompt))
+            }
+            AppEvent::HandoffCancelled(pane) => self.update_root(pane, RootEvent::HandoffCancelled),
+            AppEvent::HandoffFailed { pane, error } => {
+                self.update_root(pane, RootEvent::HandoffFailed(error))
             }
             AppEvent::QueueEditorFinished { pane, index, text } => {
                 self.update_root(pane, RootEvent::RestoreQueued { index, text })
@@ -863,6 +904,27 @@ mod tests {
                 .composer()
                 .context_tokens(),
             136_000
+        );
+    }
+
+    #[test]
+    fn handoff_starts_a_fresh_session_with_an_editable_draft() {
+        let mut app = app();
+
+        let update = app.update(AppEvent::HandoffReady {
+            pane: PaneId::Main,
+            prompt: "Continue from the validated parser design.".to_owned(),
+            effort: ReasoningEffort::High,
+            reasoning_mode: ReasoningMode::Standard,
+            fast_mode: false,
+            skills: Arc::from([]),
+        });
+
+        assert!(update.effects.is_empty());
+        let root = app.root(PaneId::Main).expect("the main pane should remain");
+        assert_eq!(
+            root.composer().draft(),
+            "Continue from the validated parser design."
         );
     }
 

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -143,6 +143,9 @@ pub(crate) enum RootEvent {
     AgentStreamClosed,
     Subagent(AgentUpdate),
     ReplaceDraft(String),
+    HandoffFinished(String),
+    HandoffCancelled,
+    HandoffFailed(String),
     ReviewStarted,
     ReviewReady(String),
     ReviewCancelled,
@@ -217,6 +220,7 @@ pub(crate) enum RootEffect {
     },
     PersistSteer(String),
     Copy(String),
+    Handoff,
     Review {
         download_assets: bool,
     },
@@ -230,6 +234,7 @@ pub(crate) enum RootEffect {
     Fork,
     CancelTurns,
     CancelReview,
+    CancelHandoff,
     Shutdown,
 }
 
@@ -245,6 +250,12 @@ enum Overlay {
     Sessions(Node<SessionPicker>),
     ReviewDownload(Node<ReviewDownloadConfirmation>),
     Subagents(SubagentOverlay),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BlockingTask {
+    Handoff,
+    Review,
 }
 
 struct FileMention {
@@ -282,7 +293,7 @@ pub(crate) struct RootNode {
     queue_area: Rect,
     in_flight_turns: usize,
     in_flight_shells: usize,
-    review_active: bool,
+    blocking_task: Option<BlockingTask>,
     review_url: Option<String>,
     fork_available: bool,
     skills: Arc<[Skill]>,
@@ -314,7 +325,7 @@ impl RootNode {
             queue_area: Rect::default(),
             in_flight_turns: 0,
             in_flight_shells: 0,
-            review_active: false,
+            blocking_task: None,
             review_url: None,
             fork_available: true,
             skills: Arc::from([]),
@@ -598,7 +609,7 @@ impl RootNode {
             composer_area,
             theme,
             focused
-                && !self.review_active
+                && self.blocking_task.is_none()
                 && !self.transcript.component().expandables_focused()
                 && !self.queue.component().focused(),
             composer_selection,
@@ -658,11 +669,13 @@ impl RootNode {
         if is_confirmation_key_repeat(&event) {
             return ComponentUpdate::none();
         }
-        if self.review_active && is_control_c(&event) {
+        if self.blocking_task.is_some() && is_control_c(&event) {
             return self.update_key_confirmation(ConfirmationAction::Exit, Instant::now());
         }
-        if self.review_active {
-            return self.update_review_input(event);
+        match self.blocking_task {
+            Some(BlockingTask::Review) => return self.update_review_input(event),
+            Some(BlockingTask::Handoff) => return self.update_handoff_input(event),
+            None => {}
         }
         if is_control_c(&event) {
             if self.overlay.is_none()
@@ -841,7 +854,7 @@ impl RootNode {
         if self.composer.component().draft().is_empty() && is_actions_trigger(&event) {
             let new_session_enabled = self.in_flight_turns == 0
                 && self.in_flight_shells == 0
-                && !self.review_active
+                && self.blocking_task.is_none()
                 && self.queue.component().is_empty();
             self.overlay = Some(Overlay::Actions(Node::new(ActionsMenu::new(
                 ActionAvailability {
@@ -891,6 +904,25 @@ impl RootNode {
         }
         if is_escape(&event) {
             return self.update_key_confirmation(ConfirmationAction::CancelReview, Instant::now());
+        }
+        if is_key_release(&event) {
+            return ComponentUpdate::none();
+        }
+        let confirmation_cleared = self.key_confirmation.take().is_some();
+        ComponentUpdate::render(if confirmation_cleared {
+            RenderRequest::Immediate
+        } else {
+            RenderRequest::None
+        })
+    }
+
+    fn update_handoff_input(&mut self, event: Event) -> ComponentUpdate<RootEffect> {
+        if is_escape(&event) {
+            self.key_confirmation = None;
+            return ComponentUpdate {
+                effects: vec![RootEffect::CancelHandoff],
+                render: RenderRequest::Immediate,
+            };
         }
         if is_key_release(&event) {
             return ComponentUpdate::none();
@@ -1338,6 +1370,22 @@ impl RootNode {
                         download_assets: false,
                     }],
                     render: RenderRequest::Immediate,
+                };
+            }
+            Some(ActionsEffect::Trigger(Action::Handoff)) => {
+                self.overlay = None;
+                self.blocking_task = Some(BlockingTask::Handoff);
+                let waiting = self.update_composer(
+                    ComposerEvent::ReviewWaiting {
+                        waiting: true,
+                        status: Some("Preparing handoff…".to_owned()),
+                        now: Instant::now(),
+                    },
+                    RenderRequest::Immediate,
+                );
+                return ComponentUpdate {
+                    effects: vec![RootEffect::Handoff],
+                    render: waiting.render.max(RenderRequest::Immediate),
                 };
             }
             None => {}
@@ -1981,7 +2029,9 @@ impl Component for RootNode {
         match event {
             RootEvent::Terminal(event) => self.update_terminal(event),
             RootEvent::PasteImage(data_url) => {
-                if self.review_active || self.overlay.is_some() || self.queue.component().focused()
+                if self.blocking_task.is_some()
+                    || self.overlay.is_some()
+                    || self.queue.component().focused()
                 {
                     ComponentUpdate::none()
                 } else {
@@ -2038,8 +2088,53 @@ impl Component for RootNode {
             RootEvent::ReplaceDraft(draft) => {
                 self.update_composer(ComposerEvent::ReplaceDraft(draft), RenderRequest::Immediate)
             }
+            RootEvent::HandoffFinished(prompt) => {
+                self.blocking_task = None;
+                let waiting = self.update_composer(
+                    ComposerEvent::ReviewWaiting {
+                        waiting: false,
+                        status: None,
+                        now: Instant::now(),
+                    },
+                    RenderRequest::Immediate,
+                );
+                let mut draft = self.update_composer(
+                    ComposerEvent::ReplaceDraft(prompt),
+                    RenderRequest::Immediate,
+                );
+                draft.effects.extend(waiting.effects);
+                draft.render = draft.render.max(waiting.render);
+                draft
+            }
+            RootEvent::HandoffCancelled => {
+                self.blocking_task = None;
+                self.notification = Some(Notification::plain(
+                    "Handoff cancelled.".to_owned(),
+                    Color::Yellow,
+                ));
+                self.update_composer(
+                    ComposerEvent::ReviewWaiting {
+                        waiting: false,
+                        status: None,
+                        now: Instant::now(),
+                    },
+                    RenderRequest::Immediate,
+                )
+            }
+            RootEvent::HandoffFailed(message) => {
+                self.blocking_task = None;
+                self.notification = Some(Notification::plain(message, Color::Red));
+                self.update_composer(
+                    ComposerEvent::ReviewWaiting {
+                        waiting: false,
+                        status: None,
+                        now: Instant::now(),
+                    },
+                    RenderRequest::Immediate,
+                )
+            }
             RootEvent::ReviewStarted => {
-                self.review_active = true;
+                self.blocking_task = Some(BlockingTask::Review);
                 self.review_url = None;
                 self.update_composer(
                     ComposerEvent::ReviewWaiting {
@@ -2062,7 +2157,7 @@ impl Component for RootNode {
                 )
             }
             RootEvent::ReviewFinished(markdown) => {
-                self.review_active = false;
+                self.blocking_task = None;
                 self.review_url = None;
                 let waiting = self.update_composer(
                     ComposerEvent::ReviewWaiting {
@@ -2096,7 +2191,7 @@ impl Component for RootNode {
                 update
             }
             RootEvent::ReviewCancelled => {
-                self.review_active = false;
+                self.blocking_task = None;
                 self.review_url = None;
                 self.notification = Some(Notification::plain(
                     "Review cancelled.".to_owned(),
@@ -2112,7 +2207,7 @@ impl Component for RootNode {
                 )
             }
             RootEvent::ReviewFailed(message) => {
-                self.review_active = false;
+                self.blocking_task = None;
                 self.review_url = None;
                 self.notification = Some(Notification::plain(message, Color::Red));
                 self.update_composer(
@@ -4986,7 +5081,7 @@ mod tests {
             root.composer().draft(),
             "existing draft\n\n## Review: Approved"
         );
-        assert!(!root.review_active);
+        assert!(root.blocking_task.is_none());
     }
 
     #[test]
@@ -5007,7 +5102,7 @@ mod tests {
             .collect::<String>();
         assert_eq!(message, "The folder must be a git repository.");
         assert_eq!(notification.color, Color::Red);
-        assert!(!root.review_active);
+        assert!(root.blocking_task.is_none());
     }
 
     #[test]
@@ -5055,6 +5150,49 @@ mod tests {
     }
 
     #[test]
+    fn handoff_blocks_input_until_the_continuation_prompt_is_ready() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "handoff".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+
+        let started = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        let typed = root.update(key(KeyCode::Char('x'), KeyModifiers::NONE));
+        let submitted = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        let pasted = root.update(RootEvent::PasteImage(
+            "data:image/png;base64,abc".to_owned(),
+        ));
+
+        assert_eq!(started.effects, [RootEffect::Handoff]);
+        assert!(typed.effects.is_empty());
+        assert!(submitted.effects.is_empty());
+        assert!(pasted.effects.is_empty());
+        assert!(root.composer().draft().is_empty());
+        assert!(render_root_text(&mut root, 100, 20).contains("Preparing handoff"));
+
+        root.update(RootEvent::HandoffFinished(
+            "Continue by implementing the parser.".to_owned(),
+        ));
+
+        assert_eq!(
+            root.composer().draft(),
+            "Continue by implementing the parser."
+        );
+        assert!(root.blocking_task.is_none());
+    }
+
+    #[test]
+    fn escape_cancels_an_active_handoff() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.blocking_task = Some(super::BlockingTask::Handoff);
+
+        let update = root.update(key(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(update.effects, [RootEffect::CancelHandoff]);
+    }
+
+    #[test]
     fn review_ready_exposes_a_reopen_action_without_unlocking_input() {
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
         root.update(RootEvent::ReviewStarted);
@@ -5080,7 +5218,7 @@ mod tests {
             copy.effects,
             [RootEffect::Copy("http://127.0.0.1:4321/review".to_owned())]
         );
-        assert!(root.review_active);
+        assert_eq!(root.blocking_task, Some(super::BlockingTask::Review));
     }
 
     #[test]
@@ -5124,7 +5262,7 @@ mod tests {
 
         let mut fork = root.fork(Path::new("/work"), ReasoningEffort::Medium);
 
-        assert!(!fork.review_active);
+        assert!(fork.blocking_task.is_none());
         assert!(!render_root_text(&mut fork, 100, 20).contains("Waiting for review"));
     }
 }

--- a/src/tui/handoff_controller.rs
+++ b/src/tui/handoff_controller.rs
@@ -1,0 +1,128 @@
+use crate::{
+    app::config::{ReasoningEffort, ReasoningMode},
+    core::ConfiguredAgent,
+    tui::{pane::PaneId, worker::AuxiliaryError},
+};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+pub(crate) type HandoffResult = Result<PreparedHandoff, AuxiliaryError>;
+pub(crate) type HandoffTask = JoinHandle<HandoffCompletion>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HandoffIdentity {
+    pub(crate) pane: PaneId,
+    pub(crate) pane_generation: u64,
+    controller_generation: u64,
+}
+
+pub(crate) struct HandoffCompletion {
+    pub(crate) identity: HandoffIdentity,
+    pub(crate) result: HandoffResult,
+}
+
+pub(crate) struct PreparedHandoff {
+    pub(crate) prompt: String,
+    pub(crate) effort: ReasoningEffort,
+    pub(crate) reasoning_mode: ReasoningMode,
+    pub(crate) fast_mode: bool,
+    pub(crate) configured: ConfiguredAgent,
+}
+
+struct ActiveHandoff {
+    identity: HandoffIdentity,
+    cancellation: CancellationToken,
+    task: HandoffTask,
+}
+
+pub(crate) struct HandoffController {
+    next_generation: u64,
+    active: Option<ActiveHandoff>,
+}
+
+impl HandoffController {
+    pub(crate) const fn new() -> Self {
+        Self {
+            next_generation: 0,
+            active: None,
+        }
+    }
+
+    pub(crate) fn start(
+        &mut self,
+        pane: PaneId,
+        pane_generation: u64,
+        spawn: impl FnOnce(HandoffIdentity, CancellationToken) -> HandoffTask,
+    ) -> Option<HandoffIdentity> {
+        if self.active.is_some() {
+            return None;
+        }
+
+        let identity = HandoffIdentity {
+            pane,
+            pane_generation,
+            controller_generation: self.next_generation,
+        };
+        self.next_generation = self.next_generation.saturating_add(1);
+        let cancellation = CancellationToken::new();
+        let task = spawn(identity, cancellation.clone());
+        self.active = Some(ActiveHandoff {
+            identity,
+            cancellation,
+            task,
+        });
+        Some(identity)
+    }
+
+    pub(crate) fn task_mut(&mut self) -> Option<&mut HandoffTask> {
+        self.active.as_mut().map(|handoff| &mut handoff.task)
+    }
+
+    pub(crate) fn cancel(&mut self) -> Option<HandoffIdentity> {
+        let handoff = self.active.as_ref()?;
+        handoff.cancellation.cancel();
+        Some(handoff.identity)
+    }
+
+    pub(crate) fn complete(&mut self, identity: HandoffIdentity) -> bool {
+        let matches = self
+            .active
+            .as_ref()
+            .is_some_and(|handoff| handoff.identity == identity);
+        if matches {
+            self.active = None;
+        }
+        matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HandoffCompletion, HandoffController, HandoffIdentity};
+    use crate::tui::pane::PaneId;
+
+    fn pending_handoff(
+        identity: HandoffIdentity,
+        _: tokio_util::sync::CancellationToken,
+    ) -> super::HandoffTask {
+        tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            HandoffCompletion {
+                identity,
+                result: Err(crate::tui::worker::AuxiliaryError::Cancelled),
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn controller_rejects_overlap_and_cancels_its_operation() {
+        let mut controller = HandoffController::new();
+        let identity = controller
+            .start(PaneId::Main, 4, pending_handoff)
+            .expect("the first handoff should start");
+
+        assert!(controller.start(PaneId::Main, 4, pending_handoff).is_none());
+        assert_eq!(controller.cancel(), Some(identity));
+        assert!(controller.task_mut().is_some());
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,6 +6,7 @@ mod components;
 mod context;
 mod editor;
 mod format;
+mod handoff_controller;
 mod pane;
 mod prompt;
 mod review_controller;
@@ -27,6 +28,7 @@ use crate::{
     core::{
         ConfiguredAgent,
         extensions::{
+            Skill,
             memory::{MemoryError, MemoryKey, MemoryRecord, MemoryStore},
             subagents::SubagentControl,
         },
@@ -38,6 +40,7 @@ use crate::{
             RestoredSessionProjection, RootNode,
         },
         editor::EditorOutcome,
+        handoff_controller::{HandoffCompletion, HandoffController, PreparedHandoff},
         pane::PaneId,
         prompt::Submission,
         review_controller::{ReviewCompletion, ReviewController, ReviewIdentity, ReviewTask},
@@ -50,7 +53,7 @@ use crate::{
             LocalEvent, SessionEnded, SessionOutcome, SessionStarted, ShellId, TranscriptError,
             TranscriptJournal, TurnId,
         },
-        worker::{AuxiliaryError, WorkerCommand, WorkerEvent},
+        worker::{AuxiliaryContext, AuxiliaryError, WorkerCommand, WorkerEvent},
     },
 };
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
@@ -114,6 +117,16 @@ struct ReviewReady {
     identity: ReviewIdentity,
     url: String,
 }
+
+const HANDOFF_PROMPT: &str = concat!(
+    "Prepare a self-contained continuation prompt for a new coding agent that will take over this ",
+    "thread. Summarize the user's objective and requirements, important decisions and constraints, ",
+    "work already completed, the current repository and revision state, relevant files and symbols, ",
+    "validation performed, unresolved blockers, and concrete next steps. Preserve exact technical ",
+    "details that the next agent would otherwise need to rediscover. Do not continue the task, use ",
+    "tools, or address the user. Return only the continuation prompt, ready to be edited and sent ",
+    "to the new agent."
+);
 
 fn spawn_update_check() -> Option<UpdateCheckTask> {
     if crate::app::installation::current().is_development() {
@@ -515,6 +528,7 @@ pub(crate) async fn run(
     let mut fast_mode_task = None::<FastModeUpdateTask>;
     let mut new_session_task = None::<NewSessionTask>;
     let mut session_list_task = None::<SessionListTask>;
+    let mut handoff_controller = HandoffController::new();
     let mut review_controller = ReviewController::new();
     let (auxiliary_sender, mut auxiliary_jobs) = mpsc::unbounded_channel();
     let (review_ready_sender, mut review_ready_updates) = mpsc::unbounded_channel();
@@ -547,6 +561,7 @@ pub(crate) async fn run(
                     fast_mode_task: &mut fast_mode_task,
                     new_session_task: &mut new_session_task,
                     session_list_task: &mut session_list_task,
+                    handoff_controller: &mut handoff_controller,
                     review_controller: &mut review_controller,
                     auxiliary_sender: &auxiliary_sender,
                     review_ready_sender: &review_ready_sender,
@@ -575,6 +590,7 @@ pub(crate) async fn run(
         if stopping {
             shell_tasks.abort_all();
             review_controller.cancel();
+            handoff_controller.cancel();
             memory_tasks.abort_all();
         }
         if stopping && !subagents_stopping {
@@ -781,6 +797,7 @@ pub(crate) async fn run(
                         pane,
                         id,
                         prompt: prompt.into(),
+                        context: AuxiliaryContext::Clean,
                         shutdown,
                         completion,
                     })
@@ -1097,6 +1114,66 @@ pub(crate) async fn run(
                     .map_err(|_| RuntimeError::AgentWorkerStopped)?;
             }
             result = async {
+                handoff_controller
+                    .task_mut()
+                    .expect("handoff branch is disabled without a task")
+                    .await
+            }, if handoff_controller.task_mut().is_some() && !stopping => {
+                let completion = result.map_err(RuntimeError::HandoffTask)?;
+                if !handoff_controller.complete(completion.identity) {
+                    continue;
+                }
+                let pane = completion.identity.pane;
+                if !panes.get(&pane).is_some_and(|runtime| {
+                    runtime.generation == completion.identity.pane_generation
+                }) {
+                    continue;
+                }
+                match completion.result {
+                    Ok(prepared) => {
+                        let PreparedHandoff {
+                            prompt,
+                            effort,
+                            reasoning_mode,
+                            fast_mode,
+                            configured,
+                        } = prepared;
+                        let skills = install_configured_agent(
+                            pane,
+                            configured,
+                            PaneSettings::new(effort, reasoning_mode, fast_mode),
+                            &config,
+                            &mut panes,
+                            &commands,
+                            &agent_event_sender,
+                            &subagent_sender,
+                            &writer_sender,
+                            &mut writers_open,
+                            &mut subagent_shutdowns,
+                        )?;
+                        schedule(
+                            app.update(AppEvent::HandoffReady {
+                                pane,
+                                prompt,
+                                effort,
+                                reasoning_mode,
+                                fast_mode,
+                                skills,
+                            }),
+                            &mut scheduler,
+                        );
+                    }
+                    Err(AuxiliaryError::Cancelled) => schedule(
+                        app.update(AppEvent::HandoffCancelled(pane)),
+                        &mut scheduler,
+                    ),
+                    Err(AuxiliaryError::Failed(error)) => schedule(
+                        app.update(AppEvent::HandoffFailed { pane, error }),
+                        &mut scheduler,
+                    ),
+                }
+            }
+            result = async {
                 new_session_task
                     .as_mut()
                     .expect("new-session branch is disabled without a task")
@@ -1108,61 +1185,20 @@ pub(crate) async fn run(
                     result.map_err(RuntimeError::NewSessionTask)?;
                 match configured {
                     Ok(configured) => {
-                        let ConfiguredAgent {
-                            agent,
-                            events,
-                            instructions,
-                            skills,
-                            memory_enabled,
-                            subagent_updates,
-                            subagent_control,
-                        } = configured;
-                        let session_id = events.request_id().to_owned();
-                        let generation = panes
-                            .get(&pane)
-                            .expect("new-session pane must exist")
-                            .generation
-                            .saturating_add(1);
-                        schedule_subagent_shutdown(
-                            panes.get(&pane).expect("new-session pane must exist"),
+                        let skills = install_configured_agent(
+                            pane,
+                            configured,
+                            PaneSettings::new(effort, reasoning_mode, fast_mode),
+                            &config,
+                            &mut panes,
+                            &commands,
+                            &agent_event_sender,
+                            &subagent_sender,
+                            &writer_sender,
+                            &mut writers_open,
                             &mut subagent_shutdowns,
                         );
-                        close_pane_journal(
-                            panes.get_mut(&pane).expect("new-session pane must exist"),
-                            SessionOutcome::Closed,
-                            None,
-                        )?;
-                        panes.insert(
-                            pane,
-                            open_pane(
-                                PaneGeneration { pane, generation },
-                                PaneSession::new(&session_id, None, !skills.is_empty()),
-                                &config,
-                                PaneSettings::new(effort, reasoning_mode, fast_mode),
-                                instructions,
-                                subagent_control.clone(),
-                                &writer_sender,
-                            )?,
-                        );
-                        writers_open = writers_open.saturating_add(1);
-                        agent_events::forward(
-                            pane,
-                            generation,
-                            events,
-                            agent_event_sender.clone(),
-                        );
-                        subagent_updates::forward(
-                            subagent_control.runtime_id(),
-                            subagent_updates,
-                            subagent_sender.clone(),
-                        );
-                        commands
-                            .send(WorkerCommand::ReplaceAgent {
-                                pane,
-                                agent,
-                                memory_review: worker::MemoryReviewState::fresh(memory_enabled),
-                            })
-                            .map_err(|_| RuntimeError::AgentWorkerStopped)?;
+                        let skills = skills?;
                         schedule(
                             app.update(AppEvent::NewSessionReady {
                                 pane,
@@ -1382,6 +1418,73 @@ pub(crate) fn ensure_interactive() -> Result<()> {
     validate_interactive(io::stdin().is_terminal(), io::stdout().is_terminal())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn install_configured_agent(
+    pane: PaneId,
+    configured: ConfiguredAgent,
+    settings: PaneSettings,
+    config: &Config,
+    panes: &mut HashMap<PaneId, PaneRuntime>,
+    commands: &mpsc::UnboundedSender<WorkerCommand>,
+    agent_event_sender: &mpsc::UnboundedSender<ForwardedAgentEvent>,
+    subagent_sender: &mpsc::UnboundedSender<ForwardedSubagentUpdate>,
+    writer_sender: &mpsc::UnboundedSender<WriterCompletion>,
+    writers_open: &mut usize,
+    subagent_shutdowns: &mut JoinSet<()>,
+) -> Result<Arc<[Skill]>> {
+    let ConfiguredAgent {
+        agent,
+        events,
+        instructions,
+        skills,
+        memory_enabled,
+        subagent_updates,
+        subagent_control,
+    } = configured;
+    let session_id = events.request_id().to_owned();
+    let generation = panes
+        .get(&pane)
+        .expect("replacement pane must exist")
+        .generation
+        .saturating_add(1);
+    schedule_subagent_shutdown(
+        panes.get(&pane).expect("replacement pane must exist"),
+        subagent_shutdowns,
+    );
+    close_pane_journal(
+        panes.get_mut(&pane).expect("replacement pane must exist"),
+        SessionOutcome::Closed,
+        None,
+    )?;
+    panes.insert(
+        pane,
+        open_pane(
+            PaneGeneration { pane, generation },
+            PaneSession::new(&session_id, None, !skills.is_empty()),
+            config,
+            settings,
+            instructions,
+            subagent_control.clone(),
+            writer_sender,
+        )?,
+    );
+    *writers_open = writers_open.saturating_add(1);
+    agent_events::forward(pane, generation, events, agent_event_sender.clone());
+    subagent_updates::forward(
+        subagent_control.runtime_id(),
+        subagent_updates,
+        subagent_sender.clone(),
+    );
+    commands
+        .send(WorkerCommand::ReplaceAgent {
+            pane,
+            agent,
+            memory_review: worker::MemoryReviewState::fresh(memory_enabled),
+        })
+        .map_err(|_| RuntimeError::AgentWorkerStopped)?;
+    Ok(skills)
+}
+
 fn validate_interactive(stdin: bool, stdout: bool) -> Result<()> {
     if stdin && stdout {
         return Ok(());
@@ -1514,6 +1617,7 @@ struct EffectContext<'a> {
     fast_mode_task: &'a mut Option<FastModeUpdateTask>,
     new_session_task: &'a mut Option<NewSessionTask>,
     session_list_task: &'a mut Option<SessionListTask>,
+    handoff_controller: &'a mut HandoffController,
     review_controller: &'a mut ReviewController,
     auxiliary_sender: &'a mpsc::UnboundedSender<AuxiliaryJobRequest>,
     review_ready_sender: &'a mpsc::UnboundedSender<ReviewReady>,
@@ -1825,6 +1929,7 @@ fn apply_pane_effect(
                 (pane, sessions.map_err(Into::into))
             }));
         }
+        components::RootEffect::Handoff => start_handoff(context, pane),
         components::RootEffect::Review { download_assets } => {
             if context.review_controller.is_active() {
                 schedule(
@@ -2002,6 +2107,9 @@ fn apply_pane_effect(
                 context.scheduler,
             );
         }
+        components::RootEffect::CancelHandoff => {
+            context.handoff_controller.cancel();
+        }
         components::RootEffect::Fork
         | components::RootEffect::SetTheme(_)
         | components::RootEffect::Shutdown => {
@@ -2009,6 +2117,103 @@ fn apply_pane_effect(
         }
     }
     Ok(())
+}
+
+fn start_handoff(context: &mut EffectContext<'_>, pane: PaneId) {
+    let Some(runtime) = context.panes.get_mut(&pane) else {
+        schedule(
+            context.app.update(AppEvent::HandoffFailed {
+                pane,
+                error: "Could not prepare handoff: session pane is no longer available".to_owned(),
+            }),
+            context.scheduler,
+        );
+        return;
+    };
+    let pane_generation = runtime.generation;
+    let id = TurnId::new(runtime.next_turn);
+    runtime.next_turn = runtime.next_turn.saturating_add(1);
+    let commands = context.commands.clone();
+    let config = context.config.clone();
+    let started =
+        context
+            .handoff_controller
+            .start(pane, pane_generation, move |identity, cancellation| {
+                let (completion, result) = tokio::sync::oneshot::channel();
+                let sent = commands.send(WorkerCommand::Auxiliary {
+                    pane,
+                    id,
+                    prompt: HANDOFF_PROMPT.to_owned().into(),
+                    context: AuxiliaryContext::CurrentConversation,
+                    shutdown: cancellation.clone(),
+                    completion,
+                });
+                tokio::spawn(async move {
+                    let result = if sent.is_err() {
+                        Err(AuxiliaryError::Failed(
+                            "agent worker stopped before the handoff could start".to_owned(),
+                        ))
+                    } else {
+                        match result.await {
+                            Ok(result) => result,
+                            Err(_) if cancellation.is_cancelled() => Err(AuxiliaryError::Cancelled),
+                            Err(_) => Err(AuxiliaryError::Failed(
+                                "agent worker stopped before the handoff completed".to_owned(),
+                            )),
+                        }
+                    };
+                    let result = prepare_handoff(result, config, cancellation).await;
+                    HandoffCompletion { identity, result }
+                })
+            });
+    if started.is_none() {
+        schedule(
+            context.app.update(AppEvent::HandoffFailed {
+                pane,
+                error: "A handoff is already being prepared.".to_owned(),
+            }),
+            context.scheduler,
+        );
+    }
+}
+
+async fn prepare_handoff(
+    result: std::result::Result<String, AuxiliaryError>,
+    config: Config,
+    cancellation: CancellationToken,
+) -> std::result::Result<PreparedHandoff, AuxiliaryError> {
+    let prompt = result?;
+    if prompt.trim().is_empty() {
+        return Err(AuxiliaryError::Failed(
+            "The handoff agent returned an empty continuation prompt.".to_owned(),
+        ));
+    }
+    if cancellation.is_cancelled() {
+        return Err(AuxiliaryError::Cancelled);
+    }
+
+    let effort = config.agent().thinking();
+    let reasoning_mode = config.agent().reasoning_mode();
+    let fast_mode = config.agent().fast_mode();
+    let task = tokio::task::spawn_blocking(move || {
+        ConfiguredAgent::from_config_with_session(&config, effort, reasoning_mode, None, None)
+    });
+    let configured = tokio::select! {
+        result = task => result
+            .map_err(|error| AuxiliaryError::Failed(format!("handoff session task failed: {error}")))?
+            .map_err(|error| AuxiliaryError::Failed(format!("Could not start handoff session: {error}")))?,
+        () = cancellation.cancelled() => return Err(AuxiliaryError::Cancelled),
+    };
+    if cancellation.is_cancelled() {
+        return Err(AuxiliaryError::Cancelled);
+    }
+    Ok(PreparedHandoff {
+        prompt,
+        effort,
+        reasoning_mode,
+        fast_mode,
+        configured,
+    })
 }
 
 fn start_review(

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -29,6 +29,7 @@ pub(crate) enum WorkerCommand {
         pane: PaneId,
         id: TurnId,
         prompt: Submission,
+        context: AuxiliaryContext,
         shutdown: CancellationToken,
         completion: oneshot::Sender<Result<String, AuxiliaryError>>,
     },
@@ -54,6 +55,12 @@ pub(crate) enum WorkerCommand {
     CancelAll(PaneId),
     OpenFork(PaneId),
     ClosePane(PaneId),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AuxiliaryContext {
+    Clean,
+    CurrentConversation,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -133,6 +140,7 @@ struct TurnRequest {
     id: TurnId,
     prompt: Submission,
     purpose: TurnPurpose,
+    auxiliary_context: Option<AuxiliaryContext>,
     shutdown: Option<CancellationToken>,
 }
 
@@ -262,12 +270,14 @@ async fn run(
                         id,
                         prompt,
                         purpose: TurnPurpose::Conversation,
+                        auxiliary_context: None,
                         shutdown: None,
                     },
                     WorkerCommand::Auxiliary {
                         pane,
                         id,
                         prompt,
+                        context,
                         shutdown,
                         completion,
                     } => TurnRequest {
@@ -275,6 +285,7 @@ async fn run(
                         id,
                         prompt,
                         purpose: TurnPurpose::Auxiliary(completion),
+                        auxiliary_context: Some(context),
                         shutdown: Some(shutdown),
                     },
                     WorkerCommand::Steer {
@@ -485,27 +496,34 @@ async fn start_turn(
         id,
         prompt,
         purpose,
+        auxiliary_context,
         shutdown,
     } = request;
-    let auxiliary = matches!(purpose, TurnPurpose::Auxiliary(_));
-    let (isolated_agent, event_drain) = if auxiliary {
-        let spawn = agent.spawn();
+    let auxiliary = auxiliary_context.is_some();
+    let (isolated_agent, event_drain) = if let Some(context) = auxiliary_context {
+        let create_agent = async {
+            match context {
+                AuxiliaryContext::Clean => agent.spawn().await,
+                AuxiliaryContext::CurrentConversation => agent.fork().await,
+            }
+        };
         let spawned = if let Some(scope) = shutdown.clone() {
             tokio::select! {
-                result = spawn => result,
+                result = create_agent => result,
                 () = scope.cancelled() => {
                     reject_cancelled_turn(TurnRequest {
                         pane,
                         id,
                         prompt,
                         purpose,
+                        auxiliary_context: Some(context),
                         shutdown,
                     });
                     return false;
                 }
             }
         } else {
-            spawn.await
+            create_agent.await
         };
         let (agent, mut events) = match spawned {
             Ok(spawned) => spawned,
@@ -516,6 +534,7 @@ async fn start_turn(
                         id,
                         prompt,
                         purpose,
+                        auxiliary_context: Some(context),
                         shutdown,
                     },
                     error.to_string(),
@@ -550,6 +569,7 @@ async fn start_turn(
                     id,
                     prompt,
                     purpose,
+                    auxiliary_context,
                     shutdown,
                 },
                 error.to_string(),
@@ -1302,6 +1322,7 @@ mod tests {
                 pane: PaneId::Main,
                 id: TurnId::new(7),
                 prompt: "generate a visible overview".to_owned().into(),
+                context: super::AuxiliaryContext::Clean,
                 shutdown: overview_shutdown.clone(),
                 completion,
             })
@@ -1367,6 +1388,7 @@ mod tests {
                 pane: PaneId::Main,
                 id: TurnId::new(7),
                 prompt: "do not run".to_owned().into(),
+                context: super::AuxiliaryContext::Clean,
                 shutdown: job_shutdown,
                 completion,
             })


### PR DESCRIPTION
## Summary

- add a `/handoff` action that prepares a self-contained continuation prompt
- summarize from an isolated fork that inherits the current conversation
- block composer input while the handoff is being generated and support cancellation
- replace the current session and place the continuation prompt in the new composer without sending it

## Testing

- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test`

## Stack

- Depends on: #87
- Next: #90