### PR TITLE
chore(release): prepare 0.3.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary

- bump the Tact crate version from 0.3.6 to 0.3.7
- update the root package entry in `Cargo.lock`

## Testing

- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test`
- `cargo package --locked --allow-dirty`

## Stack

- Depends on: #88