### PR TITLE
feat!(tui): replace session persistence with v2 store

### DIFF
--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -79,6 +79,7 @@ mod pane;
 mod prompt;
 mod session;
 mod spinner;
+mod storage;
 mod theme;
 #[path = "transcript/mod.rs"]
 pub(crate) mod transcript;
@@ -86,7 +87,9 @@ pub(crate) mod transcript;
 // `config.rs` uses the production module path while this benchmark compiles the
 // same internal modules directly into its private target.
 mod tui {
-    pub(crate) use crate::{context, format, pane, prompt, session, spinner, theme, transcript};
+    pub(crate) use crate::{
+        context, format, pane, prompt, session, spinner, storage, theme, transcript,
+    };
 }
 
 use components::{AppEvent, AppNode, RootNode};
@@ -98,9 +101,7 @@ use pane::PaneId;
 use ratatui::{Terminal, backend::TestBackend};
 use serde_json::{json, value::to_raw_value};
 use std::{
-    fs::{self, File},
     hint::black_box,
-    io::BufWriter,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -108,13 +109,12 @@ use std::{
 use tempfile::TempDir;
 use theme::Theme;
 use transcript::{LocalEvent, SessionStarted, TranscriptRecord, TurnId};
-use zstd::stream::write::Encoder;
 
 const WIDTH: u16 = 120;
 const HEIGHT: u16 = 40;
-const TARGET_API_EVENTS: u64 = 15_000;
+const TARGET_SEMANTIC_EVENTS: u64 = 15_000;
 const UNRELATED_SESSIONS: u64 = 6;
-const UNRELATED_API_EVENTS: u64 = 4_000;
+const UNRELATED_SEMANTIC_EVENTS: u64 = 4_000;
 
 struct Harness {
     app: AppNode,
@@ -129,12 +129,8 @@ struct PersistenceFixture {
 }
 
 impl PersistenceFixture {
-    fn api_heavy_archive() -> Self {
-        Self::archive_with_target_segments(1)
-    }
-
-    fn multi_segment_archive() -> Self {
-        Self::archive_with_target_segments(4)
+    fn semantic_archive() -> Self {
+        Self::archive()
     }
 
     fn mixed_archive() -> Self {
@@ -153,32 +149,27 @@ impl PersistenceFixture {
         }
     }
 
-    fn archive_with_target_segments(target_segments: u64) -> Self {
+    fn archive() -> Self {
         let directory = tempfile::tempdir().unwrap();
         let config_path = directory.path().join("config.toml");
         let workspace = PathBuf::from("/benchmark-workspace");
         let session_id = "target-session".to_owned();
 
-        let events_per_segment = TARGET_API_EVENTS / target_segments;
-        for index in 0..target_segments {
-            write_session_segment(
-                &config_path,
-                index.saturating_add(1),
-                &session_id,
-                &workspace,
-                events_per_segment,
-            );
-        }
+        write_session(
+            &config_path,
+            &session_id,
+            &workspace,
+            TARGET_SEMANTIC_EVENTS,
+        );
         save_benchmark_checkpoint(&config_path, &session_id);
 
         for index in 0..UNRELATED_SESSIONS {
             let unrelated = format!("unrelated-session-{index}");
-            write_session_segment(
+            write_session(
                 &config_path,
-                target_segments.saturating_add(index).saturating_add(1),
                 &unrelated,
                 &workspace,
-                UNRELATED_API_EVENTS,
+                UNRELATED_SEMANTIC_EVENTS,
             );
             save_benchmark_checkpoint(&config_path, &unrelated);
         }
@@ -193,27 +184,6 @@ impl PersistenceFixture {
 
     fn load_transcript(&self) -> Vec<Arc<TranscriptRecord>> {
         session::load_transcript(&self.config_path, &self.session_id).unwrap()
-    }
-
-    fn clear_projection_cache(&self) {
-        let path = self
-            .config_path
-            .parent()
-            .unwrap()
-            .join("transcript-projections");
-        match fs::remove_dir_all(path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => panic!("failed to clear projection cache: {error}"),
-        }
-    }
-
-    fn load_transcript_parallel(&self) -> Vec<Arc<TranscriptRecord>> {
-        session::load_transcript_parallel(&self.config_path, &self.session_id).unwrap()
-    }
-
-    fn list_parallel(&self) -> Vec<session::SessionSummary> {
-        session::list_parallel(&self.config_path, &self.workspace).unwrap()
     }
 }
 
@@ -433,18 +403,8 @@ fn agent_record(
     ))
 }
 
-fn write_session_segment(
-    config_path: &Path,
-    started_at: u64,
-    session_id: &str,
-    workspace: &Path,
-    api_events: u64,
-) {
-    let directory = transcript::storage_directory(config_path);
-    fs::create_dir_all(&directory).unwrap();
-    let path = directory.join(format!("{started_at}-{session_id}.jsonl.zst"));
-    let output = BufWriter::new(File::create(path).unwrap());
-    let mut output = Encoder::new(output, 1).unwrap();
+fn write_session(config_path: &Path, session_id: &str, workspace: &Path, event_count: u64) {
+    let mut records = Vec::with_capacity(event_count.saturating_add(1) as usize);
     let started = local_record(
         1,
         LocalEvent::SessionStarted(SessionStarted {
@@ -458,40 +418,30 @@ fn write_session_segment(
             application_version: "benchmark".to_owned(),
         }),
     );
-    serde_json::to_writer(&mut output, started.as_ref()).unwrap();
-    std::io::Write::write_all(&mut output, b"\n").unwrap();
+    records.push(started);
 
     let padding = "x".repeat(512);
-    for index in 0..api_events {
+    for index in 0..event_count {
         let sequence = index.saturating_add(2);
         let record = agent_record(
             sequence,
-            AgentEventKind::ApiEvent,
+            AgentEventKind::ToolResult,
             json!({
-                "direction": "inbound",
-                "phase": "generation",
-                "event": {
-                    "type": "response.output_text.delta",
-                    "delta": "token",
-                    "metadata": {
-                        "padding": padding,
-                        "sequence": index,
-                    },
-                },
+                "call_id": format!("benchmark-{index}"),
+                "output": padding,
+                "sequence": index,
             }),
         );
-        serde_json::to_writer(&mut output, record.as_ref()).unwrap();
-        std::io::Write::write_all(&mut output, b"\n").unwrap();
+        records.push(record);
     }
-    output.finish().unwrap();
+    storage::SessionStorage::open(config_path)
+        .unwrap()
+        .append_records(session_id, &records)
+        .unwrap();
 }
 
 fn write_mixed_session_segment(config_path: &Path, session_id: &str, workspace: &Path, turns: u64) {
-    let directory = transcript::storage_directory(config_path);
-    fs::create_dir_all(&directory).unwrap();
-    let path = directory.join(format!("1-{session_id}.jsonl.zst"));
-    let output = BufWriter::new(File::create(path).unwrap());
-    let mut output = Encoder::new(output, 1).unwrap();
+    let mut records = Vec::new();
     let started = local_record(
         1,
         LocalEvent::SessionStarted(SessionStarted {
@@ -505,13 +455,12 @@ fn write_mixed_session_segment(config_path: &Path, session_id: &str, workspace: 
             application_version: "benchmark".to_owned(),
         }),
     );
-    serde_json::to_writer(&mut output, started.as_ref()).unwrap();
-    std::io::Write::write_all(&mut output, b"\n").unwrap();
-    for record in mixed_projection_records(turns) {
-        serde_json::to_writer(&mut output, record.as_ref()).unwrap();
-        std::io::Write::write_all(&mut output, b"\n").unwrap();
-    }
-    output.finish().unwrap();
+    records.push(started);
+    records.extend(mixed_projection_records(turns));
+    storage::SessionStorage::open(config_path)
+        .unwrap()
+        .append_records(session_id, &records)
+        .unwrap();
 }
 
 fn save_benchmark_checkpoint(config_path: &Path, session_id: &str) {
@@ -537,14 +486,12 @@ fn save_benchmark_checkpoint(config_path: &Path, session_id: &str) {
         }]
     }))
     .unwrap();
-    session::save_checkpoint(
-        config_path,
-        session_id,
-        &snapshot,
-        "benchmark instructions",
-        false,
-    )
-    .unwrap();
+    let resume_state =
+        session::encode_checkpoint(&snapshot, "benchmark instructions", false).unwrap();
+    storage::SessionStorage::open(config_path)
+        .unwrap()
+        .append_records_and_resume_state(session_id, &[], Some(&resume_state))
+        .unwrap();
 }
 
 fn benchmarks(criterion: &mut Criterion) {
@@ -712,79 +659,29 @@ fn benchmarks(criterion: &mut Criterion) {
             BatchSize::SmallInput,
         );
     });
-    let fixture = PersistenceFixture::api_heavy_archive();
-    let multi_segment_fixture = PersistenceFixture::multi_segment_archive();
+    let fixture = PersistenceFixture::semantic_archive();
     let mixed_fixture = PersistenceFixture::mixed_archive();
     let restored_records = fixture.load_transcript();
     let mixed_records = mixed_projection_records(1_000);
-    // Keep lazy thread creation outside CodSpeed's single measured iteration.
-    session::initialize_transcript_loader();
     let mut sessions = criterion.benchmark_group("session");
     sessions.sample_size(10);
     sessions.measurement_time(Duration::from_secs(5));
 
-    sessions.bench_function("catalog_api_heavy_archive", |bencher| {
+    sessions.bench_function("catalog_semantic_archive", |bencher| {
         bencher.iter(|| {
             black_box(session::list(&fixture.config_path, &fixture.workspace).unwrap());
         });
     });
 
-    sessions.bench_function("catalog_api_heavy_archive_parallel", |bencher| {
-        bencher.iter(|| black_box(fixture.list_parallel()));
-    });
-
-    sessions.bench_function("load_known_api_heavy_transcript", |bencher| {
+    sessions.bench_function("load_known_semantic_transcript", |bencher| {
         bencher.iter(|| black_box(fixture.load_transcript()));
     });
-
-    sessions.bench_function("load_known_api_heavy_transcript_cold", |bencher| {
-        bencher.iter_batched(
-            || fixture.clear_projection_cache(),
-            |()| black_box(fixture.load_transcript()),
-            BatchSize::LargeInput,
-        );
-    });
-
-    sessions.bench_function("load_known_multi_segment_transcript", |bencher| {
-        bencher.iter(|| black_box(multi_segment_fixture.load_transcript()));
-    });
-
-    sessions.bench_function("load_known_multi_segment_transcript_parallel", |bencher| {
-        bencher.iter(|| black_box(multi_segment_fixture.load_transcript_parallel()));
-    });
-
-    sessions.bench_function("load_known_multi_segment_transcript_cold", |bencher| {
-        bencher.iter_batched(
-            || multi_segment_fixture.clear_projection_cache(),
-            |()| black_box(multi_segment_fixture.load_transcript()),
-            BatchSize::LargeInput,
-        );
-    });
-
-    sessions.bench_function(
-        "load_known_multi_segment_transcript_parallel_cold",
-        |bencher| {
-            bencher.iter_batched(
-                || multi_segment_fixture.clear_projection_cache(),
-                |()| black_box(multi_segment_fixture.load_transcript_parallel()),
-                BatchSize::LargeInput,
-            );
-        },
-    );
 
     sessions.bench_function("load_mixed_transcript", |bencher| {
         bencher.iter(|| black_box(mixed_fixture.load_transcript()));
     });
 
-    sessions.bench_function("load_mixed_transcript_cold", |bencher| {
-        bencher.iter_batched(
-            || mixed_fixture.clear_projection_cache(),
-            |()| black_box(mixed_fixture.load_transcript()),
-            BatchSize::LargeInput,
-        );
-    });
-
-    sessions.bench_function("project_api_heavy_transcript", |bencher| {
+    sessions.bench_function("project_semantic_transcript", |bencher| {
         bencher.iter_batched(
             || {
                 (
@@ -830,7 +727,7 @@ fn benchmarks(criterion: &mut Criterion) {
         );
     });
 
-    sessions.bench_function("resume_api_heavy_transcript", |bencher| {
+    sessions.bench_function("resume_semantic_transcript", |bencher| {
         bencher.iter(|| {
             let records = fixture.load_transcript();
             let mut root = RootNode::new(&fixture.workspace, ReasoningEffort::Medium);
@@ -845,26 +742,6 @@ fn benchmarks(criterion: &mut Criterion) {
             black_box(root);
         });
     });
-    sessions.bench_function("resume_api_heavy_transcript_cold", |bencher| {
-        bencher.iter_batched(
-            || fixture.clear_projection_cache(),
-            |()| {
-                let records = fixture.load_transcript();
-                let mut root = RootNode::new(&fixture.workspace, ReasoningEffort::Medium);
-                root.restore_session(
-                    &fixture.workspace,
-                    ReasoningEffort::Medium,
-                    ReasoningMode::Standard,
-                    ReasoningMode::Standard,
-                    false,
-                    records,
-                );
-                black_box(root);
-            },
-            BatchSize::LargeInput,
-        );
-    });
-
     sessions.bench_function("resume_mixed_transcript", |bencher| {
         bencher.iter(|| {
             let records = mixed_fixture.load_transcript();
@@ -881,25 +758,6 @@ fn benchmarks(criterion: &mut Criterion) {
         });
     });
 
-    sessions.bench_function("resume_mixed_transcript_cold", |bencher| {
-        bencher.iter_batched(
-            || mixed_fixture.clear_projection_cache(),
-            |()| {
-                let records = mixed_fixture.load_transcript();
-                let mut root = RootNode::new(&mixed_fixture.workspace, ReasoningEffort::Medium);
-                root.restore_session(
-                    &mixed_fixture.workspace,
-                    ReasoningEffort::Medium,
-                    ReasoningMode::Standard,
-                    ReasoningMode::Standard,
-                    false,
-                    records,
-                );
-                black_box(root);
-            },
-            BatchSize::LargeInput,
-        );
-    });
     sessions.finish();
 }
 

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -60,13 +60,6 @@ pub(crate) struct ContextObservation {
     pub(crate) completed_tokens: Option<u64>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ApiEventProjection {
-    Discard,
-    Retain,
-    LatestOutbound,
-}
-
 impl Default for ContextDiagnostics {
     fn default() -> Self {
         Self {
@@ -96,10 +89,7 @@ impl ContextDiagnostics {
     pub(crate) fn observe(&mut self, record: &TranscriptRecord) -> ContextObservation {
         match (record.source(), record.kind()) {
             ("agent", "api.event") => self.observe_api_event(record),
-            ("agent", "model.call.completed") => {
-                self.observe_model_call_completed(record);
-                ContextObservation::default()
-            }
+            ("agent", "model.call.completed") => self.observe_model_call_completed(record),
             ("agent", "model.compaction.started") => {
                 self.observe_compaction_started(record);
                 ContextObservation::default()
@@ -166,11 +156,14 @@ impl ContextDiagnostics {
         ContextObservation { completed_tokens }
     }
 
-    fn observe_model_call_completed(&mut self, record: &TranscriptRecord) {
+    fn observe_model_call_completed(&mut self, record: &TranscriptRecord) -> ContextObservation {
         let Ok(payload) = record.decode_payload::<ModelCallCompleted>() else {
-            return;
+            return ContextObservation::default();
         };
-        self.set_usage(payload.usage.map(usage_into_tokens));
+        let usage = payload.usage.map(usage_into_tokens);
+        let completed_tokens = usage.map(|usage| usage.total);
+        self.set_usage(usage);
+        ContextObservation { completed_tokens }
     }
 
     fn observe_context_snapshot(&mut self, record: &TranscriptRecord) {
@@ -275,31 +268,6 @@ fn usage_into_tokens(usage: Usage) -> TokenUsage {
 
 fn raw_value_is_string(value: &RawValue) -> bool {
     value.get().trim_start().starts_with('"')
-}
-
-pub(crate) fn api_event_projection(record: &TranscriptRecord) -> ApiEventProjection {
-    if record.source() != "agent" || record.kind() != "api.event" {
-        return ApiEventProjection::Retain;
-    }
-    let Ok(payload) = record.decode_payload::<ApiEvent>() else {
-        return ApiEventProjection::Retain;
-    };
-    if payload.phase != "generation" {
-        return ApiEventProjection::Discard;
-    }
-    match payload.direction {
-        "outbound" => ApiEventProjection::LatestOutbound,
-        "inbound" => {
-            let completed = serde_json::from_str::<ResponseEvent>(payload.event.get())
-                .is_ok_and(|event| event.kind == "response.completed");
-            if completed {
-                ApiEventProjection::Retain
-            } else {
-                ApiEventProjection::Discard
-            }
-        }
-        _ => ApiEventProjection::Discard,
-    }
 }
 
 pub(crate) fn outbound_context_snapshot(record: &TranscriptRecord) -> Option<(bool, bool)> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,6 +14,7 @@ mod scheduler;
 pub(crate) mod session;
 mod shell;
 mod spinner;
+mod storage;
 mod subagent_updates;
 mod terminal;
 pub(crate) mod theme;
@@ -62,7 +63,10 @@ use std::{
     collections::HashMap,
     io::{self, IsTerminal},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::{
@@ -245,6 +249,7 @@ struct PaneRuntime {
     previously_persisted: bool,
     journal: Option<TranscriptJournal>,
     writer_path: PathBuf,
+    persisted_transcript: Arc<AtomicBool>,
     event_streams_open: usize,
     next_turn: u64,
     next_shell: u64,
@@ -391,7 +396,8 @@ impl PaneRuntime {
     }
 
     fn exit_session_id(&self) -> Option<String> {
-        (self.previously_persisted || self.writer_path.is_file()).then(|| self.session_id.clone())
+        (self.previously_persisted || self.persisted_transcript.load(Ordering::Acquire))
+            .then(|| self.session_id.clone())
     }
 }
 
@@ -530,7 +536,7 @@ pub(crate) async fn run(
     let mut app = AppNode::new(theme, workspace.clone(), root);
     let prompt_warmup_config = config.path().to_path_buf();
     let mut recent_prompt_task = Some(tokio::spawn(async move {
-        session::load_recent_prompts_async(prompt_warmup_config, None)
+        session::load_recent_prompts_async(prompt_warmup_config)
             .await
             .map_err(Into::into)
     }));
@@ -852,19 +858,23 @@ pub(crate) async fn run(
                         let Some(runtime) = panes.get_mut(&pane) else {
                             continue;
                         };
-                        if let Some(snapshot) = snapshot {
-                            session::save_checkpoint(
-                                config.path(),
-                                &runtime.session_id,
-                                &snapshot,
+                        let resume_state = snapshot
+                            .as_ref()
+                            .map(|snapshot| {
+                                session::encode_checkpoint(
+                                    snapshot,
                                 &runtime.instructions,
                                 runtime.skills_catalog_present,
-                            )?;
-                        }
-                        let record = runtime.journal_mut()?.append_local(LocalEvent::WorkerTurnFinished {
-                            id,
-                            error,
-                        })?;
+                                )
+                            })
+                            .transpose()?;
+                        let event = LocalEvent::WorkerTurnFinished { id, error };
+                        let record = match resume_state {
+                            Some(resume_state) => runtime
+                                .journal_mut()?
+                                .append_local_with_resume_state(event, resume_state)?,
+                            None => runtime.journal_mut()?.append_local(event)?,
+                        };
                         schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                         apply_app_update!(app.update(AppEvent::WorkerTurnFinished(pane)));
                     }
@@ -1565,11 +1575,9 @@ fn open_pane(
         previously_persisted,
         skills_catalog_present,
     } = session;
-    if pane == PaneId::Main && generation == 0 {
-        session::remove_obsolete_checkpoints(config.path())?;
-    }
     let (mut journal, writer) = TranscriptJournal::open(config.path(), session_id)?;
     let writer_path = journal.path().to_path_buf();
+    let persisted_transcript = journal.persistence_flag();
     journal.defer_start(SessionStarted {
         session_id: session_id.to_owned(),
         parent_session_id: parent_session_id.map(str::to_owned),
@@ -1604,6 +1612,7 @@ fn open_pane(
         previously_persisted,
         journal: Some(journal),
         writer_path,
+        persisted_transcript,
         event_streams_open: 1,
         next_turn: 1,
         next_shell: 1,
@@ -2070,7 +2079,7 @@ fn apply_pane_effect(
             if context.recent_prompt_task.is_none() {
                 let config_path = context.config.path().to_path_buf();
                 *context.recent_prompt_task = Some(tokio::spawn(async move {
-                    session::load_recent_prompts_async(config_path, None)
+                    session::load_recent_prompts_async(config_path)
                         .await
                         .map_err(Into::into)
                 }));
@@ -2551,9 +2560,9 @@ mod tests {
         tui::{
             components::RecentPromptDraft,
             pane::PaneId,
-            session::RecentPrompt,
+            session::{self, RecentPrompt},
             subagent_updates::ForwardedSubagentUpdate,
-            transcript::{LocalEvent, TurnId, load},
+            transcript::{LocalEvent, TurnId},
             worker::WorkerCommand,
         },
     };
@@ -2764,43 +2773,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn opening_a_session_removes_obsolete_checkpoints() {
-        let directory = tempdir().unwrap();
-        let config_path = directory.path().join("config.toml");
-        fs::write(&config_path, "").unwrap();
-        let config = Config::load(ConfigOverrides {
-            path: Some(config_path),
-            workspace: Some(directory.path().to_path_buf()),
-            ..ConfigOverrides::default()
-        })
-        .unwrap();
-        let obsolete = directory.path().join("checkpoints/6161.json.zst");
-        fs::create_dir_all(obsolete.parent().unwrap()).unwrap();
-        fs::write(&obsolete, b"obsolete checkpoint").unwrap();
-        let (sender, mut completions) = tokio::sync::mpsc::unbounded_channel();
-        let (_subagents, subagent_control, _updates) =
-            crate::core::extensions::subagents::channel(32);
-
-        let pane = open_pane(
-            PaneGeneration {
-                pane: PaneId::Main,
-                generation: 0,
-            },
-            PaneSession::new("main-session", None, false),
-            &config,
-            PaneSettings::new(ReasoningEffort::Low, ReasoningMode::Standard, false),
-            Arc::from("instructions"),
-            subagent_control,
-            &sender,
-        )
-        .unwrap();
-
-        assert!(!obsolete.exists());
-        drop(pane);
-        completions.recv().await.unwrap().result.unwrap();
-    }
-
-    #[tokio::test]
     async fn fork_pane_has_an_independent_session_and_persisted_transcript() {
         let directory = tempdir().unwrap();
         let config_path = directory.path().join("config.toml");
@@ -2867,7 +2839,6 @@ mod tests {
         let mut main = panes.remove(&PaneId::Main).unwrap();
         let mut fork = panes.remove(&PaneId::Fork(1)).unwrap();
         let main_path = main.writer_path.clone();
-        let fork_path = fork.writer_path.clone();
         fork.journal_mut()
             .unwrap()
             .append_local(LocalEvent::UserSubmitted {
@@ -2878,17 +2849,17 @@ mod tests {
 
         assert_eq!(main.session_id, "main-session");
         assert_eq!(fork.session_id, "fork-session");
-        assert_ne!(main.writer_path, fork.writer_path);
+        assert_eq!(main.writer_path, fork.writer_path);
 
         drop(main.journal.take());
         drop(fork.journal.take());
         for _ in 0..2 {
             completions.recv().await.unwrap().result.unwrap();
         }
-        assert!(!main_path.exists());
+        assert!(main_path.exists());
         assert!(main.exit_session_id().is_none());
         assert_eq!(fork.exit_session_id().as_deref(), Some("fork-session"));
-        let records = load(&fork_path).unwrap();
+        let records = session::load_transcript(config.path(), "fork-session").unwrap();
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].kind(), "session.started");
         let started = records[0]
@@ -2925,7 +2896,6 @@ mod tests {
             &sender,
         )
         .unwrap();
-        let old_path = old.writer_path.clone();
         old.journal_mut()
             .unwrap()
             .append_local(LocalEvent::UserSubmitted {
@@ -2948,13 +2918,12 @@ mod tests {
             &sender,
         )
         .unwrap();
-        let new_path = new.writer_path.clone();
         drop(new.journal.take());
 
         for _ in 0..2 {
             completions.recv().await.unwrap().result.unwrap();
         }
-        let old_records = load(&old_path).unwrap();
+        let old_records = session::load_transcript(config.path(), "old-session").unwrap();
 
         assert_eq!(old_records.last().unwrap().kind(), "session.ended");
         let ended = old_records
@@ -2963,7 +2932,11 @@ mod tests {
             .decode_payload::<crate::tui::transcript::SessionEnded>()
             .unwrap();
         assert_eq!(ended.outcome, super::SessionOutcome::Closed);
-        assert!(!new_path.exists());
+        assert!(
+            session::load_transcript(config.path(), "new-session")
+                .unwrap()
+                .is_empty()
+        );
         assert!(new.exit_session_id().is_none());
     }
 }

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -1,38 +1,23 @@
-//! Resumable Nanocodex checkpoints and transcript-derived session discovery.
+//! V2 resumable session storage and indexed session discovery.
 
 use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
     tui::{
-        context::{ApiEventProjection, api_event_projection, outbound_context_snapshot},
-        transcript::{self, LocalEvent, SessionStarted, TranscriptRecord},
+        storage::{SessionStorage, StorageError},
+        transcript::{SessionStarted, TranscriptRecord},
     },
 };
 use nanocodex::agent::session::SessionSnapshot;
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
-    fs::{self, File},
-    hash::{Hash, Hasher},
-    io::{self, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, MutexGuard, OnceLock},
-    time::{SystemTime, UNIX_EPOCH},
+    sync::Arc,
+    time::Duration,
 };
-use tempfile::NamedTempFile;
 use thiserror::Error;
-use tokio::sync::oneshot;
-use zstd::stream::{read::Decoder, write::Encoder};
 
-const COMPRESSION_LEVEL: i32 = 3;
-const CHECKPOINT_FORMAT_VERSION: u32 = 1;
-const SEGMENT_SUMMARY_FORMAT_VERSION: u32 = 2;
-const PROJECTION_FORMAT_VERSION: u32 = 1;
+const RESUME_STATE_FORMAT_VERSION: u32 = 2;
 pub(crate) const MAX_RECENT_PROMPTS: usize = 100;
-const MAX_TRANSCRIPT_LOADER_THREADS: usize = 16;
-
-#[cfg(unix)]
-use std::os::unix::fs::DirBuilderExt;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct SessionSummary {
@@ -53,94 +38,22 @@ pub(crate) struct RecentPrompt {
     pub(crate) workspace: PathBuf,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-struct StoredRecentPrompt {
-    prompt: RecentPrompt,
-    sequence: u64,
-}
-
 #[derive(Deserialize, Serialize)]
-struct StoredSegmentSummary {
+struct StoredResumeState {
     format_version: u32,
-    transcript_filename: String,
-    transcript_bytes: u64,
-    transcript_modified_unix_ns: u128,
-    summary: SessionSummary,
-    prompts: Vec<StoredRecentPrompt>,
-}
-
-struct SegmentIndex {
-    summary: SessionSummary,
-    prompts: Vec<StoredRecentPrompt>,
-}
-
-struct LoadedRecentPrompt {
-    prompt: RecentPrompt,
-    transcript_filename: String,
-    sequence: u64,
-}
-
-#[derive(Deserialize, Eq, PartialEq, Serialize)]
-struct TranscriptFingerprint {
-    filename: String,
-    bytes: u64,
-    modified_unix_ns: u128,
-}
-
-#[derive(Deserialize, Serialize)]
-struct StoredTranscriptProjection {
-    format_version: u32,
-    session_id: String,
-    transcript_fingerprint: Vec<TranscriptFingerprint>,
-    records: Vec<Arc<TranscriptRecord>>,
-}
-
-#[derive(Serialize)]
-struct TranscriptProjectionEnvelope<'a> {
-    format_version: u32,
-    session_id: &'a str,
-    transcript_fingerprint: &'a [TranscriptFingerprint],
-    records: &'a [Arc<TranscriptRecord>],
-}
-
-struct LoadedSessionSegment {
-    records: Vec<Arc<TranscriptRecord>>,
-    complete: bool,
-    observed_records: usize,
-}
-
-#[derive(Serialize)]
-struct CheckpointEnvelope<'a> {
-    format_version: u32,
-    instructions: &'a str,
+    snapshot: SessionSnapshot,
+    instructions: String,
     skills_catalog_present: bool,
-    snapshot: &'a SessionSnapshot,
-}
-
-#[derive(Deserialize)]
-struct StoredCheckpoint {
-    #[serde(default)]
-    format_version: Option<u32>,
-    #[serde(default)]
-    instructions: Option<String>,
-    #[serde(default)]
-    skills_catalog_present: Option<bool>,
-    #[serde(default)]
-    snapshot: Option<SessionSnapshot>,
 }
 
 pub(crate) struct ResumeState {
     snapshot: SessionSnapshot,
     instructions: String,
-    skills_catalog_present: Option<bool>,
+    skills_catalog_present: bool,
 }
 
 impl ResumeState {
-    fn new(
-        snapshot: SessionSnapshot,
-        instructions: String,
-        skills_catalog_present: Option<bool>,
-    ) -> Self {
+    fn new(snapshot: SessionSnapshot, instructions: String, skills_catalog_present: bool) -> Self {
         Self {
             snapshot,
             instructions,
@@ -152,81 +65,26 @@ impl ResumeState {
         (
             self.snapshot,
             self.instructions,
-            self.skills_catalog_present,
+            Some(self.skills_catalog_present),
         )
     }
 }
 
 #[derive(Debug, Error)]
 pub(crate) enum SessionError {
-    #[error("failed to create session directory {path}: {source}")]
-    CreateDirectory {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to inspect session directory {path}: {source}")]
-    ReadDirectory {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to create checkpoint in {path}: {source}")]
-    CreateCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to encode checkpoint {path}: {source}")]
-    EncodeCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: serde_json::Error,
-    },
-    #[error("failed to write checkpoint {path}: {source}")]
-    WriteCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to replace checkpoint {path}: {source}")]
-    PersistCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: tempfile::PersistError,
-    },
-    #[error("failed to remove obsolete checkpoint {path}: {source}")]
-    RemoveObsoleteCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("no resumable checkpoint exists for session {session_id}")]
-    MissingCheckpoint { session_id: String },
-    #[error("obsolete checkpoint {path} was removed; start a new session")]
-    ObsoleteCheckpointRemoved { path: PathBuf },
-    #[error("failed to read checkpoint {path}: {source}")]
-    ReadCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to decode checkpoint {path}: {source}")]
-    DecodeCheckpoint {
-        path: PathBuf,
-        #[source]
-        source: serde_json::Error,
-    },
-    #[error("checkpoint {path} was created by an incompatible tact version; start a new session")]
-    IncompatibleCheckpoint { path: PathBuf },
-    #[error("checkpoint {path} is incomplete or corrupt; start a new session")]
-    InvalidCheckpoint { path: PathBuf },
     #[error(transparent)]
-    Transcript(#[from] transcript::TranscriptError),
-    #[error("the transcript loading worker stopped unexpectedly")]
-    TranscriptLoaderStopped,
+    Storage(#[from] StorageError),
+    #[error("no resumable state exists for session {session_id}")]
+    MissingCheckpoint { session_id: String },
+    #[error(
+        "session {session_id} uses resume-state format {found}; expected {RESUME_STATE_FORMAT_VERSION}"
+    )]
+    IncompatibleCheckpoint { session_id: String, found: u32 },
+    #[error("the session storage task stopped unexpectedly: {0}")]
+    StorageTask(#[source] tokio::task::JoinError),
 }
 
+#[cfg(test)]
 pub(crate) fn save_checkpoint(
     config_path: &Path,
     session_id: &str,
@@ -234,1769 +92,289 @@ pub(crate) fn save_checkpoint(
     instructions: &str,
     skills_catalog_present: bool,
 ) -> Result<(), SessionError> {
-    let directory = checkpoint_directory(config_path);
-    create_private_directory(&directory)?;
-    let path = checkpoint_path(config_path, session_id);
-    let temporary =
-        NamedTempFile::new_in(&directory).map_err(|source| SessionError::CreateCheckpoint {
-            path: directory.clone(),
-            source,
-        })?;
-    let file = temporary
-        .reopen()
-        .map_err(|source| SessionError::WriteCheckpoint {
-            path: path.clone(),
-            source,
-        })?;
-    let output = BufWriter::new(file);
-    let mut output = Encoder::new(output, COMPRESSION_LEVEL).map_err(|source| {
-        SessionError::WriteCheckpoint {
-            path: path.clone(),
-            source,
-        }
-    })?;
-    let checkpoint = CheckpointEnvelope {
-        format_version: CHECKPOINT_FORMAT_VERSION,
-        instructions,
+    let encoded = encode_checkpoint(snapshot, instructions, skills_catalog_present)?;
+    SessionStorage::open(config_path)?
+        .save_resume_state(session_id, &encoded)
+        .map_err(Into::into)
+}
+
+pub(crate) fn encode_checkpoint(
+    snapshot: &SessionSnapshot,
+    instructions: &str,
+    skills_catalog_present: bool,
+) -> Result<Vec<u8>, SessionError> {
+    let state = StoredResumeState {
+        format_version: RESUME_STATE_FORMAT_VERSION,
+        snapshot: snapshot.clone(),
+        instructions: instructions.to_owned(),
         skills_catalog_present,
-        snapshot,
     };
-    serde_json::to_writer(&mut output, &checkpoint).map_err(|source| {
-        SessionError::EncodeCheckpoint {
-            path: path.clone(),
-            source,
-        }
-    })?;
-    let mut output = output
-        .finish()
-        .map_err(|source| SessionError::WriteCheckpoint {
-            path: path.clone(),
-            source,
-        })?;
-    output
-        .flush()
-        .map_err(|source| SessionError::WriteCheckpoint {
-            path: path.clone(),
-            source,
-        })?;
-    output
-        .get_ref()
-        .sync_all()
-        .map_err(|source| SessionError::WriteCheckpoint {
-            path: path.clone(),
-            source,
-        })?;
-    drop(output);
-    temporary
-        .persist(&path)
-        .map_err(|source| SessionError::PersistCheckpoint { path, source })?;
-    remove_obsolete_checkpoint(config_path, session_id)?;
-    Ok(())
+    serde_json::to_vec(&state)
+        .map_err(StorageError::from)
+        .map_err(Into::into)
 }
 
 pub(crate) fn load_checkpoint(
     config_path: &Path,
     session_id: &str,
 ) -> Result<ResumeState, SessionError> {
-    let path = checkpoint_path(config_path, session_id);
-    let file = match File::open(&path) {
-        Ok(file) => file,
-        Err(source) if source.kind() == io::ErrorKind::NotFound => {
-            let obsolete_path = obsolete_checkpoint_path(config_path, session_id);
-            if remove_obsolete_checkpoint(config_path, session_id)? {
-                return Err(SessionError::ObsoleteCheckpointRemoved {
-                    path: obsolete_path,
-                });
-            }
-            return Err(SessionError::MissingCheckpoint {
-                session_id: session_id.to_owned(),
-            });
-        }
-        Err(source) => {
-            return Err(SessionError::ReadCheckpoint {
-                path: path.clone(),
-                source,
-            });
-        }
-    };
-    let decoder = Decoder::new(file).map_err(|source| SessionError::ReadCheckpoint {
-        path: path.clone(),
-        source,
-    })?;
-    let checkpoint = serde_json::from_reader::<_, StoredCheckpoint>(BufReader::new(decoder))
-        .map_err(|source| SessionError::DecodeCheckpoint {
-            path: path.clone(),
-            source,
+    let encoded = SessionStorage::open(config_path)?
+        .load_resume_state(session_id)?
+        .ok_or_else(|| SessionError::MissingCheckpoint {
+            session_id: session_id.to_owned(),
         })?;
-    if checkpoint.format_version != Some(CHECKPOINT_FORMAT_VERSION) {
-        return Err(SessionError::IncompatibleCheckpoint { path });
+    let stored =
+        serde_json::from_slice::<StoredResumeState>(&encoded).map_err(StorageError::from)?;
+    if stored.format_version != RESUME_STATE_FORMAT_VERSION {
+        return Err(SessionError::IncompatibleCheckpoint {
+            session_id: session_id.to_owned(),
+            found: stored.format_version,
+        });
     }
-    let (Some(snapshot), Some(instructions)) = (checkpoint.snapshot, checkpoint.instructions)
-    else {
-        return Err(SessionError::InvalidCheckpoint { path });
-    };
     Ok(ResumeState::new(
-        snapshot,
-        instructions,
-        checkpoint.skills_catalog_present,
+        stored.snapshot,
+        stored.instructions,
+        stored.skills_catalog_present,
     ))
 }
 
-#[allow(
-    dead_code,
-    reason = "used by compatibility tests and catalog benchmarks"
-)]
+#[allow(dead_code, reason = "used by session benchmarks")]
 pub(crate) fn list(
     config_path: &Path,
     workspace: &Path,
 ) -> Result<Vec<SessionSummary>, SessionError> {
-    remove_obsolete_checkpoints(config_path)?;
-    let segments = transcript_paths(config_path)?
+    SessionStorage::open(config_path)?
+        .list_sessions(workspace)?
         .into_iter()
-        .map(|path| load_catalog_segment(&path, workspace));
-    collect_catalog(config_path, workspace, segments)
+        .map(|session| {
+            Ok(SessionSummary {
+                session_id: session.session_id,
+                started_at_unix_ms: session.started_at_unix_ms,
+                model: session.model,
+                effort: session.effort,
+                reasoning_mode: session.reasoning_mode,
+                workspace: session.workspace,
+                preview: session.preview,
+            })
+        })
+        .collect()
 }
 
 pub(crate) async fn list_async(
     config_path: PathBuf,
     workspace: PathBuf,
 ) -> Result<Vec<SessionSummary>, SessionError> {
-    let (sender, receiver) = oneshot::channel();
-    transcript_loader().spawn(move || {
-        drop(sender.send(list_parallel_inner(&config_path, &workspace)));
-    });
-    receiver
+    tokio::task::spawn_blocking(move || list(&config_path, &workspace))
         .await
-        .map_err(|_| SessionError::TranscriptLoaderStopped)?
+        .map_err(SessionError::StorageTask)?
 }
 
 pub(crate) async fn load_recent_prompts_async(
     config_path: PathBuf,
-    excluded_session_id: Option<String>,
 ) -> Result<Vec<RecentPrompt>, SessionError> {
-    let (sender, receiver) = oneshot::channel();
-    transcript_loader().spawn(move || {
-        drop(sender.send(load_recent_prompts_parallel_inner(
-            &config_path,
-            excluded_session_id.as_deref(),
-        )));
-    });
-    receiver
-        .await
-        .map_err(|_| SessionError::TranscriptLoaderStopped)?
-}
-
-fn load_recent_prompts_parallel_inner(
-    config_path: &Path,
-    excluded_session_id: Option<&str>,
-) -> Result<Vec<RecentPrompt>, SessionError> {
-    let segments = transcript_paths(config_path)?
-        .into_par_iter()
-        .map(|path| load_recent_prompts_from_segment(&path, excluded_session_id))
-        .collect::<Vec<_>>()
-        .into_iter()
-        .collect::<Result<Vec<_>, SessionError>>()?;
-    let mut prompts = segments.into_iter().flatten().collect::<Vec<_>>();
-    prompts.sort_unstable_by(|left, right| {
-        right
-            .prompt
-            .recorded_at_unix_ms
-            .cmp(&left.prompt.recorded_at_unix_ms)
-            .then_with(|| right.transcript_filename.cmp(&left.transcript_filename))
-            .then_with(|| right.sequence.cmp(&left.sequence))
-    });
-    prompts.truncate(MAX_RECENT_PROMPTS);
-    Ok(prompts.into_iter().map(|loaded| loaded.prompt).collect())
-}
-
-fn load_recent_prompts_from_segment(
-    path: &Path,
-    excluded_session_id: Option<&str>,
-) -> Result<Vec<LoadedRecentPrompt>, SessionError> {
-    let _index_guard = lock_segment_index(path);
-    if let Some(index) = read_segment_index(path) {
-        if excluded_session_id == Some(index.summary.session_id.as_str()) {
-            return Ok(Vec::new());
-        }
-        return Ok(loaded_recent_prompts(path, index.prompts));
-    }
-    let source_fingerprint = transcript_fingerprint_entry(path)?;
-    let segment = transcript::load_matching_segment_filtered(
-        path,
-        |first| {
-            session_started_record(first)
-                .is_none_or(|started| excluded_session_id != Some(started.session_id.as_str()))
-        },
-        |record| {
-            record.source() == "tact"
-                && matches!(
-                    record.kind(),
-                    "session.started" | "user.submitted" | "user.steered" | "effort.changed"
-                )
-        },
-    )?;
-    let Some(segment) = segment else {
-        return Ok(Vec::new());
-    };
-    let Some(summary) = summarize_segment(&segment.records) else {
-        return Ok(Vec::new());
-    };
-    let prompts = recent_prompts(&segment.records, &summary);
-    write_segment_index_if_unchanged(path, &summary, &prompts, &source_fingerprint);
-    Ok(loaded_recent_prompts(path, prompts))
-}
-
-fn loaded_recent_prompts(path: &Path, prompts: Vec<StoredRecentPrompt>) -> Vec<LoadedRecentPrompt> {
-    let transcript_filename = path
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .into_owned();
-    prompts
-        .into_iter()
-        .map(|stored| LoadedRecentPrompt {
-            prompt: stored.prompt,
-            transcript_filename: transcript_filename.clone(),
-            sequence: stored.sequence,
-        })
-        .collect()
-}
-
-#[allow(dead_code, reason = "used by session catalog benchmarks")]
-pub(crate) fn list_parallel(
-    config_path: &Path,
-    workspace: &Path,
-) -> Result<Vec<SessionSummary>, SessionError> {
-    transcript_loader().install(|| list_parallel_inner(config_path, workspace))
-}
-
-fn list_parallel_inner(
-    config_path: &Path,
-    workspace: &Path,
-) -> Result<Vec<SessionSummary>, SessionError> {
-    remove_obsolete_checkpoints(config_path)?;
-    let segments = transcript_paths(config_path)?
-        .into_par_iter()
-        .map(|path| load_catalog_segment(&path, workspace))
-        .collect::<Vec<_>>();
-    collect_catalog(config_path, workspace, segments)
-}
-
-fn load_catalog_segment(
-    path: &Path,
-    workspace: &Path,
-) -> Result<Option<SessionSummary>, SessionError> {
-    let _index_guard = lock_segment_index(path);
-    if let Some(index) = read_segment_index(path) {
-        return Ok((index.summary.workspace == workspace).then_some(index.summary));
-    }
-    let segment = transcript::load_matching_segment_filtered(
-        path,
-        |first| session_started_record(first).is_none_or(|started| started.workspace == workspace),
-        |record| {
-            record.source() == "tact"
-                && matches!(
-                    record.kind(),
-                    "session.started" | "user.submitted" | "user.steered" | "effort.changed"
-                )
-        },
-    )?;
-    let Some(segment) = segment else {
-        return Ok(None);
-    };
-    let summary = summarize_segment(&segment.records);
-    if segment.complete
-        && let Some(summary) = &summary
-    {
-        let prompts = recent_prompts(&segment.records, summary);
-        write_segment_index(path, summary, &prompts);
-    }
-    Ok(summary.filter(|summary| summary.workspace == workspace))
-}
-
-fn collect_catalog(
-    config_path: &Path,
-    workspace: &Path,
-    segments: impl IntoIterator<Item = Result<Option<SessionSummary>, SessionError>>,
-) -> Result<Vec<SessionSummary>, SessionError> {
-    let mut sessions = HashMap::<String, SessionSummary>::new();
-    for segment in segments {
-        let Some(summary) = segment? else {
-            continue;
-        };
-        if summary.workspace != workspace {
-            continue;
-        }
-        if !has_checkpoint(config_path, &summary.session_id)? {
-            continue;
-        }
-        sessions
-            .entry(summary.session_id.clone())
-            .and_modify(|existing| {
-                if summary.started_at_unix_ms > existing.started_at_unix_ms {
-                    existing.started_at_unix_ms = summary.started_at_unix_ms;
-                    existing.effort = summary.effort;
-                    existing.reasoning_mode = summary.reasoning_mode;
-                }
-                if existing.preview == "No user prompt" {
-                    existing.preview.clone_from(&summary.preview);
-                }
+    tokio::task::spawn_blocking(move || {
+        let prompts = SessionStorage::open(&config_path)?.recent_prompts(MAX_RECENT_PROMPTS)?;
+        Ok(prompts
+            .into_iter()
+            .map(|prompt| RecentPrompt {
+                text: prompt.text,
+                recorded_at_unix_ms: prompt.recorded_at_unix_ms,
+                session_id: prompt.session_id,
+                workspace: prompt.workspace,
             })
-            .or_insert(summary);
-    }
-    let mut sessions = sessions.into_values().collect::<Vec<_>>();
-    sessions.sort_unstable_by_key(|session| std::cmp::Reverse(session.started_at_unix_ms));
-    Ok(sessions)
+            .collect())
+    })
+    .await
+    .map_err(SessionError::StorageTask)?
 }
 
-#[allow(
-    dead_code,
-    reason = "used by compatibility tests and restoration benchmarks"
-)]
+#[allow(dead_code, reason = "used by session benchmarks")]
 pub(crate) fn load_transcript(
     config_path: &Path,
     session_id: &str,
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
-    if let Some(records) = read_transcript_projection(config_path, session_id) {
-        return Ok(records);
-    }
-    let source_fingerprint = transcript_fingerprint(config_path)?;
-    let mut records = Vec::new();
-    let mut complete = true;
-    let mut observed_records = 0;
-    for path in transcript_paths(config_path)? {
-        let Some(segment) = load_session_segment(&path, session_id)? else {
-            continue;
-        };
-        complete &= segment.complete;
-        observed_records += segment.observed_records;
-        records.extend(segment.records);
-    }
-    if complete && observed_records > records.len() {
-        records = compact_projection_records(records);
-        if projection_cache_worthwhile(observed_records, records.len()) {
-            write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
-        }
-    }
-    Ok(records)
+    SessionStorage::open(config_path)?
+        .load_records(session_id)
+        .map_err(Into::into)
 }
 
 pub(crate) async fn load_transcript_async(
     config_path: PathBuf,
     session_id: String,
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
-    let (sender, receiver) = oneshot::channel();
-    transcript_loader().spawn(move || {
-        drop(sender.send(load_transcript_parallel_inner(&config_path, &session_id)));
-    });
-    receiver
+    tokio::task::spawn_blocking(move || load_transcript(&config_path, &session_id))
         .await
-        .map_err(|_| SessionError::TranscriptLoaderStopped)?
-}
-
-#[allow(dead_code, reason = "used by restoration benchmarks")]
-pub(crate) fn load_transcript_parallel(
-    config_path: &Path,
-    session_id: &str,
-) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
-    transcript_loader().install(|| load_transcript_parallel_inner(config_path, session_id))
-}
-
-fn load_transcript_parallel_inner(
-    config_path: &Path,
-    session_id: &str,
-) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
-    if let Some(records) = read_transcript_projection(config_path, session_id) {
-        return Ok(records);
-    }
-    let source_fingerprint = transcript_fingerprint(config_path)?;
-    let segments = transcript_paths(config_path)?
-        .into_par_iter()
-        .map(|path| load_session_segment(&path, session_id))
-        .collect::<Vec<_>>()
-        .into_iter()
-        .collect::<Result<Vec<_>, SessionError>>()?;
-    let mut records = Vec::new();
-    let mut complete = true;
-    let mut observed_records = 0;
-    for segment in segments.into_iter().flatten() {
-        complete &= segment.complete;
-        observed_records += segment.observed_records;
-        records.extend(segment.records);
-    }
-    if complete && observed_records > records.len() {
-        records = compact_projection_records(records);
-        if projection_cache_worthwhile(observed_records, records.len()) {
-            write_transcript_projection(config_path, session_id, &source_fingerprint, &records);
-        }
-    }
-    Ok(records)
-}
-
-fn load_session_segment(
-    path: &Path,
-    session_id: &str,
-) -> Result<Option<LoadedSessionSegment>, SessionError> {
-    let _index_guard = lock_segment_index(path);
-    if let Some(index) = read_segment_index(path)
-        && index.summary.session_id != session_id
-    {
-        return Ok(None);
-    }
-    let segment = transcript::load_matching_segment_filtered(
-        path,
-        |first| {
-            session_started_record(first).is_none_or(|started| started.session_id == session_id)
-        },
-        |record| api_event_projection(record) != ApiEventProjection::Discard,
-    )?;
-    let Some(segment) = segment else {
-        return Ok(None);
-    };
-    let matches =
-        session_started(&segment.records).is_some_and(|started| started.session_id == session_id);
-    if segment.complete
-        && let Some(summary) = summarize_segment(&segment.records)
-    {
-        let prompts = recent_prompts(&segment.records, &summary);
-        write_segment_index(path, &summary, &prompts);
-    }
-    Ok(matches.then_some(LoadedSessionSegment {
-        records: segment.records,
-        complete: segment.complete,
-        observed_records: segment.observed_records,
-    }))
-}
-
-fn transcript_loader() -> &'static rayon::ThreadPool {
-    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
-    POOL.get_or_init(|| {
-        let available = std::thread::available_parallelism().map_or(1, usize::from);
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(available.min(MAX_TRANSCRIPT_LOADER_THREADS))
-            .thread_name(|index| format!("tact-transcript-loader-{index}"))
-            .build()
-            .expect("the transcript loading thread pool should initialize")
-    })
-}
-
-#[allow(dead_code, reason = "used by session benchmarks")]
-pub(crate) fn initialize_transcript_loader() {
-    _ = transcript_loader();
-}
-
-pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-    let elapsed = now.saturating_sub(u128::from(started_at_unix_ms));
-    let minutes = elapsed / 60_000;
-    match minutes {
-        0 => "just now".to_owned(),
-        1..=59 => format!("{minutes}m ago"),
-        60..=1_439 => format!("{}h ago", minutes / 60),
-        _ => format!("{}d ago", minutes / 1_440),
-    }
-}
-
-fn transcript_paths(config_path: &Path) -> Result<Vec<PathBuf>, SessionError> {
-    transcript::remove_obsolete(config_path)?;
-    let directory = transcript::storage_directory(config_path);
-    let entries = match fs::read_dir(&directory) {
-        Ok(entries) => entries,
-        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(source) => {
-            return Err(SessionError::ReadDirectory {
-                path: directory,
-                source,
-            });
-        }
-    };
-    let mut paths = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .filter(|path| path.extension().is_some_and(|extension| extension == "zst"))
-        .collect::<Vec<_>>();
-    paths.sort_unstable();
-    Ok(paths)
-}
-
-fn session_started(records: &[Arc<TranscriptRecord>]) -> Option<SessionStarted> {
-    let record = records
-        .iter()
-        .find(|record| record.source() == "tact" && record.kind() == "session.started")?;
-    session_started_record(record)
-}
-
-fn session_started_record(record: &TranscriptRecord) -> Option<SessionStarted> {
-    (record.source() == "tact" && record.kind() == "session.started")
-        .then(|| record.decode_payload().ok())?
+        .map_err(SessionError::StorageTask)?
 }
 
 pub(crate) fn reasoning_mode(records: &[Arc<TranscriptRecord>]) -> ReasoningMode {
-    session_started(records).map_or(ReasoningMode::Standard, |started| started.reasoning_mode)
-}
-
-fn latest_effort(records: &[Arc<TranscriptRecord>], initial: ReasoningEffort) -> ReasoningEffort {
-    #[derive(serde::Deserialize)]
-    struct EffortChanged {
-        to: ReasoningEffort,
-    }
-
     records
         .iter()
-        .filter(|record| record.source() == "tact" && record.kind() == "effort.changed")
-        .filter_map(|record| record.decode_payload::<EffortChanged>().ok())
-        .fold(initial, |_, change| change.to)
+        .find(|record| record.source() == "tact" && record.kind() == "session.started")
+        .and_then(|record| record.decode_payload::<SessionStarted>().ok())
+        .map_or(ReasoningMode::Standard, |started| started.reasoning_mode)
 }
 
-fn first_user_message(records: &[Arc<TranscriptRecord>]) -> Option<String> {
-    #[derive(serde::Deserialize)]
-    struct UserSubmitted {
-        text: String,
+pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let started = Duration::from_millis(started_at_unix_ms);
+    let elapsed = now.saturating_sub(started);
+    let seconds = elapsed.as_secs();
+    match seconds {
+        0..=59 => "now".to_owned(),
+        60..=3_599 => format!("{}m", seconds / 60),
+        3_600..=86_399 => format!("{}h", seconds / 3_600),
+        _ => format!("{}d", seconds / 86_400),
     }
-
-    records
-        .iter()
-        .find(|record| record.source() == "tact" && record.kind() == "user.submitted")
-        .and_then(|record| record.decode_payload::<UserSubmitted>().ok())
-        .map(|payload| {
-            payload
-                .text
-                .split_whitespace()
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .filter(|preview| !preview.is_empty())
-}
-
-fn summarize_segment(records: &[Arc<TranscriptRecord>]) -> Option<SessionSummary> {
-    let started = session_started(records)?;
-    Some(SessionSummary {
-        session_id: started.session_id,
-        started_at_unix_ms: records
-            .first()
-            .map_or(0, |record| record.recorded_at_unix_ms()),
-        model: started.model,
-        effort: latest_effort(records, started.effort),
-        reasoning_mode: started.reasoning_mode,
-        workspace: started.workspace,
-        preview: first_user_message(records).unwrap_or_else(|| "No user prompt".to_owned()),
-    })
-}
-
-fn recent_prompts(
-    records: &[Arc<TranscriptRecord>],
-    summary: &SessionSummary,
-) -> Vec<StoredRecentPrompt> {
-    #[derive(Deserialize)]
-    struct UserPrompt {
-        text: String,
-    }
-
-    let mut prompts = records
-        .iter()
-        .filter(|record| {
-            record.source() == "tact" && matches!(record.kind(), "user.submitted" | "user.steered")
-        })
-        .filter_map(|record| {
-            let payload = record.decode_payload::<UserPrompt>().ok()?;
-            Some(StoredRecentPrompt {
-                prompt: RecentPrompt {
-                    text: payload.text,
-                    recorded_at_unix_ms: record.recorded_at_unix_ms(),
-                    session_id: summary.session_id.clone(),
-                    workspace: summary.workspace.clone(),
-                },
-                sequence: record.sequence(),
-            })
-        })
-        .collect::<Vec<_>>();
-    let obsolete = prompts.len().saturating_sub(MAX_RECENT_PROMPTS);
-    prompts.drain(..obsolete);
-    prompts
-}
-
-fn read_segment_index(transcript_path: &Path) -> Option<SegmentIndex> {
-    let metadata = fs::metadata(transcript_path).ok()?;
-    let stored = serde_json::from_slice::<StoredSegmentSummary>(
-        &fs::read(segment_summary_path(transcript_path)).ok()?,
-    )
-    .ok()?;
-    (stored.format_version == SEGMENT_SUMMARY_FORMAT_VERSION
-        && stored.transcript_filename == transcript_path.file_name()?.to_string_lossy().as_ref()
-        && stored.transcript_bytes == metadata.len()
-        && stored.transcript_modified_unix_ns == modified_unix_ns(&metadata))
-    .then_some(SegmentIndex {
-        summary: stored.summary,
-        prompts: stored.prompts,
-    })
-}
-
-fn lock_segment_index(path: &Path) -> MutexGuard<'static, ()> {
-    const LOCK_COUNT: usize = 64;
-    static LOCKS: OnceLock<Box<[Mutex<()>]>> = OnceLock::new();
-    let locks = LOCKS.get_or_init(|| {
-        (0..LOCK_COUNT)
-            .map(|_| Mutex::new(()))
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
-    });
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    path.hash(&mut hasher);
-    let index = usize::try_from(hasher.finish()).unwrap_or(0) % locks.len();
-    locks[index]
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
-fn write_segment_index(
-    transcript_path: &Path,
-    summary: &SessionSummary,
-    prompts: &[StoredRecentPrompt],
-) {
-    let Ok(source_fingerprint) = transcript_fingerprint_entry(transcript_path) else {
-        return;
-    };
-    write_segment_index_if_unchanged(transcript_path, summary, prompts, &source_fingerprint);
-}
-
-fn write_segment_index_if_unchanged(
-    transcript_path: &Path,
-    summary: &SessionSummary,
-    prompts: &[StoredRecentPrompt],
-    source_fingerprint: &TranscriptFingerprint,
-) {
-    let Some(directory) = transcript_path.parent() else {
-        return;
-    };
-    let stored = StoredSegmentSummary {
-        format_version: SEGMENT_SUMMARY_FORMAT_VERSION,
-        transcript_filename: source_fingerprint.filename.clone(),
-        transcript_bytes: source_fingerprint.bytes,
-        transcript_modified_unix_ns: source_fingerprint.modified_unix_ns,
-        summary: summary.clone(),
-        prompts: prompts.to_vec(),
-    };
-    let Ok(encoded) = serde_json::to_vec(&stored) else {
-        return;
-    };
-    let Ok(mut temporary) = NamedTempFile::new_in(directory) else {
-        return;
-    };
-    if temporary.write_all(&encoded).is_err() {
-        return;
-    }
-    if transcript_fingerprint_entry(transcript_path).ok().as_ref() != Some(source_fingerprint) {
-        return;
-    }
-    let cache_path = segment_summary_path(transcript_path);
-    if temporary.persist(&cache_path).is_err() {
-        return;
-    }
-    if transcript_fingerprint_entry(transcript_path).ok().as_ref() != Some(source_fingerprint) {
-        drop(fs::remove_file(cache_path));
-    }
-}
-
-fn segment_summary_path(transcript_path: &Path) -> PathBuf {
-    transcript_path.with_extension("summary.json")
-}
-
-fn compact_projection_records(records: Vec<Arc<TranscriptRecord>>) -> Vec<Arc<TranscriptRecord>> {
-    let records = discard_completed_assistant_deltas(records);
-    let latest_outbound = records
-        .iter()
-        .rposition(|record| api_event_projection(record) == ApiEventProjection::LatestOutbound);
-    records
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, record)| match api_event_projection(&record) {
-            ApiEventProjection::Discard => None,
-            ApiEventProjection::Retain => Some(record),
-            ApiEventProjection::LatestOutbound if Some(index) == latest_outbound => {
-                let (prompt_cache, previous_response) = outbound_context_snapshot(&record)?;
-                TranscriptRecord::from_local(
-                    record.sequence(),
-                    record.recorded_at_unix_ms(),
-                    LocalEvent::ContextObserved {
-                        prompt_cache,
-                        previous_response,
-                    },
-                )
-                .ok()
-                .map(Arc::new)
-            }
-            ApiEventProjection::LatestOutbound => None,
-        })
-        .collect()
-}
-
-fn projection_cache_worthwhile(observed_records: usize, projected_records: usize) -> bool {
-    observed_records > 0 && projected_records.saturating_mul(2) <= observed_records
-}
-
-fn discard_completed_assistant_deltas(
-    records: Vec<Arc<TranscriptRecord>>,
-) -> Vec<Arc<TranscriptRecord>> {
-    let mut completed_messages = HashSet::new();
-    let mut compacted = Vec::with_capacity(records.len());
-    for record in records.into_iter().rev() {
-        match record.kind() {
-            "assistant.message" => {
-                if let Some(key) = assistant_message_key(&record) {
-                    completed_messages.insert(key);
-                }
-                compacted.push(record);
-            }
-            "assistant.delta" => {
-                let completed = assistant_message_key(&record)
-                    .is_some_and(|key| completed_messages.contains(&key));
-                if !completed {
-                    compacted.push(record);
-                }
-            }
-            _ => compacted.push(record),
-        }
-    }
-    compacted.reverse();
-    compacted
-}
-
-fn assistant_message_key(record: &TranscriptRecord) -> Option<AssistantMessageKey> {
-    let payload = record.decode_payload::<AssistantMessageIdentity>().ok()?;
-    Some(AssistantMessageKey {
-        model_call_index: payload.model_call_index,
-        item_id: payload.item_id,
-        commentary: payload.phase.as_deref() == Some("commentary"),
-    })
-}
-
-#[derive(Eq, Hash, PartialEq)]
-struct AssistantMessageKey {
-    model_call_index: u32,
-    item_id: Option<String>,
-    commentary: bool,
-}
-
-#[derive(Deserialize)]
-struct AssistantMessageIdentity {
-    model_call_index: u32,
-    item_id: Option<String>,
-    phase: Option<String>,
-}
-
-fn read_transcript_projection(
-    config_path: &Path,
-    session_id: &str,
-) -> Option<Vec<Arc<TranscriptRecord>>> {
-    let path = transcript_projection_path(config_path, session_id);
-    let decoder = Decoder::new(File::open(path).ok()?).ok()?;
-    let stored =
-        serde_json::from_reader::<_, StoredTranscriptProjection>(BufReader::new(decoder)).ok()?;
-    if stored.format_version != PROJECTION_FORMAT_VERSION {
-        return None;
-    }
-    if stored.session_id != session_id {
-        return None;
-    }
-    let fingerprint = transcript_fingerprint(config_path).ok()?;
-    (stored.transcript_fingerprint == fingerprint).then_some(stored.records)
-}
-
-fn write_transcript_projection(
-    config_path: &Path,
-    session_id: &str,
-    source_fingerprint: &[TranscriptFingerprint],
-    records: &[Arc<TranscriptRecord>],
-) {
-    let _ = try_write_transcript_projection(config_path, session_id, source_fingerprint, records);
-}
-
-fn try_write_transcript_projection(
-    config_path: &Path,
-    session_id: &str,
-    source_fingerprint: &[TranscriptFingerprint],
-    records: &[Arc<TranscriptRecord>],
-) -> Option<()> {
-    let directory = transcript_projection_directory(config_path);
-    create_private_directory(&directory).ok()?;
-    let path = transcript_projection_path(config_path, session_id);
-    let mut temporary = NamedTempFile::new_in(&directory).ok()?;
-    {
-        let mut output = Encoder::new(&mut temporary, COMPRESSION_LEVEL).ok()?;
-        serde_json::to_writer(
-            &mut output,
-            &TranscriptProjectionEnvelope {
-                format_version: PROJECTION_FORMAT_VERSION,
-                session_id,
-                transcript_fingerprint: source_fingerprint,
-                records,
-            },
-        )
-        .ok()?;
-        output.finish().ok()?;
-    }
-    temporary.flush().ok()?;
-    if transcript_fingerprint(config_path).ok()?.as_slice() != source_fingerprint {
-        return None;
-    }
-    temporary.persist(path).ok()?;
-    Some(())
-}
-
-fn transcript_fingerprint(config_path: &Path) -> Result<Vec<TranscriptFingerprint>, SessionError> {
-    transcript_paths(config_path)?
-        .into_iter()
-        .map(|path| transcript_fingerprint_entry(&path))
-        .collect()
-}
-
-fn transcript_fingerprint_entry(path: &Path) -> Result<TranscriptFingerprint, SessionError> {
-    let metadata = fs::metadata(path).map_err(|source| SessionError::ReadDirectory {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    Ok(TranscriptFingerprint {
-        filename: path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .into_owned(),
-        bytes: metadata.len(),
-        modified_unix_ns: modified_unix_ns(&metadata),
-    })
-}
-
-fn modified_unix_ns(metadata: &fs::Metadata) -> u128 {
-    metadata
-        .modified()
-        .unwrap_or(UNIX_EPOCH)
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos()
-}
-
-fn transcript_projection_directory(config_path: &Path) -> PathBuf {
-    data_directory(config_path).join("transcript-projections/v1")
-}
-
-fn transcript_projection_path(config_path: &Path, session_id: &str) -> PathBuf {
-    transcript_projection_directory(config_path)
-        .join(format!("{}.json.zst", encode_filename(session_id)))
-}
-
-fn checkpoint_directory(config_path: &Path) -> PathBuf {
-    checkpoint_root(config_path).join(format!("v{CHECKPOINT_FORMAT_VERSION}"))
-}
-
-fn checkpoint_path(config_path: &Path, session_id: &str) -> PathBuf {
-    checkpoint_directory(config_path).join(format!("{}.json.zst", encode_filename(session_id)))
-}
-
-fn checkpoint_root(config_path: &Path) -> PathBuf {
-    data_directory(config_path).join("checkpoints")
-}
-
-fn obsolete_checkpoint_path(config_path: &Path, session_id: &str) -> PathBuf {
-    checkpoint_root(config_path).join(format!("{}.json.zst", encode_filename(session_id)))
-}
-
-fn remove_obsolete_checkpoint(config_path: &Path, session_id: &str) -> Result<bool, SessionError> {
-    let path = obsolete_checkpoint_path(config_path, session_id);
-    match fs::remove_file(&path) {
-        Ok(()) => Ok(true),
-        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(source) => Err(SessionError::RemoveObsoleteCheckpoint { path, source }),
-    }
-}
-
-pub(super) fn remove_obsolete_checkpoints(config_path: &Path) -> Result<(), SessionError> {
-    let directory = checkpoint_root(config_path);
-    let entries = match fs::read_dir(&directory) {
-        Ok(entries) => entries,
-        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(source) => {
-            return Err(SessionError::ReadDirectory {
-                path: directory,
-                source,
-            });
-        }
-    };
-    for entry in entries {
-        let entry = entry.map_err(|source| SessionError::ReadDirectory {
-            path: directory.clone(),
-            source,
-        })?;
-        let file_type = entry
-            .file_type()
-            .map_err(|source| SessionError::ReadDirectory {
-                path: directory.clone(),
-                source,
-            })?;
-        if !file_type.is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if !is_unversioned_checkpoint(&path) {
-            continue;
-        }
-        match fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(source) if source.kind() == io::ErrorKind::NotFound => {}
-            Err(source) => {
-                return Err(SessionError::RemoveObsoleteCheckpoint { path, source });
-            }
-        }
-    }
-    Ok(())
-}
-
-fn is_unversioned_checkpoint(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    let Some(session_id) = name.strip_suffix(".json.zst") else {
-        return false;
-    };
-    !session_id.is_empty()
-        && session_id.len() % 2 == 0
-        && session_id.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn has_checkpoint(config_path: &Path, session_id: &str) -> Result<bool, SessionError> {
-    let path = checkpoint_path(config_path, session_id);
-    match fs::metadata(&path) {
-        Ok(metadata) => Ok(metadata.is_file()),
-        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(source) => Err(SessionError::ReadCheckpoint { path, source }),
-    }
-}
-
-fn data_directory(config_path: &Path) -> &Path {
-    config_path.parent().unwrap_or_else(|| Path::new("."))
-}
-
-fn encode_filename(value: &str) -> String {
-    use std::fmt::Write as _;
-    let mut encoded = String::with_capacity(value.len() * 2);
-    for byte in value.as_bytes() {
-        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
-    }
-    encoded
-}
-
-fn create_private_directory(path: &Path) -> Result<(), SessionError> {
-    let mut builder = fs::DirBuilder::new();
-    builder.recursive(true);
-    #[cfg(unix)]
-    builder.mode(0o700);
-    builder
-        .create(path)
-        .map_err(|source| SessionError::CreateDirectory {
-            path: path.to_path_buf(),
-            source,
-        })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        encode_filename, format_age, initialize_transcript_loader, list, list_async,
-        load_checkpoint, load_recent_prompts_async, load_transcript, load_transcript_async,
-        obsolete_checkpoint_path, save_checkpoint, segment_summary_path, transcript_fingerprint,
-        transcript_loader, transcript_paths, transcript_projection_path,
-        write_transcript_projection,
-    };
+    use super::{encode_checkpoint, load_checkpoint, save_checkpoint};
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::transcript::{LocalEvent, SessionStarted, TranscriptJournal, TurnId},
     };
-    use nanocodex::agent::{
-        events::{AgentEvent, AgentEventKind},
-        session::SessionSnapshot,
-    };
-    use serde_json::{Value, json, value::to_raw_value};
-    use std::{fs, io::Write, path::Path, sync::Arc};
+    use nanocodex::agent::session::SessionSnapshot;
+    use serde_json::{Value, json};
     use tempfile::tempdir;
-    use zstd::stream::write::Encoder;
 
     fn snapshot(lineage: &str) -> SessionSnapshot {
         serde_json::from_value(json!({
             "version": 1,
             "model": nanocodex::oai::MODEL,
             "lineage_id": lineage,
-            "prompt_cache_key": "test-cache-key",
+            "prompt_cache_key": format!("cache-{lineage}"),
             "workspace": "/work",
             "request_prefix": [
                 {"type": "additional_tools", "role": "developer", "tools": []},
                 {"type": "message", "role": "developer", "content": []}
             ],
             "canonical_context": {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "hello"}]
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "canonical"}]
             },
-            "history": [{
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "hello"}]
-            }]
+            "history": [
+                {"type": "message", "role": "user",
+                 "content": [{"type": "input_text", "text": "hello"}]}
+            ]
         }))
         .unwrap()
     }
 
     #[test]
-    fn initializes_transcript_loader_before_parallel_work() {
-        initialize_transcript_loader();
+    fn resume_state_round_trips_the_opaque_nanocodex_snapshot() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let expected = snapshot("lineage");
+        save_checkpoint(&config, "session", &expected, "exact instructions", true).unwrap();
 
-        assert!(transcript_loader().current_num_threads() > 0);
+        let restored = load_checkpoint(&config, "session").unwrap();
+        let (actual, instructions, catalog) = restored.into_parts();
+
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+        assert_eq!(instructions, "exact instructions");
+        assert_eq!(catalog, Some(true));
+        assert!(directory.path().join("sessions/v2.sqlite3").is_file());
+        assert!(!directory.path().join("checkpoints").exists());
     }
 
-    async fn write_minimal_session(config: &Path, session_id: &str) {
-        let (mut journal, writer) = TranscriptJournal::open(config, session_id).unwrap();
-        journal
-            .append_local(LocalEvent::SessionStarted(SessionStarted {
-                session_id: session_id.to_owned(),
-                parent_session_id: None,
-                model: "model".to_owned(),
-                effort: ReasoningEffort::Medium,
-                reasoning_mode: ReasoningMode::Standard,
-                fast_mode: false,
-                workspace: "/work".into(),
-                application_version: "test".to_owned(),
-            }))
-            .unwrap();
-        drop(journal);
-        writer.into_task().await.unwrap().unwrap();
+    #[test]
+    fn newer_successful_snapshot_atomically_replaces_the_previous_state() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        save_checkpoint(&config, "session", &snapshot("first"), "first", false).unwrap();
+        save_checkpoint(&config, "session", &snapshot("second"), "second", true).unwrap();
+
+        let restored = load_checkpoint(&config, "session").unwrap();
+        let (snapshot, instructions, catalog) = restored.into_parts();
+        let snapshot = serde_json::to_value(snapshot).unwrap();
+
+        assert_eq!(snapshot["lineage_id"], Value::String("second".to_owned()));
+        assert_eq!(instructions, "second");
+        assert_eq!(catalog, Some(true));
     }
 
-    fn started(session_id: &str, workspace: &str) -> LocalEvent {
-        LocalEvent::SessionStarted(SessionStarted {
-            session_id: session_id.to_owned(),
+    #[tokio::test]
+    async fn failed_turn_tail_does_not_replace_the_last_successful_snapshot() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let expected = snapshot("successful");
+        save_checkpoint(&config, "session", &expected, "instructions", true).unwrap();
+
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal.defer_start(SessionStarted {
+            session_id: "session".to_owned(),
             parent_session_id: None,
-            model: "model".to_owned(),
+            model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
-            workspace: workspace.into(),
+            workspace: "/work".into(),
             application_version: "test".to_owned(),
-        })
-    }
-
-    fn write_segment(
-        config: &Path,
-        filename: &str,
-        events: impl IntoIterator<Item = (u64, LocalEvent)>,
-    ) -> std::path::PathBuf {
-        let directory = crate::tui::transcript::storage_directory(config);
-        fs::create_dir_all(&directory).unwrap();
-        let path = directory.join(filename);
-        let file = fs::File::create(&path).unwrap();
-        let mut output = Encoder::new(file, 3).unwrap();
-        for (index, (recorded_at_unix_ms, event)) in events.into_iter().enumerate() {
-            let record = crate::tui::transcript::TranscriptRecord::from_local(
-                u64::try_from(index + 1).unwrap(),
-                recorded_at_unix_ms,
-                event,
-            )
+        });
+        journal
+            .append_local(LocalEvent::WorkerTurnFinished {
+                id: TurnId::new(2),
+                error: Some("API failed".to_owned()),
+            })
             .unwrap();
-            serde_json::to_writer(&mut output, &record).unwrap();
-            output.write_all(b"\n").unwrap();
-        }
-        output.finish().unwrap();
-        path
-    }
-
-    fn write_projection_cache(config: &Path, session_id: &str) {
-        let records = load_transcript(config, session_id).unwrap();
-        let source_fingerprint = transcript_fingerprint(config).unwrap();
-        write_transcript_projection(config, session_id, &source_fingerprint, &records);
-    }
-
-    #[test]
-    fn checkpoint_filenames_are_distinct_and_path_safe() {
-        assert_eq!(encode_filename("a/b"), "612f62");
-        assert_ne!(encode_filename("a/b"), encode_filename("a_b"));
-    }
-
-    #[test]
-    fn nanocodex_0_2_snapshot_shape_remains_compatible() {
-        let snapshot = serde_json::to_value(snapshot("legacy-lineage")).unwrap();
-
-        assert_eq!(snapshot["version"], 1);
-        assert_eq!(snapshot["lineage_id"], "legacy-lineage");
-        assert!(snapshot.get("base_instructions").is_none());
-        assert!(snapshot.get("context_snapshot").is_none());
-    }
-
-    #[test]
-    fn age_is_human_readable() {
-        assert!(!format_age(0).is_empty());
-    }
-
-    #[test]
-    fn checkpoint_is_compressed_and_atomically_replaced() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let obsolete = obsolete_checkpoint_path(&config, "session");
-        std::fs::create_dir_all(obsolete.parent().unwrap()).unwrap();
-        std::fs::write(&obsolete, b"obsolete checkpoint").unwrap();
-        save_checkpoint(
-            &config,
-            "session",
-            &snapshot("first"),
-            "first instructions",
-            false,
-        )
-        .unwrap();
-        save_checkpoint(
-            &config,
-            "session",
-            &snapshot("second"),
-            "second instructions",
-            true,
-        )
-        .unwrap();
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
 
         let restored = load_checkpoint(&config, "session").unwrap();
-        let (restored, instructions, skills_catalog_present) = restored.into_parts();
-        let restored = serde_json::to_value(restored).unwrap();
-        assert_eq!(restored["lineage_id"], Value::String("second".to_owned()));
-        assert_eq!(instructions, "second instructions");
-        assert_eq!(skills_catalog_present, Some(true));
-        assert!(!obsolete.exists());
-        let checkpoints = std::fs::read_dir(directory.path().join("checkpoints/v1"))
-            .unwrap()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-        assert_eq!(checkpoints.len(), 1);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mode = checkpoints[0].metadata().unwrap().permissions().mode() & 0o777;
-            assert_eq!(mode, 0o600);
-        }
+        let (actual, _, _) = restored.into_parts();
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+        let records = super::load_transcript(&config, "session").unwrap();
+        assert_eq!(records.last().unwrap().kind(), "worker.turn_finished");
     }
 
     #[tokio::test]
-    async fn catalog_only_includes_sessions_from_the_requested_workspace() {
+    async fn successful_turn_publishes_its_tail_and_snapshot_together() {
         let directory = tempdir().unwrap();
         let config = directory.path().join("config.toml");
-        let (mut journal, writer) = TranscriptJournal::open(&config, "session/one").unwrap();
-        journal
-            .append_local(LocalEvent::SessionStarted(SessionStarted {
-                session_id: "session/one".to_owned(),
-                parent_session_id: None,
-                model: "model".to_owned(),
-                effort: ReasoningEffort::High,
-                reasoning_mode: ReasoningMode::Pro,
-                fast_mode: false,
-                workspace: "/work".into(),
-                application_version: "test".to_owned(),
-            }))
-            .unwrap();
-        journal
-            .append_local(LocalEvent::UserSubmitted {
-                id: TurnId::new(1),
-                text: "  inspect\n the workspace  ".to_owned(),
-            })
-            .unwrap();
-        journal
-            .append_local(LocalEvent::EffortChanged {
-                from: ReasoningEffort::High,
-                to: ReasoningEffort::Low,
-            })
-            .unwrap();
-        drop(journal);
-        writer.into_task().await.unwrap().unwrap();
-        save_checkpoint(
-            &config,
-            "session/one",
-            &snapshot("lineage"),
-            "instructions",
-            false,
-        )
-        .unwrap();
-
-        let (mut journal, writer) = TranscriptJournal::open(&config, "other-session").unwrap();
-        journal
-            .append_local(LocalEvent::SessionStarted(SessionStarted {
-                session_id: "other-session".to_owned(),
-                parent_session_id: None,
-                model: "model".to_owned(),
-                effort: ReasoningEffort::Medium,
-                reasoning_mode: ReasoningMode::Standard,
-                fast_mode: false,
-                workspace: "/other-workspace".into(),
-                application_version: "test".to_owned(),
-            }))
-            .unwrap();
-        drop(journal);
-        writer.into_task().await.unwrap().unwrap();
-        save_checkpoint(
-            &config,
-            "other-session",
-            &snapshot("other-lineage"),
-            "instructions",
-            false,
-        )
-        .unwrap();
-
-        let sessions = list(&config, Path::new("/work")).unwrap();
-        assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].session_id, "session/one");
-        assert_eq!(sessions[0].preview, "inspect the workspace");
-        assert_eq!(sessions[0].effort, ReasoningEffort::Low);
-        assert_eq!(sessions[0].reasoning_mode, ReasoningMode::Pro);
-        let summaries = fs::read_dir(directory.path().join("transcripts/v1"))
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .filter(|path| path.to_string_lossy().ends_with(".summary.json"))
-            .collect::<Vec<_>>();
-        assert_eq!(summaries.len(), 1);
-        fs::write(&summaries[0], b"invalid cache").unwrap();
-        let async_sessions = list_async(config.clone(), Path::new("/work").to_path_buf())
-            .await
-            .unwrap();
-        assert_eq!(async_sessions.len(), 1);
-        assert_eq!(async_sessions[0].session_id, "session/one");
-        assert_eq!(load_transcript(&config, "session/one").unwrap().len(), 3);
-        let loaded = load_transcript_async(config.clone(), "session/one".to_owned())
-            .await
-            .unwrap();
-        assert_eq!(loaded.len(), 3);
-        assert_eq!(loaded[0].kind(), "session.started");
-        assert_eq!(loaded[2].kind(), "effort.changed");
-    }
-
-    #[tokio::test]
-    async fn projection_cache_discards_streaming_api_events_and_recovers_from_corruption() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
+        let expected = snapshot("successful");
+        let resume_state = encode_checkpoint(&expected, "instructions", true).unwrap();
         let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal.defer_start(SessionStarted {
+            session_id: "session".to_owned(),
+            parent_session_id: None,
+            model: nanocodex::oai::MODEL.to_owned(),
+            effort: ReasoningEffort::Medium,
+            reasoning_mode: ReasoningMode::Standard,
+            fast_mode: false,
+            workspace: "/work".into(),
+            application_version: "test".to_owned(),
+        });
         journal
-            .append_local(LocalEvent::SessionStarted(SessionStarted {
-                session_id: "session".to_owned(),
-                parent_session_id: None,
-                model: "model".to_owned(),
-                effort: ReasoningEffort::Medium,
-                reasoning_mode: ReasoningMode::Standard,
-                fast_mode: false,
-                workspace: "/work".into(),
-                application_version: "test".to_owned(),
-            }))
-            .unwrap();
-        for (sequence, payload) in [
-            json!({
-                "direction": "outbound",
-                "phase": "generation",
-                "event": {"prompt_cache_key": "first"}
-            }),
-            json!({
-                "direction": "inbound",
-                "phase": "generation",
-                "event": {"type": "response.output_text.delta", "delta": "discard me"}
-            }),
-            json!({
-                "direction": "outbound",
-                "phase": "generation",
-                "event": {
-                    "prompt_cache_key": "latest-secret-key",
-                    "previous_response_id": "secret-response-id"
-                }
-            }),
-            json!({
-                "direction": "inbound",
-                "phase": "generation",
-                "event": {
-                    "type": "response.completed",
-                    "response": {"usage": {"total_tokens": 42}}
-                }
-            }),
-        ]
-        .into_iter()
-        .enumerate()
-        {
-            journal
-                .append_agent(AgentEvent {
-                    protocol_version: 1,
-                    request_id: Arc::from("request"),
-                    seq: u64::try_from(sequence).unwrap(),
-                    kind: AgentEventKind::ApiEvent,
-                    payload: to_raw_value(&payload).unwrap().into(),
-                })
-                .unwrap();
-        }
-        for (sequence, kind, payload) in [
-            (
-                4,
-                AgentEventKind::AssistantDelta,
-                json!({
-                    "model_call_index": 1,
-                    "item_id": "message",
-                    "phase": "final_answer",
-                    "text": "partial"
-                }),
-            ),
-            (
-                5,
-                AgentEventKind::AssistantDelta,
-                json!({
-                    "model_call_index": 1,
-                    "item_id": "message",
-                    "phase": "final_answer",
-                    "text": " response"
-                }),
-            ),
-            (
-                6,
-                AgentEventKind::AssistantMessage,
-                json!({
-                    "model_call_index": 1,
-                    "item_id": "message",
-                    "phase": "final_answer",
-                    "text": "complete response"
-                }),
-            ),
-        ] {
-            journal
-                .append_agent(AgentEvent {
-                    protocol_version: 1,
-                    request_id: Arc::from("request"),
-                    seq: sequence,
-                    kind,
-                    payload: to_raw_value(&payload).unwrap().into(),
-                })
-                .unwrap();
-        }
-        drop(journal);
-        writer.into_task().await.unwrap().unwrap();
-
-        let projected = load_transcript(&config, "session").unwrap();
-        assert_eq!(projected.len(), 4);
-        assert_eq!(
-            projected
-                .iter()
-                .filter(|record| record.kind() == "api.event")
-                .count(),
-            1
-        );
-        assert_eq!(
-            projected
-                .iter()
-                .filter(|record| record.kind() == "assistant.delta")
-                .count(),
-            0
-        );
-        assert_eq!(
-            projected
-                .iter()
-                .filter(|record| record.kind() == "assistant.message")
-                .count(),
-            1
-        );
-
-        let cache = transcript_projection_path(&config, "session");
-        assert!(cache.is_file());
-        let cached = load_transcript(&config, "session").unwrap();
-        assert_eq!(cached.len(), projected.len());
-        assert!(!format!("{cached:?}").contains("latest-secret-key"));
-        assert!(!format!("{cached:?}").contains("secret-response-id"));
-
-        fs::write(&cache, b"invalid cache").unwrap();
-        let recovered = load_transcript(&config, "session").unwrap();
-        assert_eq!(recovered.len(), projected.len());
-        assert!(fs::metadata(cache).unwrap().len() > b"invalid cache".len() as u64);
-    }
-
-    #[tokio::test]
-    async fn visible_transcript_does_not_create_projection_cache() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
-        journal
-            .append_local(LocalEvent::SessionStarted(SessionStarted {
-                session_id: "session".to_owned(),
-                parent_session_id: None,
-                model: "model".to_owned(),
-                effort: ReasoningEffort::Medium,
-                reasoning_mode: ReasoningMode::Standard,
-                fast_mode: false,
-                workspace: "/work".into(),
-                application_version: "test".to_owned(),
-            }))
-            .unwrap();
-        journal
-            .append_local(LocalEvent::UserSubmitted {
-                id: TurnId::new(1),
-                text: "inspect the workspace".to_owned(),
-            })
-            .unwrap();
-        for (sequence, kind, payload) in [
-            (0, AgentEventKind::RunStarted, json!({})),
-            (
-                1,
-                AgentEventKind::AssistantDelta,
-                json!({
-                    "model_call_index": 1,
-                    "item_id": "message",
-                    "phase": "final_answer",
-                    "text": "partial response"
-                }),
-            ),
-            (
-                2,
-                AgentEventKind::AssistantMessage,
-                json!({
-                    "model_call_index": 1,
-                    "item_id": "message",
-                    "phase": "final_answer",
-                    "text": "complete response"
-                }),
-            ),
-            (3, AgentEventKind::RunCompleted, json!({})),
-        ] {
-            journal
-                .append_agent(AgentEvent {
-                    protocol_version: 1,
-                    request_id: Arc::from("request"),
-                    seq: sequence,
-                    kind,
-                    payload: to_raw_value(&payload).unwrap().into(),
-                })
-                .unwrap();
-        }
-        drop(journal);
-        writer.into_task().await.unwrap().unwrap();
-
-        let projected = load_transcript(&config, "session").unwrap();
-
-        assert_eq!(
-            projected
-                .iter()
-                .filter(|record| record.kind() == "assistant.delta")
-                .count(),
-            1
-        );
-        assert!(!transcript_projection_path(&config, "session").exists());
-    }
-
-    #[tokio::test]
-    async fn projection_cache_is_bound_to_its_session() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        write_minimal_session(&config, "session-one").await;
-        write_minimal_session(&config, "session-two").await;
-        write_projection_cache(&config, "session-one");
-        write_projection_cache(&config, "session-two");
-        let first = transcript_projection_path(&config, "session-one");
-        let second = transcript_projection_path(&config, "session-two");
-        let first_bytes = fs::read(&first).unwrap();
-        fs::write(&first, fs::read(&second).unwrap()).unwrap();
-        fs::write(&second, first_bytes).unwrap();
-
-        let records = load_transcript(&config, "session-one").unwrap();
-        let started = super::session_started(&records).unwrap();
-
-        assert_eq!(started.session_id, "session-one");
-    }
-
-    #[tokio::test]
-    async fn projection_cache_is_not_written_for_changed_source() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        write_minimal_session(&config, "session-one").await;
-        let records = load_transcript(&config, "session-one").unwrap();
-        let source_fingerprint = transcript_fingerprint(&config).unwrap();
-        let cache = transcript_projection_path(&config, "session-one");
-        assert!(!cache.exists());
-
-        let transcript = transcript_paths(&config).unwrap().remove(0);
-        std::fs::OpenOptions::new()
-            .append(true)
-            .open(transcript)
-            .unwrap()
-            .write_all(b"changed")
-            .unwrap();
-
-        write_transcript_projection(&config, "session-one", &source_fingerprint, &records);
-
-        assert!(!cache.exists());
-    }
-
-    #[tokio::test]
-    async fn segment_summary_is_bound_to_its_transcript() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        write_minimal_session(&config, "session-one").await;
-        load_transcript(&config, "session-one").unwrap();
-        assert!(!directory.path().join("transcript-projections").exists());
-        let summaries = fs::read_dir(directory.path().join("transcripts/v1"))
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .filter(|path| path.to_string_lossy().ends_with(".summary.json"))
-            .collect::<Vec<_>>();
-        assert_eq!(summaries.len(), 1);
-        let summary = fs::read_to_string(&summaries[0])
-            .unwrap()
-            .replace("session-one", "session-xxx");
-        fs::write(&summaries[0], summary).unwrap();
-
-        let records = load_transcript(&config, "session-one").unwrap();
-        let started = super::session_started(&records).unwrap();
-
-        assert_eq!(started.session_id, "session-one");
-    }
-
-    #[tokio::test]
-    async fn recent_prompts_are_global_exact_and_filterable_by_session() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        write_segment(
-            &config,
-            "0001-first.jsonl.zst",
-            [
-                (1, started("current", "/work/one")),
-                (
-                    10,
-                    LocalEvent::UserSubmitted {
-                        id: TurnId::new(1),
-                        text: "  exact\n  indentation  ".to_owned(),
-                    },
-                ),
-                (
-                    20,
-                    LocalEvent::UserSteered {
-                        text: "duplicate".to_owned(),
-                    },
-                ),
-            ],
-        );
-        write_segment(
-            &config,
-            "0002-second.jsonl.zst",
-            [
-                (2, started("other", "/work/two")),
-                (
-                    30,
-                    LocalEvent::UserSubmitted {
-                        id: TurnId::new(2),
-                        text: "duplicate".to_owned(),
-                    },
-                ),
-            ],
-        );
-
-        let prompts = load_recent_prompts_async(config, None).await.unwrap();
-
-        assert_eq!(
-            prompts
-                .iter()
-                .map(|prompt| prompt.text.as_str())
-                .collect::<Vec<_>>(),
-            ["duplicate", "duplicate", "  exact\n  indentation  "]
-        );
-        assert_eq!(prompts[0].session_id, "other");
-        assert_eq!(prompts[0].workspace, Path::new("/work/two"));
-        let current = prompts
-            .iter()
-            .filter(|prompt| prompt.session_id == "current")
-            .collect::<Vec<_>>();
-        assert_eq!(current.len(), 2);
-        assert!(
-            current
-                .iter()
-                .all(|prompt| prompt.workspace == Path::new("/work/one"))
-        );
-
-        let without_current = load_recent_prompts_async(
-            directory.path().join("config.toml"),
-            Some("current".to_owned()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(without_current.len(), 1);
-        assert_eq!(without_current[0].session_id, "other");
-    }
-
-    #[tokio::test]
-    async fn recent_prompt_order_has_deterministic_tie_breakers() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        write_segment(
-            &config,
-            "0001-a.jsonl.zst",
-            [
-                (1, started("a", "/a")),
-                (
-                    100,
-                    LocalEvent::UserSteered {
-                        text: "a-first".to_owned(),
-                    },
-                ),
-                (
-                    100,
-                    LocalEvent::UserSteered {
-                        text: "a-second".to_owned(),
-                    },
-                ),
-            ],
-        );
-        write_segment(
-            &config,
-            "0002-b.jsonl.zst",
-            [
-                (1, started("b", "/b")),
-                (
-                    100,
-                    LocalEvent::UserSteered {
-                        text: "b".to_owned(),
-                    },
-                ),
-            ],
-        );
-
-        let prompts = load_recent_prompts_async(config, None).await.unwrap();
-
-        assert_eq!(
-            prompts
-                .iter()
-                .map(|prompt| prompt.text.as_str())
-                .collect::<Vec<_>>(),
-            ["b", "a-second", "a-first"]
-        );
-    }
-
-    #[tokio::test]
-    async fn recent_prompt_loading_is_bounded_to_the_newest_entries() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let mut events = vec![(1, started("session", "/work"))];
-        events.extend((0..=super::MAX_RECENT_PROMPTS).map(|index| {
-            (
-                u64::try_from(index + 10).unwrap(),
-                LocalEvent::UserSteered {
-                    text: format!("prompt {index}"),
-                },
-            )
-        }));
-        write_segment(&config, "prompts.jsonl.zst", events);
-
-        let prompts = load_recent_prompts_async(config, None).await.unwrap();
-
-        assert_eq!(prompts.len(), super::MAX_RECENT_PROMPTS);
-        assert_eq!(prompts[0].text, "prompt 100");
-        assert_eq!(prompts.last().unwrap().text, "prompt 1");
-    }
-
-    #[tokio::test]
-    async fn recent_prompt_cache_is_reused_and_invalidated() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let transcript = write_segment(
-            &config,
-            "segment.jsonl.zst",
-            [
-                (1, started("session", "/work")),
-                (
-                    10,
-                    LocalEvent::UserSubmitted {
-                        id: TurnId::new(1),
-                        text: "first".to_owned(),
-                    },
-                ),
-            ],
-        );
-        let first = load_recent_prompts_async(config.clone(), None)
-            .await
-            .unwrap();
-        let cache = segment_summary_path(&transcript);
-        assert_eq!(first[0].text, "first");
-        assert!(cache.is_file());
-        let cached_bytes = fs::read(&cache).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&transcript).unwrap().permissions();
-            permissions.set_mode(0o000);
-            fs::set_permissions(&transcript, permissions).unwrap();
-        }
-        let warm = load_recent_prompts_async(config.clone(), None)
-            .await
-            .unwrap();
-        assert_eq!(warm, first);
-        assert_eq!(fs::read(&cache).unwrap(), cached_bytes);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&transcript).unwrap().permissions();
-            permissions.set_mode(0o600);
-            fs::set_permissions(&transcript, permissions).unwrap();
-        }
-
-        fs::write(&transcript, b"not a zstd transcript").unwrap();
-        let error = load_recent_prompts_async(config.clone(), None)
-            .await
-            .unwrap_err();
-        assert!(matches!(error, super::SessionError::Transcript(_)));
-
-        write_segment(
-            &config,
-            "segment.jsonl.zst",
-            [
-                (1, started("session", "/work")),
-                (
-                    20,
-                    LocalEvent::UserSteered {
-                        text: "replacement".to_owned(),
-                    },
-                ),
-            ],
-        );
-        let replacement = load_recent_prompts_async(config, None).await.unwrap();
-        assert_eq!(replacement[0].text, "replacement");
-    }
-
-    #[tokio::test]
-    async fn stable_incomplete_segments_create_recent_prompt_caches() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let transcript_directory = crate::tui::transcript::storage_directory(&config);
-        fs::create_dir_all(&transcript_directory).unwrap();
-        let transcript = transcript_directory.join("active.jsonl.zst");
-        let mut output = Encoder::new(fs::File::create(&transcript).unwrap(), 3).unwrap();
-        for (index, (recorded_at_unix_ms, event)) in [
-            (1, started("session", "/work")),
-            (
-                10,
-                LocalEvent::UserSubmitted {
+            .append_local_with_resume_state(
+                LocalEvent::WorkerTurnFinished {
                     id: TurnId::new(1),
-                    text: "durable line".to_owned(),
+                    error: None,
                 },
-            ),
-        ]
-        .into_iter()
-        .enumerate()
-        {
-            let record = crate::tui::transcript::TranscriptRecord::from_local(
-                u64::try_from(index + 1).unwrap(),
-                recorded_at_unix_ms,
-                event,
+                resume_state,
             )
             .unwrap();
-            serde_json::to_writer(&mut output, &record).unwrap();
-            output.write_all(b"\n").unwrap();
-        }
-        output.flush().unwrap();
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
 
-        let prompts = load_recent_prompts_async(config, None).await.unwrap();
-
-        assert_eq!(prompts[0].text, "durable line");
-        assert!(segment_summary_path(&transcript).is_file());
+        let records = super::load_transcript(&config, "session").unwrap();
+        assert_eq!(records.last().unwrap().kind(), "worker.turn_finished");
+        let (actual, instructions, catalog) =
+            load_checkpoint(&config, "session").unwrap().into_parts();
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+        assert_eq!(instructions, "instructions");
+        assert_eq!(catalog, Some(true));
     }
 }

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -118,7 +118,10 @@ pub(crate) fn load_checkpoint(
     config_path: &Path,
     session_id: &str,
 ) -> Result<ResumeState, SessionError> {
-    let encoded = SessionStorage::open(config_path)?
+    let encoded = SessionStorage::open_read_only(config_path)?
+        .ok_or_else(|| SessionError::MissingCheckpoint {
+            session_id: session_id.to_owned(),
+        })?
         .load_resume_state(session_id)?
         .ok_or_else(|| SessionError::MissingCheckpoint {
             session_id: session_id.to_owned(),
@@ -143,7 +146,10 @@ pub(crate) fn list(
     config_path: &Path,
     workspace: &Path,
 ) -> Result<Vec<SessionSummary>, SessionError> {
-    SessionStorage::open(config_path)?
+    let Some(storage) = SessionStorage::open_read_only(config_path)? else {
+        return Ok(Vec::new());
+    };
+    storage
         .list_sessions(workspace)?
         .into_iter()
         .map(|session| {
@@ -173,7 +179,10 @@ pub(crate) async fn load_recent_prompts_async(
     config_path: PathBuf,
 ) -> Result<Vec<RecentPrompt>, SessionError> {
     tokio::task::spawn_blocking(move || {
-        let prompts = SessionStorage::open(&config_path)?.recent_prompts(MAX_RECENT_PROMPTS)?;
+        let Some(storage) = SessionStorage::open_read_only(&config_path)? else {
+            return Ok(Vec::new());
+        };
+        let prompts = storage.recent_prompts(MAX_RECENT_PROMPTS)?;
         Ok(prompts
             .into_iter()
             .map(|prompt| RecentPrompt {
@@ -193,9 +202,10 @@ pub(crate) fn load_transcript(
     config_path: &Path,
     session_id: &str,
 ) -> Result<Vec<Arc<TranscriptRecord>>, SessionError> {
-    SessionStorage::open(config_path)?
-        .load_records(session_id)
-        .map_err(Into::into)
+    let Some(storage) = SessionStorage::open_read_only(config_path)? else {
+        return Ok(Vec::new());
+    };
+    storage.load_records(session_id).map_err(Into::into)
 }
 
 pub(crate) async fn load_transcript_async(
@@ -232,13 +242,18 @@ pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{encode_checkpoint, load_checkpoint, save_checkpoint};
+    use super::{encode_checkpoint, load_checkpoint, load_transcript, save_checkpoint};
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
-        tui::transcript::{LocalEvent, SessionStarted, TranscriptJournal, TurnId},
+        tui::{
+            storage::{SessionStorage, database_path},
+            transcript::{LocalEvent, SessionStarted, TranscriptJournal, TranscriptRecord, TurnId},
+        },
     };
     use nanocodex::agent::session::SessionSnapshot;
+    use rusqlite::Connection;
     use serde_json::{Value, json};
+    use std::sync::Arc;
     use tempfile::tempdir;
 
     fn snapshot(lineage: &str) -> SessionSnapshot {
@@ -262,6 +277,63 @@ mod tests {
             ]
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn loading_a_missing_session_does_not_create_storage() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+
+        assert!(load_transcript(&config, "missing").unwrap().is_empty());
+        assert!(!database_path(&config).exists());
+    }
+
+    #[test]
+    fn loading_a_session_does_not_require_a_writer_lock() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let records = [
+            Arc::new(
+                TranscriptRecord::from_local(
+                    1,
+                    1,
+                    LocalEvent::SessionStarted(SessionStarted {
+                        session_id: "session".to_owned(),
+                        parent_session_id: None,
+                        model: "model".to_owned(),
+                        effort: ReasoningEffort::Medium,
+                        reasoning_mode: ReasoningMode::Standard,
+                        fast_mode: false,
+                        workspace: "/work".into(),
+                        application_version: "test".to_owned(),
+                    }),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                TranscriptRecord::from_local(
+                    2,
+                    2,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(1),
+                        text: "inspect storage".to_owned(),
+                    },
+                )
+                .unwrap(),
+            ),
+        ];
+        SessionStorage::open(&config)
+            .unwrap()
+            .append_records("session", &records)
+            .unwrap();
+        let writer = Connection::open(database_path(&config)).unwrap();
+        writer.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let loaded = load_transcript(&config, "session").unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].kind(), "session.started");
+        assert_eq!(loaded[1].kind(), "user.submitted");
     }
 
     #[test]

--- a/src/tui/storage.rs
+++ b/src/tui/storage.rs
@@ -16,7 +16,6 @@ use thiserror::Error;
 
 const FORMAT_VERSION: i32 = 2;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
-const RECORD_COMPRESSION_LEVEL: i32 = 1;
 const STATE_COMPRESSION_LEVEL: i32 = 3;
 
 #[derive(Debug, Error)]
@@ -105,6 +104,41 @@ impl SessionStorage {
         })
     }
 
+    pub(crate) fn open_read_only(config_path: &Path) -> Result<Option<Self>, StorageError> {
+        let path = database_path(config_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+        let connection =
+            Connection::open_with_flags(&path, flags).map_err(|source| StorageError::Open {
+                path: path.clone(),
+                source,
+            })?;
+        connection
+            .busy_timeout(BUSY_TIMEOUT)
+            .and_then(|_| connection.execute_batch("PRAGMA query_only = ON;"))
+            .map_err(|source| StorageError::Configure {
+                path: path.clone(),
+                source,
+            })?;
+        let version = database_version(&connection, &path)?;
+        if version == 0 {
+            return Ok(None);
+        }
+        if version != FORMAT_VERSION {
+            return Err(StorageError::UnsupportedVersion {
+                path,
+                found: version,
+            });
+        }
+        Ok(Some(Self {
+            path,
+            connection,
+            active_turns: HashMap::new(),
+        }))
+    }
+
     pub(crate) fn append_records(
         &mut self,
         session_id: &str,
@@ -132,6 +166,7 @@ impl SessionStorage {
             .transaction()
             .map_err(|source| query(&path, source))?;
         let mut active_turn = self.active_turns.get(session_id).copied();
+        let mut encoded = Vec::new();
         for record in records {
             if record.source() == "tact" && record.kind() == "worker.turn_accepted" {
                 #[derive(serde::Deserialize)]
@@ -140,7 +175,16 @@ impl SessionStorage {
                 }
                 active_turn = Some(record.decode_payload::<AcceptedTurn>()?.id);
             }
-            append_record(&transaction, &path, session_id, active_turn, record)?;
+            encoded.clear();
+            serde_json::to_writer(&mut encoded, record.as_ref())?;
+            append_record(
+                &transaction,
+                &path,
+                session_id,
+                active_turn,
+                record,
+                &encoded,
+            )?;
         }
         if let Some(compressed) = compressed_state {
             write_resume_state(&transaction, &path, session_id, &compressed)?;
@@ -160,18 +204,30 @@ impl SessionStorage {
     ) -> Result<Vec<Arc<TranscriptRecord>>, StorageError> {
         let mut statement = self
             .connection
-            .prepare("SELECT record_zstd FROM events WHERE session_id = ?1 ORDER BY event_id")
+            .prepare("SELECT record_json FROM events WHERE session_id = ?1 ORDER BY event_id")
             .map_err(|source| query(&self.path, source))?;
-        let rows = statement
-            .query_map([session_id], |row| row.get::<_, Vec<u8>>(0))
+        let mut rows = statement
+            .query([session_id])
             .map_err(|source| query(&self.path, source))?;
-        let compressed = rows
-            .map(|row| row.map_err(|source| query(&self.path, source)))
-            .collect::<Result<Vec<_>, _>>()?;
-        compressed
-            .iter()
-            .map(|record| decode_record(record).map(Arc::new))
-            .collect()
+        let mut records = Vec::new();
+        while let Some(row) = rows.next().map_err(|source| query(&self.path, source))? {
+            let encoded = row
+                .get_ref(0)
+                .map_err(|source| query(&self.path, source))?
+                .as_blob()
+                .map_err(|source| {
+                    query(
+                        &self.path,
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Blob,
+                            Box::new(source),
+                        ),
+                    )
+                })?;
+            records.push(Arc::new(decode_record(encoded)?));
+        }
+        Ok(records)
     }
 
     #[cfg(test)]
@@ -267,9 +323,8 @@ fn write_resume_state(
     Ok(())
 }
 
-fn decode_record(compressed: &[u8]) -> Result<TranscriptRecord, StorageError> {
-    let encoded = zstd::decode_all(compressed).map_err(StorageError::Decode)?;
-    let record = serde_json::from_slice::<TranscriptRecord>(&encoded)?;
+fn decode_record(encoded: &[u8]) -> Result<TranscriptRecord, StorageError> {
+    let record = serde_json::from_slice::<TranscriptRecord>(encoded)?;
     if record.schema_version() != SCHEMA_VERSION {
         return Err(StorageError::UnsupportedRecordVersion {
             found: record.schema_version(),
@@ -306,10 +361,11 @@ fn configure(connection: &Connection, path: &Path) -> Result<(), StorageError> {
 }
 
 fn initialize(connection: &Connection, path: &Path) -> Result<(), StorageError> {
-    let version = connection
-        .query_row("PRAGMA user_version", [], |row| row.get::<_, i32>(0))
-        .map_err(|source| query(path, source))?;
-    if version != 0 && version != FORMAT_VERSION {
+    let version = database_version(connection, path)?;
+    if version == FORMAT_VERSION {
+        return Ok(());
+    }
+    if version != 0 {
         return Err(StorageError::UnsupportedVersion {
             path: path.to_path_buf(),
             found: version,
@@ -328,7 +384,7 @@ fn initialize(connection: &Connection, path: &Path) -> Result<(), StorageError> 
              CREATE TABLE IF NOT EXISTS events(\n\
                  event_id INTEGER PRIMARY KEY AUTOINCREMENT,\n\
                  session_id TEXT NOT NULL REFERENCES sessions(session_id),\n\
-                 record_zstd BLOB NOT NULL, prompt_text TEXT, prompt_recorded_at_ms INTEGER,\n\
+                 record_json BLOB NOT NULL, prompt_text TEXT, prompt_recorded_at_ms INTEGER,\n\
                  assistant_stream TEXT,\n\
                  CHECK((prompt_text IS NULL) = (prompt_recorded_at_ms IS NULL))\n\
              ) STRICT;\n\
@@ -346,12 +402,19 @@ fn initialize(connection: &Connection, path: &Path) -> Result<(), StorageError> 
         .map_err(|source| query(path, source))
 }
 
+fn database_version(connection: &Connection, path: &Path) -> Result<i32, StorageError> {
+    connection
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|source| query(path, source))
+}
+
 fn append_record(
     transaction: &Transaction<'_>,
     path: &Path,
     session_id: &str,
     active_turn: Option<u64>,
     record: &TranscriptRecord,
+    encoded: &[u8],
 ) -> Result<(), StorageError> {
     if record.source() == "tact" && record.kind() == "session.started" {
         let started = record.decode_payload::<SessionStarted>()?;
@@ -369,17 +432,14 @@ fn append_record(
             )
             .map_err(|source| query(path, source))?;
     }
-    let encoded = serde_json::to_vec(record)?;
-    let compressed = zstd::encode_all(encoded.as_slice(), RECORD_COMPRESSION_LEVEL)
-        .map_err(StorageError::Compress)?;
     transaction
         .execute(
             "INSERT INTO events(\n\
-                 session_id, record_zstd, prompt_text, prompt_recorded_at_ms, assistant_stream\n\
+                 session_id, record_json, prompt_text, prompt_recorded_at_ms, assistant_stream\n\
              ) VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
                 session_id,
-                compressed,
+                encoded,
                 prompt_text,
                 prompt_text
                     .as_ref()

--- a/src/tui/storage.rs
+++ b/src/tui/storage.rs
@@ -1,0 +1,685 @@
+//! SQLite-backed V2 session persistence.
+
+use crate::{
+    app::config::{ReasoningEffort, ReasoningMode},
+    tui::transcript::{SCHEMA_VERSION, SessionStarted, TranscriptRecord},
+};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Transaction, params};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+use thiserror::Error;
+
+const FORMAT_VERSION: i32 = 2;
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const RECORD_COMPRESSION_LEVEL: i32 = 1;
+const STATE_COMPRESSION_LEVEL: i32 = 3;
+
+#[derive(Debug, Error)]
+pub(crate) enum StorageError {
+    #[error("failed to create private session directory {path}: {source}")]
+    CreateDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to open session database {path}: {source}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("failed to configure session database {path}: {source}")]
+    Configure {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("session database {path} uses format version {found}; expected {FORMAT_VERSION}")]
+    UnsupportedVersion { path: PathBuf, found: i32 },
+    #[error("failed to access session database {path}: {source}")]
+    Query {
+        path: PathBuf,
+        #[source]
+        source: rusqlite::Error,
+    },
+    #[error("failed to encode session data: {0}")]
+    Encode(#[from] serde_json::Error),
+    #[error("failed to compress session data: {0}")]
+    Compress(#[source] std::io::Error),
+    #[error("failed to decode session data: {0}")]
+    Decode(#[source] std::io::Error),
+    #[error("stored transcript record uses schema version {found}; expected {SCHEMA_VERSION}")]
+    UnsupportedRecordVersion { found: u32 },
+}
+
+#[derive(Debug)]
+pub(crate) struct StoredSession {
+    pub(crate) session_id: String,
+    pub(crate) started_at_unix_ms: u64,
+    pub(crate) model: String,
+    pub(crate) effort: ReasoningEffort,
+    pub(crate) reasoning_mode: ReasoningMode,
+    pub(crate) workspace: PathBuf,
+    pub(crate) preview: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct StoredPrompt {
+    pub(crate) text: String,
+    pub(crate) recorded_at_unix_ms: u64,
+    pub(crate) session_id: String,
+    pub(crate) workspace: PathBuf,
+}
+
+pub(crate) struct SessionStorage {
+    path: PathBuf,
+    connection: Connection,
+    active_turns: HashMap<String, u64>,
+}
+
+impl SessionStorage {
+    pub(crate) fn open(config_path: &Path) -> Result<Self, StorageError> {
+        let path = database_path(config_path);
+        let directory = path.parent().unwrap_or_else(|| Path::new("."));
+        create_private_directory(directory)?;
+        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+        let connection =
+            Connection::open_with_flags(&path, flags).map_err(|source| StorageError::Open {
+                path: path.clone(),
+                source,
+            })?;
+        configure(&connection, &path)?;
+        initialize(&connection, &path)?;
+        set_private_file_permissions(&path)?;
+        Ok(Self {
+            path,
+            connection,
+            active_turns: HashMap::new(),
+        })
+    }
+
+    pub(crate) fn append_records(
+        &mut self,
+        session_id: &str,
+        records: &[Arc<TranscriptRecord>],
+    ) -> Result<(), StorageError> {
+        self.append_records_and_resume_state(session_id, records, None)
+    }
+
+    pub(crate) fn append_records_and_resume_state(
+        &mut self,
+        session_id: &str,
+        records: &[Arc<TranscriptRecord>],
+        resume_state: Option<&[u8]>,
+    ) -> Result<(), StorageError> {
+        if records.is_empty() && resume_state.is_none() {
+            return Ok(());
+        }
+        let compressed_state = resume_state
+            .map(|state| zstd::encode_all(state, STATE_COMPRESSION_LEVEL))
+            .transpose()
+            .map_err(StorageError::Compress)?;
+        let path = self.path.clone();
+        let transaction = self
+            .connection
+            .transaction()
+            .map_err(|source| query(&path, source))?;
+        let mut active_turn = self.active_turns.get(session_id).copied();
+        for record in records {
+            if record.source() == "tact" && record.kind() == "worker.turn_accepted" {
+                #[derive(serde::Deserialize)]
+                struct AcceptedTurn {
+                    id: u64,
+                }
+                active_turn = Some(record.decode_payload::<AcceptedTurn>()?.id);
+            }
+            append_record(&transaction, &path, session_id, active_turn, record)?;
+        }
+        if let Some(compressed) = compressed_state {
+            write_resume_state(&transaction, &path, session_id, &compressed)?;
+        }
+        transaction
+            .commit()
+            .map_err(|source| query(&path, source))?;
+        if let Some(active_turn) = active_turn {
+            self.active_turns.insert(session_id.to_owned(), active_turn);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn load_records(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<Arc<TranscriptRecord>>, StorageError> {
+        let mut statement = self
+            .connection
+            .prepare("SELECT record_zstd FROM events WHERE session_id = ?1 ORDER BY event_id")
+            .map_err(|source| query(&self.path, source))?;
+        let rows = statement
+            .query_map([session_id], |row| row.get::<_, Vec<u8>>(0))
+            .map_err(|source| query(&self.path, source))?;
+        let compressed = rows
+            .map(|row| row.map_err(|source| query(&self.path, source)))
+            .collect::<Result<Vec<_>, _>>()?;
+        compressed
+            .iter()
+            .map(|record| decode_record(record).map(Arc::new))
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn save_resume_state(
+        &mut self,
+        session_id: &str,
+        encoded: &[u8],
+    ) -> Result<(), StorageError> {
+        let compressed =
+            zstd::encode_all(encoded, STATE_COMPRESSION_LEVEL).map_err(StorageError::Compress)?;
+        write_resume_state(&self.connection, &self.path, session_id, &compressed)
+    }
+
+    pub(crate) fn load_resume_state(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let compressed = self
+            .connection
+            .query_row(
+                "SELECT state_zstd FROM resume_states WHERE session_id = ?1",
+                [session_id],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .map_err(|source| query(&self.path, source))?;
+        compressed
+            .map(|compressed| zstd::decode_all(compressed.as_slice()).map_err(StorageError::Decode))
+            .transpose()
+    }
+
+    pub(crate) fn list_sessions(
+        &self,
+        workspace: &Path,
+    ) -> Result<Vec<StoredSession>, StorageError> {
+        let workspace = workspace.to_string_lossy();
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
+                        s.workspace, s.preview\n\
+                 FROM sessions s INNER JOIN resume_states r ON r.session_id = s.session_id\n\
+                 WHERE s.workspace = ?1\n\
+                 ORDER BY s.updated_at_ms DESC, s.session_id",
+            )
+            .map_err(|source| query(&self.path, source))?;
+        let rows = statement
+            .query_map([workspace.as_ref()], decode_session)
+            .map_err(|source| query(&self.path, source))?;
+        rows.map(|row| row.map_err(|source| query(&self.path, source)))
+            .collect()
+    }
+
+    pub(crate) fn recent_prompts(&self, limit: usize) -> Result<Vec<StoredPrompt>, StorageError> {
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT e.prompt_text, e.prompt_recorded_at_ms, e.session_id, s.workspace\n\
+                 FROM events e INNER JOIN sessions s ON s.session_id = e.session_id\n\
+                 WHERE e.prompt_text IS NOT NULL\n\
+                 ORDER BY e.prompt_recorded_at_ms DESC, e.event_id DESC LIMIT ?1",
+            )
+            .map_err(|source| query(&self.path, source))?;
+        let rows = statement
+            .query_map([limit], |row| {
+                Ok(StoredPrompt {
+                    text: row.get(0)?,
+                    recorded_at_unix_ms: from_sql_u64(row.get(1)?),
+                    session_id: row.get(2)?,
+                    workspace: PathBuf::from(row.get::<_, String>(3)?),
+                })
+            })
+            .map_err(|source| query(&self.path, source))?;
+        rows.map(|row| row.map_err(|source| query(&self.path, source)))
+            .collect()
+    }
+}
+
+fn write_resume_state(
+    connection: &Connection,
+    path: &Path,
+    session_id: &str,
+    compressed: &[u8],
+) -> Result<(), StorageError> {
+    connection
+        .execute(
+            "INSERT INTO resume_states(session_id, state_zstd) VALUES (?1, ?2)\n\
+             ON CONFLICT(session_id) DO UPDATE SET state_zstd = excluded.state_zstd",
+            params![session_id, compressed],
+        )
+        .map_err(|source| query(path, source))?;
+    Ok(())
+}
+
+fn decode_record(compressed: &[u8]) -> Result<TranscriptRecord, StorageError> {
+    let encoded = zstd::decode_all(compressed).map_err(StorageError::Decode)?;
+    let record = serde_json::from_slice::<TranscriptRecord>(&encoded)?;
+    if record.schema_version() != SCHEMA_VERSION {
+        return Err(StorageError::UnsupportedRecordVersion {
+            found: record.schema_version(),
+        });
+    }
+    Ok(record)
+}
+
+pub(crate) fn database_path(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("sessions/v2.sqlite3")
+}
+
+fn configure(connection: &Connection, path: &Path) -> Result<(), StorageError> {
+    connection
+        .busy_timeout(BUSY_TIMEOUT)
+        .map_err(|source| StorageError::Configure {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    connection
+        .execute_batch(
+            "PRAGMA foreign_keys = ON;\n\
+             PRAGMA journal_mode = WAL;\n\
+             PRAGMA synchronous = FULL;\n\
+             PRAGMA wal_autocheckpoint = 1000;",
+        )
+        .map_err(|source| StorageError::Configure {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn initialize(connection: &Connection, path: &Path) -> Result<(), StorageError> {
+    let version = connection
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, i32>(0))
+        .map_err(|source| query(path, source))?;
+    if version != 0 && version != FORMAT_VERSION {
+        return Err(StorageError::UnsupportedVersion {
+            path: path.to_path_buf(),
+            found: version,
+        });
+    }
+    connection
+        .execute_batch(
+            "BEGIN IMMEDIATE;\n\
+             CREATE TABLE IF NOT EXISTS sessions(\n\
+                 session_id TEXT PRIMARY KEY, parent_session_id TEXT, workspace TEXT NOT NULL,\n\
+                 model TEXT NOT NULL, effort TEXT NOT NULL, reasoning_mode TEXT NOT NULL,\n\
+                 fast_mode INTEGER NOT NULL CHECK(fast_mode IN (0, 1)),\n\
+                 application_version TEXT NOT NULL, started_at_ms INTEGER NOT NULL,\n\
+                 updated_at_ms INTEGER NOT NULL, preview TEXT NOT NULL\n\
+             ) STRICT;\n\
+             CREATE TABLE IF NOT EXISTS events(\n\
+                 event_id INTEGER PRIMARY KEY AUTOINCREMENT,\n\
+                 session_id TEXT NOT NULL REFERENCES sessions(session_id),\n\
+                 record_zstd BLOB NOT NULL, prompt_text TEXT, prompt_recorded_at_ms INTEGER,\n\
+                 assistant_stream TEXT,\n\
+                 CHECK((prompt_text IS NULL) = (prompt_recorded_at_ms IS NULL))\n\
+             ) STRICT;\n\
+             CREATE INDEX IF NOT EXISTS events_by_session ON events(session_id, event_id);\n\
+             CREATE INDEX IF NOT EXISTS recent_prompts\n\
+                 ON events(prompt_recorded_at_ms DESC, event_id DESC)\n\
+                 WHERE prompt_text IS NOT NULL;\n\
+             CREATE INDEX IF NOT EXISTS assistant_streams\n\
+                 ON events(session_id, assistant_stream) WHERE assistant_stream IS NOT NULL;\n\
+             CREATE TABLE IF NOT EXISTS resume_states(\n\
+                 session_id TEXT PRIMARY KEY, state_zstd BLOB NOT NULL\n\
+             ) STRICT;\n\
+             PRAGMA user_version = 2; COMMIT;",
+        )
+        .map_err(|source| query(path, source))
+}
+
+fn append_record(
+    transaction: &Transaction<'_>,
+    path: &Path,
+    session_id: &str,
+    active_turn: Option<u64>,
+    record: &TranscriptRecord,
+) -> Result<(), StorageError> {
+    if record.source() == "tact" && record.kind() == "session.started" {
+        let started = record.decode_payload::<SessionStarted>()?;
+        upsert_session(transaction, path, record, &started)?;
+    }
+    let prompt_text = prompt_text(record)?;
+    let assistant_stream = assistant_stream(active_turn, record)?;
+    if record.kind() == "assistant.message"
+        && let Some(stream) = &assistant_stream
+    {
+        transaction
+            .execute(
+                "DELETE FROM events WHERE session_id = ?1 AND assistant_stream = ?2",
+                params![session_id, stream],
+            )
+            .map_err(|source| query(path, source))?;
+    }
+    let encoded = serde_json::to_vec(record)?;
+    let compressed = zstd::encode_all(encoded.as_slice(), RECORD_COMPRESSION_LEVEL)
+        .map_err(StorageError::Compress)?;
+    transaction
+        .execute(
+            "INSERT INTO events(\n\
+                 session_id, record_zstd, prompt_text, prompt_recorded_at_ms, assistant_stream\n\
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                compressed,
+                prompt_text,
+                prompt_text
+                    .as_ref()
+                    .map(|_| to_sql_u64(record.recorded_at_unix_ms())),
+                (record.kind() == "assistant.delta")
+                    .then_some(assistant_stream)
+                    .flatten()
+            ],
+        )
+        .map_err(|source| query(path, source))?;
+    transaction
+        .execute(
+            "UPDATE sessions SET updated_at_ms = ?2 WHERE session_id = ?1",
+            params![session_id, to_sql_u64(record.recorded_at_unix_ms())],
+        )
+        .map_err(|source| query(path, source))?;
+    if let Some(prompt) = prompt_text {
+        let preview = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+        if !preview.is_empty() {
+            transaction
+                .execute(
+                    "UPDATE sessions SET preview = ?2\n\
+                     WHERE session_id = ?1 AND preview = 'No user prompt'",
+                    params![session_id, preview],
+                )
+                .map_err(|source| query(path, source))?;
+        }
+    }
+    update_settings(transaction, path, session_id, record)
+}
+
+fn upsert_session(
+    transaction: &Transaction<'_>,
+    path: &Path,
+    record: &TranscriptRecord,
+    started: &SessionStarted,
+) -> Result<(), StorageError> {
+    let effort = serde_json::to_string(&started.effort)?;
+    let reasoning_mode = serde_json::to_string(&started.reasoning_mode)?;
+    transaction
+        .execute(
+            "INSERT INTO sessions(\n\
+                 session_id, parent_session_id, workspace, model, effort, reasoning_mode,\n\
+                 fast_mode, application_version, started_at_ms, updated_at_ms, preview\n\
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9, 'No user prompt')\n\
+             ON CONFLICT(session_id) DO UPDATE SET\n\
+                 workspace=excluded.workspace, model=excluded.model, effort=excluded.effort,\n\
+                 reasoning_mode=excluded.reasoning_mode, fast_mode=excluded.fast_mode,\n\
+                 application_version=excluded.application_version,\n\
+                 started_at_ms=excluded.started_at_ms, updated_at_ms=excluded.updated_at_ms",
+            params![
+                started.session_id,
+                started.parent_session_id,
+                started.workspace.to_string_lossy(),
+                started.model,
+                effort,
+                reasoning_mode,
+                started.fast_mode,
+                started.application_version,
+                to_sql_u64(record.recorded_at_unix_ms())
+            ],
+        )
+        .map_err(|source| query(path, source))?;
+    Ok(())
+}
+
+fn prompt_text(record: &TranscriptRecord) -> Result<Option<String>, serde_json::Error> {
+    #[derive(serde::Deserialize)]
+    struct Prompt {
+        text: String,
+    }
+    if record.source() != "tact" || !matches!(record.kind(), "user.submitted" | "user.steered") {
+        return Ok(None);
+    }
+    Ok(Some(record.decode_payload::<Prompt>()?.text))
+}
+
+fn assistant_stream(
+    active_turn: Option<u64>,
+    record: &TranscriptRecord,
+) -> Result<Option<String>, serde_json::Error> {
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct AssistantRecord {
+        model_call_index: u32,
+        phase: Option<serde_json::Value>,
+    }
+    if !matches!(record.kind(), "assistant.delta" | "assistant.message") {
+        return Ok(None);
+    }
+    let assistant = record.decode_payload::<AssistantRecord>()?;
+    serde_json::to_string(&(active_turn, assistant.model_call_index, assistant.phase)).map(Some)
+}
+
+fn update_settings(
+    transaction: &Transaction<'_>,
+    path: &Path,
+    session_id: &str,
+    record: &TranscriptRecord,
+) -> Result<(), StorageError> {
+    #[derive(serde::Deserialize)]
+    struct EffortChanged {
+        to: ReasoningEffort,
+    }
+    #[derive(serde::Deserialize)]
+    struct FastModeChanged {
+        to: bool,
+    }
+    match (record.source(), record.kind()) {
+        ("tact", "effort.changed") => {
+            let effort = serde_json::to_string(&record.decode_payload::<EffortChanged>()?.to)?;
+            transaction
+                .execute(
+                    "UPDATE sessions SET effort=?2 WHERE session_id=?1",
+                    params![session_id, effort],
+                )
+                .map_err(|source| query(path, source))?;
+        }
+        ("tact", "fast_mode.changed") => {
+            let enabled = record.decode_payload::<FastModeChanged>()?.to;
+            transaction
+                .execute(
+                    "UPDATE sessions SET fast_mode=?2 WHERE session_id=?1",
+                    params![session_id, enabled],
+                )
+                .map_err(|source| query(path, source))?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn decode_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredSession> {
+    let effort = row.get::<_, String>(3)?;
+    let reasoning_mode = row.get::<_, String>(4)?;
+    Ok(StoredSession {
+        session_id: row.get(0)?,
+        started_at_unix_ms: from_sql_u64(row.get(1)?),
+        model: row.get(2)?,
+        effort: decode_json_column(3, &effort)?,
+        reasoning_mode: decode_json_column(4, &reasoning_mode)?,
+        workspace: PathBuf::from(row.get::<_, String>(5)?),
+        preview: row.get(6)?,
+    })
+}
+
+fn decode_json_column<T: serde::de::DeserializeOwned>(
+    index: usize,
+    value: &str,
+) -> rusqlite::Result<T> {
+    serde_json::from_str(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn query(path: &Path, source: rusqlite::Error) -> StorageError {
+    StorageError::Query {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+fn to_sql_u64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+fn from_sql_u64(value: i64) -> u64 {
+    u64::try_from(value).unwrap_or_default()
+}
+
+fn create_private_directory(path: &Path) -> Result<(), StorageError> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder
+        .create(path)
+        .map_err(|source| StorageError::CreateDirectory {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn set_private_file_permissions(path: &Path) -> Result<(), StorageError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|source| {
+            StorageError::CreateDirectory {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SessionStorage, StorageError, database_path};
+    use crate::{
+        app::config::{ReasoningEffort, ReasoningMode},
+        tui::transcript::{LocalEvent, SessionStarted, TranscriptRecord, TurnId},
+    };
+    use rusqlite::Connection;
+    use std::{fs, sync::Arc};
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_an_unknown_database_version() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let path = database_path(&config);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let connection = Connection::open(&path).unwrap();
+        connection.pragma_update(None, "user_version", 3).unwrap();
+        drop(connection);
+
+        let error = SessionStorage::open(&config).err().unwrap();
+        assert!(matches!(
+            error,
+            StorageError::UnsupportedVersion { found: 3, .. }
+        ));
+    }
+
+    #[test]
+    fn opening_v2_storage_does_not_touch_v1_artifacts() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let artifacts = [
+            "transcripts/sentinel",
+            "checkpoints/sentinel",
+            "transcript-projections/sentinel",
+            "session-summaries/sentinel",
+        ];
+        for artifact in artifacts {
+            let path = directory.path().join(artifact);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"leave untouched").unwrap();
+        }
+
+        drop(SessionStorage::open(&config).unwrap());
+
+        for artifact in artifacts {
+            assert_eq!(
+                fs::read(directory.path().join(artifact)).unwrap(),
+                b"leave untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn recent_prompts_use_occurrence_time_not_writer_commit_order() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        append_prompt(&mut storage, "newer", 200, "newer prompt");
+        append_prompt(&mut storage, "older", 100, "older prompt");
+
+        let prompts = storage.recent_prompts(10).unwrap();
+        assert_eq!(prompts[0].text, "newer prompt");
+        assert_eq!(prompts[1].text, "older prompt");
+    }
+
+    fn append_prompt(storage: &mut SessionStorage, session_id: &str, at: u64, text: &str) {
+        let records = [
+            Arc::new(
+                TranscriptRecord::from_local(
+                    1,
+                    at.saturating_sub(1),
+                    LocalEvent::SessionStarted(SessionStarted {
+                        session_id: session_id.to_owned(),
+                        parent_session_id: None,
+                        model: "model".to_owned(),
+                        effort: ReasoningEffort::Medium,
+                        reasoning_mode: ReasoningMode::Standard,
+                        fast_mode: false,
+                        workspace: "/work".into(),
+                        application_version: "test".to_owned(),
+                    }),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                TranscriptRecord::from_local(
+                    2,
+                    at,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(1),
+                        text: text.to_owned(),
+                    },
+                )
+                .unwrap(),
+            ),
+        ];
+        storage.append_records(session_id, &records).unwrap();
+    }
+}

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -1,29 +1,24 @@
-use super::{TranscriptError, record::SCHEMA_VERSION};
-use crate::{
-    app::config::ReasoningEffort,
-    tui::transcript::{LocalEvent, SessionStarted, TranscriptRecord},
+use super::{TranscriptError, TranscriptRecord};
+use crate::tui::{
+    context::outbound_context_snapshot,
+    storage::{SessionStorage, database_path},
+    transcript::{LocalEvent, SessionStarted},
 };
 use nanocodex::agent::events::AgentEvent;
 use std::{
-    fs::{self, File, OpenOptions},
-    io::{self, BufRead, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::{sync::mpsc, task::JoinHandle};
-use zstd::stream::{read::Decoder, write::Encoder};
-
-// Journals favor low-latency ingestion; repeated JSON keys still compress well at level 1.
-const COMPRESSION_LEVEL: i32 = 1;
-const FORMAT_VERSION: u32 = SCHEMA_VERSION;
-
-#[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
 
 pub(crate) struct TranscriptJournal {
     path: PathBuf,
-    sender: mpsc::UnboundedSender<Arc<TranscriptRecord>>,
+    sender: mpsc::UnboundedSender<PendingWrite>,
+    persisted: Arc<AtomicBool>,
     pending_start: Option<SessionStarted>,
     next_sequence: u64,
 }
@@ -32,20 +27,9 @@ pub(crate) struct TranscriptWriter {
     task: JoinHandle<Result<(), TranscriptError>>,
 }
 
-pub(crate) struct LoadedSegment {
-    pub(crate) records: Vec<Arc<TranscriptRecord>>,
-    pub(crate) complete: bool,
-    pub(crate) observed_records: usize,
-}
-
-trait DurableWrite: Write + Send + 'static {
-    fn synchronize(&self) -> io::Result<()>;
-}
-
-impl DurableWrite for File {
-    fn synchronize(&self) -> io::Result<()> {
-        self.sync_all()
-    }
+struct PendingWrite {
+    record: Arc<TranscriptRecord>,
+    resume_state: Option<Vec<u8>>,
 }
 
 impl TranscriptJournal {
@@ -53,19 +37,20 @@ impl TranscriptJournal {
         config_path: &Path,
         session_id: &str,
     ) -> Result<(Self, TranscriptWriter), TranscriptError> {
-        remove_obsolete(config_path)?;
-        let directory = storage_directory(config_path);
-        let started_at = unix_milliseconds();
-        let filename = format!("{started_at}-{}.jsonl.zst", sanitize_filename(session_id));
-        let path = directory.join(filename);
+        let path = database_path(config_path);
         let (sender, receiver) = mpsc::unbounded_channel();
-        let writer_path = path.clone();
-        let task = tokio::task::spawn_blocking(move || write_journal(receiver, &writer_path));
-
+        let persisted = Arc::new(AtomicBool::new(false));
+        let writer_config = config_path.to_path_buf();
+        let writer_session = session_id.to_owned();
+        let writer_persisted = Arc::clone(&persisted);
+        let task = tokio::task::spawn_blocking(move || {
+            write_journal(receiver, &writer_config, &writer_session, &writer_persisted)
+        });
         Ok((
             Self {
-                path: path.clone(),
+                path,
                 sender,
+                persisted,
                 pending_start: None,
                 next_sequence: 1,
             },
@@ -77,6 +62,10 @@ impl TranscriptJournal {
         &self.path
     }
 
+    pub(crate) fn persistence_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.persisted)
+    }
+
     pub(crate) fn defer_start(&mut self, started: SessionStarted) {
         self.pending_start = Some(started);
     }
@@ -85,7 +74,7 @@ impl TranscriptJournal {
         self.next_sequence == 1
     }
 
-    pub(crate) fn set_initial_effort(&mut self, effort: ReasoningEffort) {
+    pub(crate) fn set_initial_effort(&mut self, effort: crate::app::config::ReasoningEffort) {
         if let Some(started) = &mut self.pending_start {
             started.effort = effort;
         }
@@ -97,13 +86,28 @@ impl TranscriptJournal {
         }
     }
 
+    /// Returns the live event record while persisting only its resume-relevant representation.
+    ///
+    /// Raw API transport events repeat complete requests, response snapshots, and streaming
+    /// payloads already represented by normalized agent events. They remain available to the live
+    /// diagnostics reducer, but V2 stores only the content-free outbound context facts it needs.
     pub(crate) fn append_agent(
         &mut self,
         event: AgentEvent,
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
         self.start_if_needed()?;
-        let record = TranscriptRecord::from_agent(self.take_sequence(), unix_milliseconds(), event);
-        self.send(record)
+        let record = TranscriptRecord::from_agent(self.next_sequence, unix_milliseconds(), event);
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        if record.kind() == "api.event" {
+            if let Some((prompt_cache, previous_response)) = outbound_context_snapshot(&record) {
+                self.append_local_record(LocalEvent::ContextObserved {
+                    prompt_cache,
+                    previous_response,
+                })?;
+            }
+            return Ok(Arc::new(record));
+        }
+        self.send(record, None)
     }
 
     pub(crate) fn append_local(
@@ -112,6 +116,16 @@ impl TranscriptJournal {
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
         self.start_if_needed()?;
         self.append_local_record(event)
+    }
+
+    pub(crate) fn append_local_with_resume_state(
+        &mut self,
+        event: LocalEvent,
+        resume_state: Vec<u8>,
+    ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
+        self.start_if_needed()?;
+        let record = self.local_record(event)?;
+        self.send(record, Some(resume_state))
     }
 
     fn start_if_needed(&mut self) -> Result<(), TranscriptError> {
@@ -126,108 +140,35 @@ impl TranscriptJournal {
         &mut self,
         event: LocalEvent,
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
-        let record = TranscriptRecord::from_local(self.take_sequence(), unix_milliseconds(), event)
-            .map_err(|source| TranscriptError::Encode {
-                path: self.path.clone(),
-                source,
-            })?;
-        self.send(record)
+        let record = self.local_record(event)?;
+        self.send(record, None)
     }
 
-    fn take_sequence(&mut self) -> u64 {
+    fn local_record(&mut self, event: LocalEvent) -> Result<TranscriptRecord, TranscriptError> {
         let sequence = self.next_sequence;
         self.next_sequence = self.next_sequence.saturating_add(1);
-        sequence
+        TranscriptRecord::from_local(sequence, unix_milliseconds(), event).map_err(|source| {
+            TranscriptError::Encode {
+                path: self.path.clone(),
+                source,
+            }
+        })
     }
 
-    fn send(&self, record: TranscriptRecord) -> Result<Arc<TranscriptRecord>, TranscriptError> {
+    fn send(
+        &self,
+        record: TranscriptRecord,
+        resume_state: Option<Vec<u8>>,
+    ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
         let record = Arc::new(record);
         self.sender
-            .send(Arc::clone(&record))
+            .send(PendingWrite {
+                record: Arc::clone(&record),
+                resume_state,
+            })
             .map_err(|_| TranscriptError::WriterStopped(self.path.clone()))?;
         Ok(record)
     }
-}
-
-pub(crate) fn storage_directory(config_path: &Path) -> PathBuf {
-    transcript_root(config_path).join(format!("v{FORMAT_VERSION}"))
-}
-
-pub(crate) fn remove_obsolete(config_path: &Path) -> Result<(), TranscriptError> {
-    let directory = transcript_root(config_path);
-    let entries = match fs::read_dir(&directory) {
-        Ok(entries) => entries,
-        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(source) => {
-            return Err(TranscriptError::ReadDirectory {
-                path: directory,
-                source,
-            });
-        }
-    };
-    for entry in entries {
-        let entry = entry.map_err(|source| TranscriptError::ReadDirectory {
-            path: directory.clone(),
-            source,
-        })?;
-        let file_type = entry
-            .file_type()
-            .map_err(|source| TranscriptError::ReadDirectory {
-                path: directory.clone(),
-                source,
-            })?;
-        if !file_type.is_file() {
-            continue;
-        }
-        let path = entry.path();
-        if !is_unversioned_transcript(&path) {
-            continue;
-        }
-        match fs::remove_file(&path) {
-            Ok(()) => {}
-            Err(source) if source.kind() == io::ErrorKind::NotFound => {}
-            Err(source) => return Err(TranscriptError::RemoveObsolete { path, source }),
-        }
-    }
-    Ok(())
-}
-
-fn transcript_root(config_path: &Path) -> PathBuf {
-    config_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join("transcripts")
-}
-
-fn is_unversioned_transcript(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    let Some(stem) = name.strip_suffix(".jsonl.zst") else {
-        return false;
-    };
-    let Some((started_at, session_id)) = stem.split_once('-') else {
-        return false;
-    };
-    !started_at.is_empty()
-        && started_at.bytes().all(|byte| byte.is_ascii_digit())
-        && !session_id.is_empty()
-        && session_id
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
-}
-
-fn write_journal(
-    mut receiver: mpsc::UnboundedReceiver<Arc<TranscriptRecord>>,
-    path: &Path,
-) -> Result<(), TranscriptError> {
-    let Some(first) = receiver.blocking_recv() else {
-        return Ok(());
-    };
-    let directory = path.parent().unwrap_or_else(|| Path::new("."));
-    create_private_directory(directory)?;
-    let file = create_private_file(path)?;
-    write_records_from(file, first, receiver, path)
 }
 
 impl TranscriptWriter {
@@ -236,224 +177,41 @@ impl TranscriptWriter {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn load(path: &Path) -> Result<Vec<Arc<TranscriptRecord>>, TranscriptError> {
-    Ok(load_matching(path, |_| true)?.unwrap_or_default())
-}
-
-#[cfg(test)]
-pub(crate) fn load_matching(
-    path: &Path,
-    matches_first: impl FnOnce(&TranscriptRecord) -> bool,
-) -> Result<Option<Vec<Arc<TranscriptRecord>>>, TranscriptError> {
-    Ok(load_matching_segment(path, matches_first)?.map(|segment| segment.records))
-}
-
-#[cfg(test)]
-pub(crate) fn load_matching_segment(
-    path: &Path,
-    matches_first: impl FnOnce(&TranscriptRecord) -> bool,
-) -> Result<Option<LoadedSegment>, TranscriptError> {
-    load_matching_segment_filtered(path, matches_first, |_| true)
-}
-
-pub(crate) fn load_matching_segment_filtered(
-    path: &Path,
-    matches_first: impl FnOnce(&TranscriptRecord) -> bool,
-    mut retain: impl FnMut(&TranscriptRecord) -> bool,
-) -> Result<Option<LoadedSegment>, TranscriptError> {
-    let file = File::open(path).map_err(|source| TranscriptError::Read {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let decoder = Decoder::new(file).map_err(|source| TranscriptError::Read {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    let mut input = BufReader::new(decoder);
-    let mut records = Vec::new();
-    let mut bytes = Vec::new();
-    let mut line = 0_usize;
-    let mut matches_first = Some(matches_first);
-    let mut complete = false;
-
-    loop {
-        bytes.clear();
-        let read = match input.read_until(b'\n', &mut bytes) {
-            Ok(read) => read,
-            Err(source) if incomplete_zstd_frame(&source) => break,
-            Err(source) => {
-                return Err(TranscriptError::Read {
-                    path: path.to_path_buf(),
-                    source,
-                });
-            }
-        };
-        if read == 0 {
-            complete = true;
-            break;
-        }
-        line += 1;
-        if bytes.last() != Some(&b'\n') {
-            break;
-        }
-        bytes.pop();
-        if bytes.last() == Some(&b'\r') {
-            bytes.pop();
-        }
-        let record = serde_json::from_slice::<TranscriptRecord>(&bytes).map_err(|source| {
-            TranscriptError::Decode {
-                path: path.to_path_buf(),
-                line,
-                source,
-            }
-        })?;
-        if record.schema_version() != SCHEMA_VERSION {
-            return Err(TranscriptError::UnsupportedVersion {
-                path: path.to_path_buf(),
-                line,
-                found: record.schema_version(),
-                supported: SCHEMA_VERSION,
-            });
-        }
-        let expected = u64::try_from(line).unwrap_or(u64::MAX);
-        if record.sequence() != expected {
-            return Err(TranscriptError::Sequence {
-                path: path.to_path_buf(),
-                line,
-                found: record.sequence(),
-                expected,
-            });
-        }
-        if let Some(matches_first) = matches_first.take()
-            && !matches_first(&record)
-        {
-            return Ok(None);
-        }
-        if retain(&record) {
-            records.push(Arc::new(record));
-        }
-    }
-
-    Ok(Some(LoadedSegment {
-        records,
-        complete,
-        observed_records: line,
-    }))
-}
-
-fn incomplete_zstd_frame(error: &io::Error) -> bool {
-    error.kind() == io::ErrorKind::UnexpectedEof || error.to_string().contains("incomplete frame")
-}
-
-#[cfg(test)]
-fn write_records<W: DurableWrite>(
-    output: W,
-    mut receiver: mpsc::UnboundedReceiver<Arc<TranscriptRecord>>,
-    path: &Path,
+fn write_journal(
+    mut receiver: mpsc::UnboundedReceiver<PendingWrite>,
+    config_path: &Path,
+    session_id: &str,
+    persisted: &AtomicBool,
 ) -> Result<(), TranscriptError> {
     let Some(first) = receiver.blocking_recv() else {
         return Ok(());
     };
-    write_records_from(output, first, receiver, path)
-}
-
-fn write_records_from<W: DurableWrite>(
-    output: W,
-    first: Arc<TranscriptRecord>,
-    mut receiver: mpsc::UnboundedReceiver<Arc<TranscriptRecord>>,
-    path: &Path,
-) -> Result<(), TranscriptError> {
-    let output = BufWriter::with_capacity(Encoder::<W>::recommended_input_size(), output);
-    let mut output =
-        Encoder::new(output, COMPRESSION_LEVEL).map_err(|source| TranscriptError::Write {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    let mut synchronized_last_record = false;
-    let mut current = Some(first);
-    while let Some(record) = current {
-        serde_json::to_writer(&mut output, &record).map_err(|source| TranscriptError::Encode {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        output
-            .write_all(b"\n")
-            .and_then(|()| output.flush())
-            .map_err(|source| TranscriptError::Write {
-                path: path.to_path_buf(),
-                source,
-            })?;
-        synchronized_last_record = record.is_sync_boundary();
-        if synchronized_last_record {
-            synchronize(output.get_ref().get_ref(), path)?;
+    let mut storage = SessionStorage::open(config_path)?;
+    let mut batch = vec![first];
+    loop {
+        while let Ok(record) = receiver.try_recv() {
+            batch.push(record);
         }
-        current = receiver.blocking_recv();
+        let records = batch
+            .iter()
+            .map(|pending| Arc::clone(&pending.record))
+            .collect::<Vec<_>>();
+        let resume_state = batch
+            .iter()
+            .rev()
+            .find_map(|pending| pending.resume_state.as_deref());
+        if let Some(resume_state) = resume_state {
+            storage.append_records_and_resume_state(session_id, &records, Some(resume_state))?;
+        } else {
+            storage.append_records(session_id, &records)?;
+        }
+        persisted.store(true, Ordering::Release);
+        batch.clear();
+        let Some(record) = receiver.blocking_recv() else {
+            return Ok(());
+        };
+        batch.push(record);
     }
-    let mut output = output.finish().map_err(|source| TranscriptError::Write {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    output.flush().map_err(|source| TranscriptError::Write {
-        path: path.to_path_buf(),
-        source,
-    })?;
-    if !synchronized_last_record {
-        synchronize(output.get_ref(), path)?;
-    }
-    Ok(())
-}
-
-fn synchronize(output: &impl DurableWrite, path: &Path) -> Result<(), TranscriptError> {
-    output
-        .synchronize()
-        .map_err(|source| TranscriptError::Sync {
-            path: path.to_path_buf(),
-            source,
-        })
-}
-
-fn create_private_directory(path: &Path) -> Result<(), TranscriptError> {
-    let mut builder = fs::DirBuilder::new();
-    builder.recursive(true);
-    #[cfg(unix)]
-    builder.mode(0o700);
-    builder
-        .create(path)
-        .map_err(|source| TranscriptError::CreateDirectory {
-            path: path.to_path_buf(),
-            source,
-        })
-}
-
-fn create_private_file(path: &Path) -> Result<File, TranscriptError> {
-    let mut options = OpenOptions::new();
-    options.create_new(true).write(true);
-    #[cfg(unix)]
-    options.mode(0o600);
-    options
-        .open(path)
-        .map_err(|source| TranscriptError::Create {
-            path: path.to_path_buf(),
-            source,
-        })
-}
-
-fn sanitize_filename(session_id: &str) -> String {
-    let sanitized = session_id
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
-                character
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    if sanitized.is_empty() {
-        return "session".to_owned();
-    }
-    sanitized
 }
 
 fn unix_milliseconds() -> u64 {
@@ -465,113 +223,39 @@ fn unix_milliseconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DurableWrite, TranscriptJournal, load, load_matching, load_matching_segment, write_records,
-    };
+    use super::TranscriptJournal;
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
-        tui::transcript::{
-            LocalEvent, SessionEnded, SessionOutcome, SessionStarted, TranscriptError, TurnId,
+        tui::{
+            session,
+            storage::SessionStorage,
+            transcript::{LocalEvent, SessionStarted, TurnId},
         },
     };
-    use std::{
-        fs,
-        io::{self, Write},
-        path::Path,
-        sync::{Arc, Mutex, mpsc as std_mpsc},
-        time::Duration,
-    };
+    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use serde_json::{json, value::to_raw_value};
+    use std::sync::Arc;
     use tempfile::tempdir;
-    use tokio::sync::mpsc;
 
-    #[tokio::test]
-    async fn journal_round_trips_ordered_records_and_ignores_truncated_tail() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let (mut journal, writer) = TranscriptJournal::open(&config, "session/one").unwrap();
-        let path = journal.path().to_path_buf();
-        journal
-            .append_local(LocalEvent::SessionStarted(SessionStarted {
-                session_id: "session/one".to_owned(),
-                parent_session_id: None,
-                model: "model".to_owned(),
-                effort: ReasoningEffort::Medium,
-                reasoning_mode: ReasoningMode::Standard,
-                fast_mode: false,
-                workspace: directory.path().to_path_buf(),
-                application_version: "test".to_owned(),
-            }))
-            .unwrap();
-        journal
-            .append_local(LocalEvent::UserSubmitted {
-                id: TurnId::new(1),
-                text: "hello".to_owned(),
-            })
-            .unwrap();
-        journal
-            .append_local(LocalEvent::SessionEnded(SessionEnded {
-                outcome: SessionOutcome::Closed,
-                error: None,
-            }))
-            .unwrap();
-        drop(journal);
-        writer.into_task().await.unwrap().unwrap();
-
-        let records = load(&path).unwrap();
-        assert_eq!(records.len(), 3);
-        assert_eq!(records[0].sequence(), 1);
-        assert_eq!(records[1].kind(), "user.submitted");
-        assert_eq!(records[2].kind(), "session.ended");
-        assert_eq!(
-            path.extension().and_then(|extension| extension.to_str()),
-            Some("zst")
-        );
-        assert_eq!(
-            path.parent().unwrap(),
-            directory.path().join("transcripts/v1")
-        );
-        assert!(
-            load_matching_segment(&path, |_| true)
-                .unwrap()
-                .unwrap()
-                .complete
-        );
-
-        let length = fs::metadata(&path).unwrap().len();
-        fs::OpenOptions::new()
-            .write(true)
-            .open(&path)
-            .unwrap()
-            .set_len(length - 3)
-            .unwrap();
-        assert_eq!(load(&path).unwrap().len(), 3);
-        assert!(
-            !load_matching_segment(&path, |_| true)
-                .unwrap()
-                .unwrap()
-                .complete
-        );
-    }
-
-    #[tokio::test]
-    async fn settings_changed_before_the_first_entry_update_session_metadata() {
-        let directory = tempdir().unwrap();
-        let config = directory.path().join("config.toml");
-        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
-        let path = journal.path().to_path_buf();
-        journal.defer_start(SessionStarted {
-            session_id: "session".to_owned(),
+    fn started(session_id: &str) -> SessionStarted {
+        SessionStarted {
+            session_id: session_id.to_owned(),
             parent_session_id: None,
             model: "model".to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
-            workspace: directory.path().to_path_buf(),
+            workspace: "/work".into(),
             application_version: "test".to_owned(),
-        });
+        }
+    }
 
-        journal.set_initial_effort(ReasoningEffort::High);
-        journal.set_initial_fast_mode(true);
+    #[tokio::test]
+    async fn semantic_records_round_trip_in_order() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal.defer_start(started("session"));
         journal
             .append_local(LocalEvent::UserSubmitted {
                 id: TurnId::new(1),
@@ -581,234 +265,204 @@ mod tests {
         drop(journal);
         writer.into_task().await.unwrap().unwrap();
 
-        let records = load(&path).unwrap();
-        let started = records[0].decode_payload::<SessionStarted>().unwrap();
-        assert_eq!(started.effort, ReasoningEffort::High);
-        assert_eq!(started.reasoning_mode, ReasoningMode::Standard);
-        assert!(started.fast_mode);
+        let records = session::load_transcript(&config, "session").unwrap();
         assert_eq!(records.len(), 2);
-        assert!(
-            records
-                .iter()
-                .all(|record| !matches!(record.kind(), "effort.changed" | "fast_mode.changed"))
-        );
+        assert_eq!(records[0].kind(), "session.started");
+        assert_eq!(records[1].kind(), "user.submitted");
     }
 
     #[tokio::test]
-    async fn empty_journal_does_not_create_a_transcript() {
+    async fn raw_api_events_are_not_persisted() {
         let directory = tempdir().unwrap();
         let config = directory.path().join("config.toml");
-        let (journal, writer) = TranscriptJournal::open(&config, "empty").unwrap();
-        let path = journal.path().to_path_buf();
-
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal.defer_start(started("session"));
+        let marker = "must-not-be-durable";
+        let live = journal
+            .append_agent(AgentEvent {
+                protocol_version: 1,
+                request_id: Arc::from("request"),
+                seq: 1,
+                kind: AgentEventKind::ApiEvent,
+                payload: to_raw_value(&json!({
+                    "direction": "outbound", "phase": "generation",
+                    "event": {"prompt_cache_key": marker, "previous_response_id": marker}
+                }))
+                .unwrap()
+                .into(),
+            })
+            .unwrap();
+        assert_eq!(live.kind(), "api.event");
         drop(journal);
         writer.into_task().await.unwrap().unwrap();
 
-        assert!(!path.exists());
-        assert!(!directory.path().join("transcripts").exists());
-    }
-
-    #[test]
-    fn corrupt_complete_middle_line_is_rejected() {
-        let directory = tempdir().unwrap();
-        let path = directory.path().join("transcript.jsonl.zst");
-        let compressed = zstd::encode_all(b"not-json\n{}\n".as_slice(), 1).unwrap();
-        fs::write(&path, compressed).unwrap();
-
-        let error = load(&path).unwrap_err();
-        assert!(matches!(error, TranscriptError::Decode { line: 1, .. }));
-    }
-
-    #[test]
-    fn rejected_segment_does_not_decode_later_records() {
-        let directory = tempdir().unwrap();
-        let path = directory.path().join("transcript.jsonl.zst");
-        let first = super::super::record::TranscriptRecord::from_local(
-            1,
-            1,
-            LocalEvent::WorkerTurnAccepted { id: TurnId::new(1) },
-        )
-        .unwrap();
-        let mut contents = serde_json::to_vec(&first).unwrap();
-        contents.extend_from_slice(b"\nnot-json\n");
-        fs::write(&path, zstd::encode_all(contents.as_slice(), 1).unwrap()).unwrap();
-
-        let records = load_matching(&path, |_| false).unwrap();
-
-        assert!(records.is_none());
-        assert!(matches!(
-            load(&path).unwrap_err(),
-            TranscriptError::Decode { line: 2, .. }
-        ));
-    }
-
-    #[test]
-    fn writer_flushes_every_record_and_syncs_terminal_boundary_once() {
-        let state = Arc::new(Mutex::new(WriteState::default()));
-        let output = RecordingWriter(Arc::clone(&state));
-        let (sender, receiver) = mpsc::unbounded_channel();
-        let first = super::super::record::TranscriptRecord::from_local(
-            1,
-            1,
-            LocalEvent::WorkerTurnAccepted { id: TurnId::new(1) },
-        )
-        .unwrap();
-        let terminal = super::super::record::TranscriptRecord::from_local(
-            2,
-            2,
-            LocalEvent::SessionEnded(SessionEnded {
-                outcome: SessionOutcome::Closed,
-                error: None,
-            }),
-        )
-        .unwrap();
-        sender.send(Arc::new(first)).unwrap();
-        sender.send(Arc::new(terminal)).unwrap();
-        drop(sender);
-
-        write_records(output, receiver, Path::new("transcript.jsonl")).unwrap();
-
-        let state = state.lock().unwrap();
-        assert!(state.flushes >= 2);
-        assert_eq!(state.synchronizations, 1);
-        let decoded = zstd::decode_all(state.bytes.as_slice()).unwrap();
-        assert_eq!(decoded.iter().filter(|&&byte| byte == b'\n').count(), 2);
-    }
-
-    #[test]
-    fn flushed_records_are_readable_before_the_zstd_stream_finishes() {
-        let directory = tempdir().unwrap();
-        let path = directory.path().join("streaming.jsonl.zst");
-        let state = Arc::new(Mutex::new(WriteState::default()));
-        let (flushed, flushes) = std_mpsc::channel();
-        let output = StreamingWriter {
-            state: Arc::clone(&state),
-            flushed,
-        };
-        let (sender, receiver) = mpsc::unbounded_channel();
-        let record = super::super::record::TranscriptRecord::from_local(
-            1,
-            1,
-            LocalEvent::WorkerTurnAccepted { id: TurnId::new(1) },
-        )
-        .unwrap();
-        let writer = std::thread::spawn(move || {
-            write_records(output, receiver, Path::new("streaming.jsonl.zst"))
-        });
-
-        sender.send(Arc::new(record)).unwrap();
-        flushes.recv_timeout(Duration::from_secs(1)).unwrap();
-        fs::write(&path, &state.lock().unwrap().bytes).unwrap();
-
-        let records = load(&path).unwrap();
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].kind(), "worker.turn_accepted");
-
-        drop(sender);
-        writer.join().unwrap().unwrap();
-    }
-
-    #[test]
-    fn repeated_transcript_content_compresses_substantially() {
-        let state = Arc::new(Mutex::new(WriteState::default()));
-        let output = RecordingWriter(Arc::clone(&state));
-        let (sender, receiver) = mpsc::unbounded_channel();
-        let mut uncompressed_bytes = 0;
-        for sequence in 1..=50 {
-            let record = super::super::record::TranscriptRecord::from_local(
-                sequence,
-                sequence,
-                LocalEvent::UserSubmitted {
-                    id: TurnId::new(sequence),
-                    text: "repeated transcript content ".repeat(150),
-                },
-            )
+        let records = SessionStorage::open(&config)
+            .unwrap()
+            .load_records("session")
             .unwrap();
-            uncompressed_bytes += serde_json::to_vec(&record).unwrap().len() + 1;
-            sender.send(Arc::new(record)).unwrap();
-        }
-        drop(sender);
-
-        write_records(output, receiver, Path::new("compressed.jsonl.zst")).unwrap();
-
-        let compressed_bytes = state.lock().unwrap().bytes.len();
-        assert!(
-            compressed_bytes * 5 < uncompressed_bytes,
-            "compressed {uncompressed_bytes} bytes to {compressed_bytes} bytes"
-        );
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].kind(), "context.observed");
+        assert!(!format!("{records:?}").contains(marker));
     }
 
-    #[cfg(unix)]
     #[tokio::test]
-    async fn journal_file_is_private() {
-        use std::os::unix::fs::PermissionsExt;
-
+    async fn completed_assistant_message_replaces_its_persisted_deltas() {
         let directory = tempdir().unwrap();
         let config = directory.path().join("config.toml");
-        let (mut journal, writer) = TranscriptJournal::open(&config, "private").unwrap();
-        let path = journal.path().to_path_buf();
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal.defer_start(started("session"));
+        for (sequence, text) in [(1, "first "), (2, "second")] {
+            journal
+                .append_agent(AgentEvent {
+                    protocol_version: 1,
+                    request_id: Arc::from("request"),
+                    seq: sequence,
+                    kind: AgentEventKind::AssistantDelta,
+                    payload: to_raw_value(&json!({
+                        "model_call_index": 0,
+                        "item_id": "message",
+                        "phase": "final_answer",
+                        "text": text,
+                    }))
+                    .unwrap()
+                    .into(),
+                })
+                .unwrap();
+        }
         journal
-            .append_local(LocalEvent::UserSubmitted {
-                id: TurnId::new(1),
-                text: "persist me".to_owned(),
+            .append_agent(AgentEvent {
+                protocol_version: 1,
+                request_id: Arc::from("request"),
+                seq: 3,
+                kind: AgentEventKind::AssistantMessage,
+                payload: to_raw_value(&json!({
+                    "model_call_index": 0,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": "first second",
+                }))
+                .unwrap()
+                .into(),
             })
             .unwrap();
         drop(journal);
         writer.into_task().await.unwrap().unwrap();
 
+        let records = session::load_transcript(&config, "session").unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].kind(), "session.started");
+        assert_eq!(records[1].kind(), "assistant.message");
+    }
+
+    #[tokio::test]
+    async fn completed_turn_does_not_remove_an_earlier_failed_turn_draft() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        journal.defer_start(started("session"));
+        journal
+            .append_local(LocalEvent::WorkerTurnAccepted { id: TurnId::new(1) })
+            .unwrap();
+        append_assistant(
+            &mut journal,
+            AgentEventKind::AssistantDelta,
+            1,
+            "failed draft",
+        );
+        journal
+            .append_local(LocalEvent::WorkerTurnFinished {
+                id: TurnId::new(1),
+                error: Some("failed".to_owned()),
+            })
+            .unwrap();
+        journal
+            .append_local(LocalEvent::WorkerTurnAccepted { id: TurnId::new(2) })
+            .unwrap();
+        append_assistant(&mut journal, AgentEventKind::AssistantDelta, 2, "complete");
+        append_assistant(
+            &mut journal,
+            AgentEventKind::AssistantMessage,
+            3,
+            "complete",
+        );
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
+
+        let records = session::load_transcript(&config, "session").unwrap();
         assert_eq!(
-            fs::metadata(path).unwrap().permissions().mode() & 0o777,
-            0o600
+            records
+                .iter()
+                .filter(|record| record.kind() == "assistant.delta")
+                .count(),
+            1
+        );
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind() == "assistant.message")
+                .count(),
+            1
         );
     }
 
-    #[derive(Default)]
-    struct WriteState {
-        bytes: Vec<u8>,
-        flushes: usize,
-        synchronizations: usize,
+    fn append_assistant(
+        journal: &mut TranscriptJournal,
+        kind: AgentEventKind,
+        sequence: u64,
+        text: &str,
+    ) {
+        journal
+            .append_agent(AgentEvent {
+                protocol_version: 1,
+                request_id: Arc::from("request"),
+                seq: sequence,
+                kind,
+                payload: to_raw_value(&json!({
+                    "model_call_index": 0,
+                    "item_id": "message",
+                    "phase": "final_answer",
+                    "text": text,
+                }))
+                .unwrap()
+                .into(),
+            })
+            .unwrap();
     }
 
-    struct RecordingWriter(Arc<Mutex<WriteState>>);
-
-    struct StreamingWriter {
-        state: Arc<Mutex<WriteState>>,
-        flushed: std_mpsc::Sender<()>,
+    #[tokio::test]
+    async fn an_empty_journal_creates_no_session() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (journal, writer) = TranscriptJournal::open(&config, "empty").unwrap();
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
+        assert!(!directory.path().join("sessions").exists());
     }
 
-    impl Write for RecordingWriter {
-        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            self.0.lock().unwrap().bytes.extend_from_slice(bytes);
-            Ok(bytes.len())
+    #[tokio::test]
+    async fn recent_prompts_are_indexed_in_reverse_order_without_changing_whitespace() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        for (session_id, prompt) in [
+            ("first", "  preserve\n  this spacing  "),
+            ("second", "newest prompt"),
+        ] {
+            let (mut journal, writer) = TranscriptJournal::open(&config, session_id).unwrap();
+            journal.defer_start(started(session_id));
+            journal
+                .append_local(LocalEvent::UserSubmitted {
+                    id: TurnId::new(1),
+                    text: prompt.to_owned(),
+                })
+                .unwrap();
+            drop(journal);
+            writer.into_task().await.unwrap().unwrap();
         }
 
-        fn flush(&mut self) -> io::Result<()> {
-            self.0.lock().unwrap().flushes += 1;
-            Ok(())
-        }
-    }
-
-    impl DurableWrite for RecordingWriter {
-        fn synchronize(&self) -> io::Result<()> {
-            self.0.lock().unwrap().synchronizations += 1;
-            Ok(())
-        }
-    }
-
-    impl Write for StreamingWriter {
-        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            self.state.lock().unwrap().bytes.extend_from_slice(bytes);
-            Ok(bytes.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.flushed.send(()).map_err(io::Error::other)
-        }
-    }
-
-    impl DurableWrite for StreamingWriter {
-        fn synchronize(&self) -> io::Result<()> {
-            Ok(())
-        }
+        let prompts = session::load_recent_prompts_async(config).await.unwrap();
+        assert_eq!(prompts.len(), 2);
+        assert_eq!(prompts[0].text, "newest prompt");
+        assert_eq!(prompts[1].text, "  preserve\n  this spacing  ");
+        assert_eq!(prompts[1].session_id, "first");
     }
 }

--- a/src/tui/transcript/mod.rs
+++ b/src/tui/transcript/mod.rs
@@ -5,117 +5,34 @@ mod journal;
 mod model;
 mod record;
 
+use crate::tui::storage::StorageError;
 pub(crate) use entry::{
     DirectedMessageEntry, EntryId, EntryKind, MessageDelivery, MessagePhase, ToolEntry, ToolState,
     TranscriptEntry, TransientStatus,
 };
-#[cfg(test)]
-pub(crate) use journal::load;
-pub(crate) use journal::{
-    TranscriptJournal, load_matching_segment_filtered, remove_obsolete, storage_directory,
-};
+pub(crate) use journal::TranscriptJournal;
 pub(crate) use model::TranscriptModel;
 pub(crate) use record::{
-    LocalEvent, SessionEnded, SessionOutcome, SessionStarted, ShellId, TranscriptRecord, TurnId,
+    LocalEvent, SCHEMA_VERSION, SessionEnded, SessionOutcome, SessionStarted, ShellId,
+    TranscriptRecord, TurnId,
 };
-use std::{io, path::PathBuf};
+use std::path::PathBuf;
 use thiserror::Error;
 
 /// Errors retain the transcript path because failures otherwise occur after the
 /// terminal has already yielded its screen to the application.
 #[derive(Debug, Error)]
 pub(crate) enum TranscriptError {
-    #[error("failed to create transcript directory {path}: {source}")]
-    CreateDirectory {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to inspect transcript directory {path}: {source}")]
-    ReadDirectory {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to remove obsolete transcript {path}: {source}")]
-    RemoveObsolete {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to create transcript {path}: {source}")]
-    Create {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
+    #[error(transparent)]
+    Storage(#[from] StorageError),
     #[error("failed to encode transcript record for {path}: {source}")]
     Encode {
         path: PathBuf,
         #[source]
         source: serde_json::Error,
     },
-    #[error("failed to write transcript {path}: {source}")]
-    Write {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to synchronize transcript {path}: {source}")]
-    Sync {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
     #[error("the transcript writer for {0} stopped unexpectedly")]
     WriterStopped(PathBuf),
     #[error("the transcript writer task stopped unexpectedly: {0}")]
     WriterTask(#[source] tokio::task::JoinError),
-    #[error("failed to read transcript {path}: {source}")]
-    #[allow(
-        dead_code,
-        reason = "used when the planned session picker loads transcripts"
-    )]
-    Read {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("failed to decode transcript {path} at line {line}: {source}")]
-    #[allow(
-        dead_code,
-        reason = "used when the planned session picker loads transcripts"
-    )]
-    Decode {
-        path: PathBuf,
-        line: usize,
-        #[source]
-        source: serde_json::Error,
-    },
-    #[error(
-        "transcript {path} line {line} uses schema version {found}; this build supports version {supported}"
-    )]
-    #[allow(
-        dead_code,
-        reason = "used when the planned session picker loads transcripts"
-    )]
-    UnsupportedVersion {
-        path: PathBuf,
-        line: usize,
-        found: u32,
-        supported: u32,
-    },
-    #[error(
-        "transcript {path} line {line} has sequence {found}; expected monotonically ordered sequence {expected}"
-    )]
-    #[allow(
-        dead_code,
-        reason = "used when the planned session picker loads transcripts"
-    )]
-    Sequence {
-        path: PathBuf,
-        line: usize,
-        found: u64,
-        expected: u64,
-    },
 }

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::{RawValue, to_raw_value};
 use std::{path::PathBuf, sync::Arc};
 
-pub(super) const SCHEMA_VERSION: u32 = 1;
+pub(crate) const SCHEMA_VERSION: u32 = 2;
 pub(super) const AGENT_SOURCE: &str = "agent";
 pub(super) const TACT_SOURCE: &str = "tact";
 
@@ -35,9 +35,7 @@ pub(crate) struct SessionStarted {
     pub(crate) parent_session_id: Option<String>,
     pub(crate) model: String,
     pub(crate) effort: ReasoningEffort,
-    #[serde(default)]
     pub(crate) reasoning_mode: ReasoningMode,
-    #[serde(default)]
     pub(crate) fast_mode: bool,
     pub(crate) workspace: PathBuf,
     pub(crate) application_version: String,
@@ -241,10 +239,6 @@ impl TranscriptRecord {
         })
     }
 
-    #[allow(
-        dead_code,
-        reason = "used when the planned session picker loads transcripts"
-    )]
     pub(crate) const fn schema_version(&self) -> u32 {
         self.schema_version
     }
@@ -274,16 +268,6 @@ impl TranscriptRecord {
         T: serde::Deserialize<'a>,
     {
         serde_json::from_str(self.payload.get())
-    }
-
-    pub(crate) fn is_sync_boundary(&self) -> bool {
-        self.source == TACT_SOURCE
-            && matches!(
-                self.kind.as_str(),
-                "session.ended" | "effort.changed" | "fast_mode.changed"
-            )
-            || self.source == AGENT_SOURCE
-                && matches!(self.kind.as_str(), "run.completed" | "run.failed")
     }
 }
 
@@ -398,8 +382,7 @@ const fn agent_kind(kind: AgentEventKind) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{LocalEvent, SessionStarted, ShellId, TranscriptRecord, TurnId};
-    use crate::app::config::ReasoningMode;
+    use super::{LocalEvent, ShellId, TranscriptRecord, TurnId};
     use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use serde_json::{json, value::to_raw_value};
     use std::sync::Arc;
@@ -420,7 +403,7 @@ mod tests {
         );
         let encoded = serde_json::to_value(record).unwrap();
 
-        assert_eq!(encoded["schema_version"], 1);
+        assert_eq!(encoded["schema_version"], 2);
         assert_eq!(encoded["sequence"], 7);
         assert_eq!(encoded["recorded_at_unix_ms"], 123);
         assert_eq!(encoded["source"], "agent");
@@ -446,29 +429,6 @@ mod tests {
         assert_eq!(encoded["source"], "tact");
         assert_eq!(encoded["type"], "user.submitted");
         assert_eq!(encoded["payload"], json!({"id": 9, "text": "hello"}));
-    }
-
-    #[test]
-    fn historical_session_metadata_defaults_to_standard_reasoning() {
-        let record = serde_json::from_value::<TranscriptRecord>(json!({
-            "schema_version": 1,
-            "sequence": 1,
-            "recorded_at_unix_ms": 123,
-            "source": "tact",
-            "type": "session.started",
-            "payload": {
-                "session_id": "session-a",
-                "model": "model",
-                "effort": "medium",
-                "fast_mode": false,
-                "workspace": "/work",
-                "application_version": "0.0.1"
-            }
-        }))
-        .unwrap();
-
-        let started = record.decode_payload::<SessionStarted>().unwrap();
-        assert_eq!(started.reasoning_mode, ReasoningMode::Standard);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace duplicated V1 transcript artifacts and projections with one V2 SQLite-backed semantic record store
- use indexed session, prompt, and transcript queries for fast listing and uncached resume
- keep resume and Nanocodex snapshots intact while removing V1 compatibility code
- leave existing V1 files untouched on disk; this release neither migrates nor deletes them

## Stack
- Depends on #93
- Followed by #95

## Testing
- just check-fmt
- just clippy
- just test (740 tests passed)