### PR TITLE
feat(update): support externally packaged installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,23 @@ tact update
 
 The updater verifies both the release checksum and signature before replacing a release-installer
 binary. If Cargo owns the installation, tact instead prints `cargo install tact --locked` so
-Cargo's records stay accurate. Automatic update notifications are shown only by official release
-builds.
+Cargo's records stay accurate, and builds declared through `TACT_PACKAGE_MANAGER` defer to the
+named package manager. Automatic update notifications are shown by every installation except
+development builds.
+
+### Packaging
+
+Distribution packagers can declare the package manager that owns the installation at build time:
+
+```sh
+TACT_PACKAGE_MANAGER=nix cargo build --release
+```
+
+Such builds keep update notifications and the managed review interface, but `tact update` points
+at the owning package manager instead of replacing the binary in place. When building from a
+source archive without the git repository, the metadata reported by `tact --version` can be
+provided through the `TACT_GIT_SHA`, `TACT_GIT_BRANCH`, `TACT_GIT_COMMIT_TIMESTAMP`, and
+`TACT_GIT_DIRTY` environment variables.
 
 ## Authentication
 

--- a/build.rs
+++ b/build.rs
@@ -11,16 +11,24 @@ fn main() {
     println!("cargo::rerun-if-env-changed=SOURCE_DATE_EPOCH");
     println!("cargo::rerun-if-env-changed=TACT_RELEASE_BUILD");
 
-    set("TACT_GIT_SHA", git(&["rev-parse", "--short=12", "HEAD"]));
+    set(
+        "TACT_GIT_SHA",
+        env_override("TACT_GIT_SHA").or_else(|| git(&["rev-parse", "--short=12", "HEAD"])),
+    );
     set(
         "TACT_GIT_BRANCH",
-        git(&["branch", "--show-current"]).filter(|branch| !branch.is_empty()),
+        env_override("TACT_GIT_BRANCH")
+            .or_else(|| git(&["branch", "--show-current"]))
+            .filter(|branch| !branch.is_empty()),
     );
     set(
         "TACT_GIT_COMMIT_TIMESTAMP",
-        git(&["log", "-1", "--format=%cI"]),
+        env_override("TACT_GIT_COMMIT_TIMESTAMP").or_else(|| git(&["log", "-1", "--format=%cI"])),
     );
-    set("TACT_GIT_DIRTY", dirty_state());
+    set(
+        "TACT_GIT_DIRTY",
+        env_override("TACT_GIT_DIRTY").or_else(dirty_state),
+    );
     set("TACT_BUILD_TIMESTAMP", Some(build_timestamp()));
     set("TACT_BUILD_TARGET", env::var("TARGET").ok());
     set("TACT_BUILD_PROFILE", env::var("PROFILE").ok());
@@ -35,6 +43,13 @@ fn main() {
             &["--version"],
         ),
     );
+}
+
+/// Reads `name` from the build environment, letting builds without a git
+/// checkout, such as distribution packaging, provide the repository metadata.
+fn env_override(name: &str) -> Option<String> {
+    println!("cargo::rerun-if-env-changed={name}");
+    env::var(name).ok().filter(|value| !value.is_empty())
 }
 
 fn git(arguments: &[&str]) -> Option<String> {

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,7 @@ fn main() {
     println!("cargo::rerun-if-changed=.git/index");
     println!("cargo::rerun-if-env-changed=SOURCE_DATE_EPOCH");
     println!("cargo::rerun-if-env-changed=TACT_RELEASE_BUILD");
+    println!("cargo::rerun-if-env-changed=TACT_PACKAGE_MANAGER");
 
     set(
         "TACT_GIT_SHA",
@@ -35,6 +36,10 @@ fn main() {
     println!(
         "cargo::rustc-env=TACT_RELEASE_BUILD={}",
         env::var("TACT_RELEASE_BUILD").is_ok_and(|value| value == "1")
+    );
+    println!(
+        "cargo::rustc-env=TACT_PACKAGE_MANAGER={}",
+        env::var("TACT_PACKAGE_MANAGER").unwrap_or_default()
     );
     set(
         "TACT_RUSTC_VERSION",

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -405,6 +405,11 @@ impl Command {
             update::UpdateStatus::UseCargo { command } => {
                 println!("This tact binary is managed by Cargo. Update it with `{command}`.");
             }
+            update::UpdateStatus::UsePackageManager { manager } => {
+                println!(
+                    "This tact binary is managed by {manager}. Update it with your package manager."
+                );
+            }
         }
         Ok(())
     }

--- a/src/app/installation.rs
+++ b/src/app/installation.rs
@@ -18,7 +18,15 @@ struct CargoInstallMetadata {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum InstallationKind {
     ReleaseArchive,
-    CratesIo { root: PathBuf },
+    CratesIo {
+        root: PathBuf,
+    },
+    /// Managed by an external package manager, declared at build time through
+    /// the `TACT_PACKAGE_MANAGER` environment variable. Updates are delegated
+    /// to the named manager instead of replacing the binary in place.
+    External {
+        manager: String,
+    },
     Development,
 }
 
@@ -31,9 +39,12 @@ impl InstallationKind {
 pub(crate) fn current() -> &'static InstallationKind {
     INSTALLATION.get_or_init(|| {
         let explicitly_released = matches!(env!("TACT_RELEASE_BUILD"), "true");
+        let package_manager =
+            Some(env!("TACT_PACKAGE_MANAGER")).filter(|manager| !manager.is_empty());
         let executable = env::current_exe().ok();
         detect(
             explicitly_released,
+            package_manager,
             executable.as_deref(),
             installed_packages,
         )
@@ -42,6 +53,7 @@ pub(crate) fn current() -> &'static InstallationKind {
 
 fn detect(
     explicitly_released: bool,
+    package_manager: Option<&str>,
     executable: Option<&Path>,
     installed_packages: impl FnOnce(&Path) -> Option<String>,
 ) -> InstallationKind {
@@ -49,6 +61,11 @@ fn detect(
         executable.and_then(|executable| crates_io_install_root(executable, installed_packages))
     {
         return InstallationKind::CratesIo { root };
+    }
+    if let Some(manager) = package_manager {
+        return InstallationKind::External {
+            manager: manager.to_owned(),
+        };
     }
     if explicitly_released {
         return InstallationKind::ReleaseArchive;
@@ -166,13 +183,22 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            detect(false, Some(&executable), |_| None),
+            detect(false, None, Some(&executable), |_| None),
             InstallationKind::CratesIo {
                 root: root.path().to_path_buf(),
             }
         );
         assert_eq!(
-            detect(true, Some(&executable), |_| None),
+            detect(true, None, Some(&executable), |_| None),
+            InstallationKind::CratesIo {
+                root: root.path().to_path_buf(),
+            }
+        );
+        // Cargo's ownership records outrank build-time declarations, like the
+        // release flag above: a cargo-managed binary must be updated through
+        // Cargo regardless of how it was produced.
+        assert_eq!(
+            detect(false, Some("nix"), Some(&executable), |_| None),
             InstallationKind::CratesIo {
                 root: root.path().to_path_buf(),
             }
@@ -182,13 +208,41 @@ mod tests {
     #[test]
     fn release_archives_and_repository_builds_are_distinct() {
         assert_eq!(
-            detect(true, Some(Path::new("/work/target/release/tact")), |_| None),
+            detect(
+                true,
+                None,
+                Some(Path::new("/work/target/release/tact")),
+                |_| None
+            ),
             InstallationKind::ReleaseArchive,
         );
         assert_eq!(
-            detect(false, Some(Path::new("/work/target/debug/tact")), |_| None),
+            detect(
+                false,
+                None,
+                Some(Path::new("/work/target/debug/tact")),
+                |_| None
+            ),
             InstallationKind::Development,
         );
+    }
+
+    #[test]
+    fn package_manager_declarations_identify_external_installations() {
+        let executable = Path::new("/nix/store/cafebabe-tact-1.2.3/bin/tact");
+        let external = InstallationKind::External {
+            manager: "nix".to_owned(),
+        };
+
+        assert_eq!(
+            detect(false, Some("nix"), Some(executable), |_| None),
+            external
+        );
+        assert_eq!(
+            detect(true, Some("nix"), Some(executable), |_| None),
+            external
+        );
+        assert!(!external.is_development());
     }
 
     #[test]
@@ -198,7 +252,7 @@ mod tests {
         fs::create_dir(root.path().join("bin")).unwrap();
 
         assert_eq!(
-            detect(false, Some(&executable), |_| {
+            detect(false, None, Some(&executable), |_| {
                 Some("tact v1.2.3:\n    tact\n".to_owned())
             }),
             InstallationKind::CratesIo {

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -136,6 +136,7 @@ pub(crate) enum UpdateStatus {
     UpToDate { version: Version },
     Updated { from: Version, to: Version },
     UseCargo { command: String },
+    UsePackageManager { manager: String },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -328,7 +329,9 @@ fn update_artifact_target(
 ) -> Result<Option<SupportedTarget>, UpdateError> {
     match installation {
         InstallationKind::ReleaseArchive => SupportedTarget::from_triple(target).map(Some),
-        InstallationKind::CratesIo { .. } | InstallationKind::Development => Ok(None),
+        InstallationKind::CratesIo { .. }
+        | InstallationKind::External { .. }
+        | InstallationKind::Development => Ok(None),
     }
 }
 
@@ -336,6 +339,11 @@ pub(crate) async fn install_latest() -> Result<UpdateStatus, UpdateError> {
     if let InstallationKind::CratesIo { root } = installation() {
         return Ok(UpdateStatus::UseCargo {
             command: cargo_update_command(root, default_cargo_install_root().as_deref()),
+        });
+    }
+    if let InstallationKind::External { manager } = installation() {
+        return Ok(UpdateStatus::UsePackageManager {
+            manager: manager.clone(),
         });
     }
     let target = SupportedTarget::current()?;
@@ -925,6 +933,16 @@ mod tests {
 
         assert_eq!(
             update_artifact_target(&installation, "x86_64-unknown-linux-musl").unwrap(),
+            None,
+        );
+        assert_eq!(
+            update_artifact_target(
+                &InstallationKind::External {
+                    manager: "nix".to_owned(),
+                },
+                "x86_64-unknown-linux-musl",
+            )
+            .unwrap(),
             None,
         );
         assert!(


### PR DESCRIPTION
Binaries built by a package manager (eg. nix) are currently classified as `Development` installs. Building from a source archive also leaves `tact --version` reporting `unknown` commit metadata, since the git checkout may be unavailable at build time.

This adds a `TACT_PACKAGE_MANAGER` build-time declaration that introduces a new `InstallationKind::External`, mirroring the existing crates.io semantics: update checks only notify, and `tact update` points at the owning package manager instead of self-replacing. The build script now also accepts `TACT_GIT_SHA`, `TACT_GIT_BRANCH`, `TACT_GIT_COMMIT_TIMESTAMP`, and `TACT_GIT_DIRTY` from the environment before falling back to git, so packagers can supply accurate version metadata.