### PR TITLE
feat(tui): add session mentions

### DIFF
--- a/src/core/extensions/mod.rs
+++ b/src/core/extensions/mod.rs
@@ -2,6 +2,7 @@
 
 mod mcp;
 pub(crate) mod memory;
+pub(crate) mod sessions;
 mod skills;
 pub(crate) mod subagents;
 

--- a/src/core/extensions/sessions.rs
+++ b/src/core/extensions/sessions.rs
@@ -218,7 +218,7 @@ fn bounded_output(
 
         let truncated = OutputRecord {
             event_id,
-            record: truncated_record(&stored, 256),
+            record: truncated_record(&stored, 256)?,
         };
         let included = if push_if_fits(&mut output, truncated, max_bytes)? {
             true
@@ -227,7 +227,7 @@ fn bounded_output(
                 &mut output,
                 OutputRecord {
                     event_id,
-                    record: truncated_record(&stored, 0),
+                    record: truncated_record(&stored, 0)?,
                 },
                 max_bytes,
             )?
@@ -280,24 +280,23 @@ impl Write for ByteCounter {
     }
 }
 
-fn truncated_record(stored: &DecodedStoredRecord, preview_bytes: usize) -> Value {
+fn truncated_record(
+    stored: &DecodedStoredRecord,
+    preview_bytes: usize,
+) -> Result<Value, serde_json::Error> {
     let payload = stored.record.payload_json();
     let mut preview_end = preview_bytes.min(payload.len());
     while !payload.is_char_boundary(preview_end) {
         preview_end = preview_end.saturating_sub(1);
     }
-    json!({
-        "schema_version": stored.record.schema_version(),
-        "sequence": stored.record.sequence(),
-        "recorded_at_unix_ms": stored.record.recorded_at_unix_ms(),
-        "source": stored.record.source(),
-        "type": stored.record.kind(),
-        "payload": {
-            "truncated": true,
-            "original_bytes": payload.len(),
-            "preview": &payload[..preview_end]
-        }
-    })
+
+    let mut record = serde_json::to_value(&stored.record)?;
+    record["payload"] = json!({
+        "truncated": true,
+        "original_bytes": payload.len(),
+        "preview": &payload[..preview_end]
+    });
+    Ok(record)
 }
 
 fn input_schema() -> Value {
@@ -362,16 +361,17 @@ fn output_schema() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{APPROX_BYTES_PER_TOKEN, MAX_PAGE_SIZE, SessionTool};
+    use super::{APPROX_BYTES_PER_TOKEN, MAX_PAGE_SIZE, SessionTool, truncated_record};
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::{
-            storage::SessionStorage,
+            storage::{DecodedStoredRecord, SessionStorage},
             transcript::{LocalEvent, SessionStarted, TranscriptRecord, TurnId},
         },
     };
     use nanocodex::{
         Tool,
+        agent::events::{AgentEvent, AgentEventKind},
         tools::contract::{ToolContext, ToolInput, ToolOutputBody},
     };
     use serde_json::{Value, json, value::to_raw_value};
@@ -390,6 +390,32 @@ mod tests {
         assert_eq!(input["additionalProperties"], json!(false));
         assert_eq!(input["properties"]["limit"]["maximum"], MAX_PAGE_SIZE);
         assert_eq!(output["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn truncated_agent_records_preserve_correlation_metadata() {
+        let stored = DecodedStoredRecord {
+            event_id: 7,
+            record: TranscriptRecord::from_agent(
+                11,
+                13,
+                AgentEvent {
+                    protocol_version: 2,
+                    request_id: Arc::from("request"),
+                    seq: 17,
+                    kind: AgentEventKind::ToolResult,
+                    payload: to_raw_value(&json!({"output": "x".repeat(10_000)}))
+                        .unwrap()
+                        .into(),
+                },
+            ),
+        };
+
+        let truncated = truncated_record(&stored, 0).unwrap();
+
+        assert_eq!(truncated["agent"]["protocol_version"], 2);
+        assert_eq!(truncated["agent"]["request_id"], "request");
+        assert_eq!(truncated["agent"]["sequence"], 17);
     }
 
     #[tokio::test]

--- a/src/core/extensions/sessions.rs
+++ b/src/core/extensions/sessions.rs
@@ -1,0 +1,476 @@
+//! Bounded, read-only access to V2 session transcripts.
+
+use crate::tui::{
+    storage::{DecodedStoredRecord, SessionStorage, StorageError, StoredRecord},
+    transcript::TranscriptRecord,
+};
+use nanocodex::{
+    Tool,
+    tools::contract::{
+        ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, async_trait,
+    },
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{io, io::Write, path::PathBuf};
+use thiserror::Error;
+
+const APPROX_BYTES_PER_TOKEN: usize = 4;
+const CURSOR_RESERVE_BYTES: usize = 32;
+const DEFAULT_PAGE_SIZE: usize = 20;
+const MAX_PAGE_SIZE: usize = 100;
+const MAX_KIND_FILTERS: usize = 16;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReadSessionInput {
+    session_id: String,
+    #[serde(default)]
+    cursor: Option<i64>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    kinds: Option<Vec<String>>,
+}
+
+#[derive(Serialize)]
+struct ReadSessionOutput {
+    session_id: String,
+    records: Vec<OutputRecord>,
+    scanned_records: usize,
+    next_cursor: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct OutputRecord {
+    event_id: i64,
+    record: Value,
+}
+
+#[derive(Serialize)]
+struct BorrowedOutputRecord<'a> {
+    event_id: i64,
+    record: &'a TranscriptRecord,
+}
+
+#[derive(Debug, Error)]
+enum ReadError {
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+    #[error(transparent)]
+    Encode(#[from] serde_json::Error),
+    #[error("the tool output budget is too small to read the next session record")]
+    OutputBudgetTooSmall,
+}
+
+pub(crate) struct SessionTool {
+    config_path: PathBuf,
+}
+
+impl SessionTool {
+    pub(crate) const fn new(config_path: PathBuf) -> Self {
+        Self { config_path }
+    }
+
+    async fn read(
+        &self,
+        session_id: String,
+        cursor: Option<i64>,
+        limit: Option<usize>,
+        kinds: Option<Vec<String>>,
+        output_token_budget: usize,
+    ) -> ToolResult {
+        if session_id.trim().is_empty() {
+            return Err(io::Error::other("session ID is empty").into());
+        }
+        if cursor.is_some_and(|cursor| cursor < 0) {
+            return Err(io::Error::other("session cursor cannot be negative").into());
+        }
+        let limit = limit.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(1..=MAX_PAGE_SIZE).contains(&limit) {
+            return Err(io::Error::other("session page size must be between 1 and 100").into());
+        }
+        if kinds
+            .as_ref()
+            .is_some_and(|kinds| kinds.is_empty() || kinds.len() > MAX_KIND_FILTERS)
+        {
+            return Err(io::Error::other("provide between 1 and 16 record kinds").into());
+        }
+        if kinds.as_ref().is_some_and(|kinds| {
+            kinds
+                .iter()
+                .any(|kind| kind.trim().is_empty() || kind.len() > 64)
+        }) {
+            return Err(io::Error::other("record kinds must contain 1 to 64 bytes").into());
+        }
+
+        let config_path = self.config_path.clone();
+        let requested_id = session_id.clone();
+        let output = tokio::task::spawn_blocking(move || {
+            let Some(storage) = SessionStorage::open_read_only(&config_path)? else {
+                return Ok(None);
+            };
+            let Some(page) = storage.load_record_page(&requested_id, cursor, limit)? else {
+                return Ok(None);
+            };
+            bounded_output(
+                requested_id,
+                cursor,
+                page.records,
+                page.next_cursor.is_some(),
+                kinds.as_deref(),
+                output_token_budget,
+            )
+            .map(Some)
+        })
+        .await??
+        .ok_or_else(|| io::Error::other(format!("session {session_id} was not found")))?;
+        Ok(ToolOutput::from_json(serde_json::to_value(output)?, true))
+    }
+}
+
+#[async_trait]
+impl Tool for SessionTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "read_session",
+            "Reads at most one bounded page of a referenced Tact V2 session; it never loads the full transcript. Use kinds to return only relevant record types, and pass next_cursor back as cursor only when another page is needed. For broad searches, call this tool from code mode, iterate pages, filter results, and stop as soon as sufficient evidence is found.",
+            input_schema(),
+        )
+        .with_output_schema(output_schema())
+    }
+
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        let ReadSessionInput {
+            session_id,
+            cursor,
+            limit,
+            kinds,
+        } = input.decode_json()?;
+        self.read(
+            session_id,
+            cursor,
+            limit,
+            kinds,
+            context.output_token_budget(),
+        )
+        .await
+    }
+}
+
+fn bounded_output(
+    session_id: String,
+    initial_cursor: Option<i64>,
+    records: Vec<StoredRecord>,
+    storage_has_more: bool,
+    kinds: Option<&[String]>,
+    output_token_budget: usize,
+) -> Result<ReadSessionOutput, ReadError> {
+    let page_records = records.len();
+    let max_bytes = output_token_budget.saturating_mul(APPROX_BYTES_PER_TOKEN);
+    let mut cursor = initial_cursor.unwrap_or(0);
+    let mut stopped_early = false;
+    let mut output = ReadSessionOutput {
+        session_id,
+        records: Vec::new(),
+        scanned_records: 0,
+        next_cursor: None,
+    };
+    let empty_output_bytes = serialized_len(&output)?;
+
+    for (index, stored) in records.into_iter().enumerate() {
+        let stored = stored.decode()?;
+        output.scanned_records = output.scanned_records.saturating_add(1);
+        if kinds.is_some_and(|kinds| !kinds.iter().any(|kind| kind == stored.record.kind())) {
+            cursor = stored.event_id;
+            continue;
+        }
+
+        let event_id = stored.event_id;
+        let full_record_bytes = serialized_len(&BorrowedOutputRecord {
+            event_id,
+            record: &stored.record,
+        })?
+        .saturating_add(1);
+        let remaining = max_bytes
+            .saturating_sub(serialized_len(&output)?)
+            .saturating_sub(CURSOR_RESERVE_BYTES);
+        if full_record_bytes <= remaining
+            && push_if_fits(
+                &mut output,
+                OutputRecord {
+                    event_id,
+                    record: serde_json::to_value(&stored.record)?,
+                },
+                max_bytes,
+            )?
+        {
+            cursor = event_id;
+            continue;
+        }
+        let empty_page_capacity = max_bytes
+            .saturating_sub(empty_output_bytes)
+            .saturating_sub(CURSOR_RESERVE_BYTES);
+        if full_record_bytes <= empty_page_capacity {
+            stopped_early = true;
+            break;
+        }
+
+        let truncated = OutputRecord {
+            event_id,
+            record: truncated_record(&stored, 256),
+        };
+        let included = if push_if_fits(&mut output, truncated, max_bytes)? {
+            true
+        } else {
+            push_if_fits(
+                &mut output,
+                OutputRecord {
+                    event_id,
+                    record: truncated_record(&stored, 0),
+                },
+                max_bytes,
+            )?
+        };
+        if included {
+            cursor = event_id;
+            stopped_early = index.saturating_add(1) < page_records;
+        } else {
+            return Err(ReadError::OutputBudgetTooSmall);
+        }
+        break;
+    }
+
+    output.next_cursor = (stopped_early || storage_has_more).then_some(cursor);
+    if serialized_len(&output)? > max_bytes {
+        return Err(ReadError::OutputBudgetTooSmall);
+    }
+    Ok(output)
+}
+
+fn push_if_fits(
+    output: &mut ReadSessionOutput,
+    record: OutputRecord,
+    max_bytes: usize,
+) -> Result<bool, serde_json::Error> {
+    output.records.push(record);
+    if serialized_len(output)?.saturating_add(CURSOR_RESERVE_BYTES) <= max_bytes {
+        return Ok(true);
+    }
+    output.records.pop();
+    Ok(false)
+}
+
+fn serialized_len(value: &impl Serialize) -> Result<usize, serde_json::Error> {
+    let mut counter = ByteCounter(0);
+    serde_json::to_writer(&mut counter, value)?;
+    Ok(counter.0)
+}
+
+struct ByteCounter(usize);
+
+impl Write for ByteCounter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0 = self.0.saturating_add(buffer.len());
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn truncated_record(stored: &DecodedStoredRecord, preview_bytes: usize) -> Value {
+    let payload = stored.record.payload_json();
+    let mut preview_end = preview_bytes.min(payload.len());
+    while !payload.is_char_boundary(preview_end) {
+        preview_end = preview_end.saturating_sub(1);
+    }
+    json!({
+        "schema_version": stored.record.schema_version(),
+        "sequence": stored.record.sequence(),
+        "recorded_at_unix_ms": stored.record.recorded_at_unix_ms(),
+        "source": stored.record.source(),
+        "type": stored.record.kind(),
+        "payload": {
+            "truncated": true,
+            "original_bytes": payload.len(),
+            "preview": &payload[..preview_end]
+        }
+    })
+}
+
+fn input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The exact ID following @@ in the user's prompt."
+            },
+            "cursor": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "The next_cursor returned by the preceding page. Omit for the first page."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_PAGE_SIZE,
+                "default": DEFAULT_PAGE_SIZE,
+                "description": "Maximum records read from disk in this page before applying kinds."
+            },
+            "kinds": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+                "minItems": 1,
+                "maxItems": MAX_KIND_FILTERS,
+                "uniqueItems": true,
+                "description": "Optional exact transcript record types to return, such as user.submitted or assistant.message. Filtering is confined to this bounded page."
+            }
+        },
+        "required": ["session_id"],
+        "additionalProperties": false
+    })
+}
+
+fn output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "session_id": { "type": "string" },
+            "records": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "event_id": { "type": "integer" },
+                        "record": { "type": "object" }
+                    },
+                    "required": ["event_id", "record"],
+                    "additionalProperties": false
+                }
+            },
+            "scanned_records": { "type": "integer", "minimum": 0 },
+            "next_cursor": { "type": ["integer", "null"] }
+        },
+        "required": ["session_id", "records", "scanned_records", "next_cursor"],
+        "additionalProperties": false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{APPROX_BYTES_PER_TOKEN, MAX_PAGE_SIZE, SessionTool};
+    use crate::{
+        app::config::{ReasoningEffort, ReasoningMode},
+        tui::{
+            storage::SessionStorage,
+            transcript::{LocalEvent, SessionStarted, TranscriptRecord, TurnId},
+        },
+    };
+    use nanocodex::{
+        Tool,
+        tools::contract::{ToolContext, ToolInput, ToolOutputBody},
+    };
+    use serde_json::{Value, json, value::to_raw_value};
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    #[test]
+    fn definition_exposes_a_closed_bounded_reader() {
+        let directory = tempdir().unwrap();
+        let tool = SessionTool::new(directory.path().join("config.toml"));
+        let definition = tool.definition();
+        let input = definition.parameters().unwrap().as_value();
+        let output = definition.output_schema().unwrap().as_value();
+
+        assert_eq!(definition.name(), "read_session");
+        assert_eq!(input["additionalProperties"], json!(false));
+        assert_eq!(input["properties"]["limit"]["maximum"], MAX_PAGE_SIZE);
+        assert_eq!(output["additionalProperties"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn reads_a_referenced_session_end_to_end() {
+        let directory = tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config_path).unwrap();
+        let records = [
+            Arc::new(
+                TranscriptRecord::from_local(
+                    1,
+                    1,
+                    LocalEvent::SessionStarted(SessionStarted {
+                        session_id: "referenced".to_owned(),
+                        parent_session_id: None,
+                        model: "model".to_owned(),
+                        effort: ReasoningEffort::Medium,
+                        reasoning_mode: ReasoningMode::Standard,
+                        fast_mode: false,
+                        workspace: "/work".into(),
+                        application_version: "test".to_owned(),
+                    }),
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                TranscriptRecord::from_local(
+                    2,
+                    2,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(1),
+                        text: "x".repeat(10_000),
+                    },
+                )
+                .unwrap(),
+            ),
+        ];
+        storage.append_records("referenced", &records).unwrap();
+        storage
+            .append_raw_record("referenced", b"not-json")
+            .unwrap();
+
+        let tool = SessionTool::new(config_path);
+        let input = ToolInput::Function(
+            to_raw_value(&json!({
+                "session_id": "referenced",
+                "limit": 3,
+                "kinds": ["user.submitted"]
+            }))
+            .unwrap(),
+        );
+        let context = ToolContext::new("test-model", "current", "test-call", &[], 128);
+        let output = tool.execute(input, context).await.unwrap();
+        let ToolOutputBody::Text(output) = output.output else {
+            panic!("session reader returned non-text output");
+        };
+        assert!(output.len() <= 128 * APPROX_BYTES_PER_TOKEN);
+        let output: Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(output["session_id"], "referenced");
+        assert_eq!(output["records"].as_array().unwrap().len(), 1);
+        assert_eq!(output["records"][0]["record"]["type"], "user.submitted");
+        assert_eq!(output["records"][0]["record"]["payload"]["truncated"], true);
+        assert_eq!(output["scanned_records"], 2);
+        assert!(output["next_cursor"].is_number());
+
+        let input = ToolInput::Function(
+            to_raw_value(&json!({
+                "session_id": "referenced",
+                "limit": 2,
+                "kinds": ["does.not.exist"]
+            }))
+            .unwrap(),
+        );
+        let context = ToolContext::new("test-model", "current", "tiny-call", &[], 1);
+        let Err(error) = tool.execute(input, context).await else {
+            panic!("tiny output budget unexpectedly succeeded");
+        };
+        assert_eq!(
+            error.to_string(),
+            "the tool output budget is too small to read the next session record"
+        );
+    }
+}

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -8,7 +8,10 @@ use super::{
         AgentDirectoryEntry, AgentSummary, OutputContract, Registry, RootAgentGuard, forward_events,
     },
 };
-use crate::core::extensions::memory::{MemoryStore, MemoryTool};
+use crate::core::extensions::{
+    memory::{MemoryStore, MemoryTool},
+    sessions::SessionTool,
+};
 use nanocodex::{
     Tool, Tools,
     agent::AgentHandle,
@@ -20,6 +23,7 @@ use nanocodex::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{
+    path::PathBuf,
     sync::{Arc, Weak},
     time::Duration,
 };
@@ -497,8 +501,11 @@ pub(crate) fn install_tools(
     registry: Arc<Registry>,
     memory: Option<MemoryStore>,
     subagents_enabled: bool,
+    session_config_path: PathBuf,
 ) -> Result<Tools, ToolsBuildError> {
-    let mut tools = tools.into_builder();
+    let mut tools = tools
+        .into_builder()
+        .tool(SessionTool::new(session_config_path));
     if subagents_enabled {
         tools = tools
             .tool(SpawnAgent {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -62,6 +62,14 @@ const TACT_INSTRUCTIONS: &str = concat!(
     "file before reading or changing it."
 );
 
+const SESSION_REFERENCE_INSTRUCTIONS: &str = concat!(
+    "Session references use `@@<session-id>`. When the user references one, use `read_session` ",
+    "to inspect only the relevant bounded transcript pages. Prefer record-kind filters. For broad ",
+    "searches, use code mode to page with `next_cursor`, filter the results, and stop as soon as ",
+    "you have enough evidence. Do not treat the ID itself as session content or load additional ",
+    "pages unless they are needed."
+);
+
 const MEMORY_INSTRUCTIONS: &str = concat!(
     "Global memory is available through the explicit `memory` tool. At the beginning of every ",
     "substantial task, use code mode to scan memory before planning or delegating. Await the scan ",
@@ -181,6 +189,7 @@ impl ConfiguredAgent {
         let memory_enabled = config.memory().enabled();
         let subagents_enabled = config.subagents().enabled();
         let memory = memory_enabled.then(|| MemoryStore::new(config.memory_path()));
+        let session_config_path = config.path().to_path_buf();
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
         let mut builder = Nanocodex::builder(openai)
@@ -195,6 +204,7 @@ impl ConfiguredAgent {
                     Arc::clone(&subagents),
                     memory.clone(),
                     subagents_enabled,
+                    session_config_path.clone(),
                 )
             });
         if let Some(codex_home) = config.codex_home() {
@@ -387,6 +397,7 @@ fn session_instructions(
             let instructions = reconcile_memory_instructions(instructions, false);
             let instructions = reconcile_tact_instructions(instructions);
             let instructions = reconcile_tool_orchestration_instructions(instructions);
+            let instructions = reconcile_session_reference_instructions(instructions);
             let instructions = reconcile_subagent_instructions(instructions, subagents_enabled);
             let instructions = reconcile_memory_instructions(instructions, memory_enabled);
             let skills = if catalog_present.unwrap_or(true) {
@@ -444,6 +455,7 @@ fn fresh_instructions_with_catalog(
         .unwrap_or_else(|| ResponsesServiceConfig::default().system_prompt.to_string());
     instructions = reconcile_tact_instructions(instructions);
     instructions = reconcile_tool_orchestration_instructions(instructions);
+    instructions = reconcile_session_reference_instructions(instructions);
     if subagents_enabled {
         instructions.push_str("\n\n");
         instructions.push_str(SUBAGENT_INSTRUCTIONS);
@@ -491,6 +503,19 @@ fn reconcile_tool_orchestration_instructions(mut instructions: String) -> String
     instructions
 }
 
+fn reconcile_session_reference_instructions(mut instructions: String) -> String {
+    let separator_and_instructions = format!("\n\n{SESSION_REFERENCE_INSTRUCTIONS}");
+    let occurrences = instructions.matches(&separator_and_instructions).count();
+    if occurrences == 1 {
+        return instructions;
+    }
+    if occurrences > 1 {
+        instructions = instructions.replace(&separator_and_instructions, "");
+    }
+    instructions.push_str(&separator_and_instructions);
+    instructions
+}
+
 fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> String {
     let separator_and_instructions = format!("\n\n{SUBAGENT_INSTRUCTIONS}");
     if enabled {
@@ -521,9 +546,10 @@ impl Cancellation {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT, SUBAGENT_INSTRUCTIONS,
-        TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions,
-        reconcile_tact_instructions, session_instructions,
+        ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT,
+        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, TACT_INSTRUCTIONS,
+        TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions, reconcile_tact_instructions,
+        session_instructions,
     };
     use crate::{
         app::{
@@ -596,12 +622,14 @@ mod tests {
 
         assert_eq!(
             fresh_instructions(None, None, &disabled),
-            format!("{default}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}")
+            format!(
+                "{default}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}"
+            )
         );
         assert_eq!(
             fresh_instructions(Some("Custom instructions."), None, &disabled),
             format!(
-                "Custom instructions.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}"
+                "Custom instructions.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}"
             )
         );
     }
@@ -644,7 +672,7 @@ mod tests {
         assert_eq!(
             instructions,
             format!(
-                "{default}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions."
+                "{default}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions."
             )
         );
         assert_eq!(
@@ -654,7 +682,7 @@ mod tests {
                 &disabled
             ),
             format!(
-                "Replacement.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions."
+                "Replacement.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\nProject instructions."
             )
         );
     }
@@ -706,7 +734,7 @@ mod tests {
         let instructions = fresh_instructions(Some("Keep this first."), None, &enabled);
 
         assert!(instructions.starts_with(&format!(
-            "Keep this first.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\n## Available local skills"
+            "Keep this first.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}\n\n{SUBAGENT_INSTRUCTIONS}\n\n## Available local skills"
         )));
         assert!(instructions.contains("Run focused tests."));
         assert!(!instructions.contains("SECRET-BODY"));
@@ -765,7 +793,9 @@ mod tests {
             )
             .text
             .as_ref(),
-            format!("{stored}\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!(
+                "{stored}\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}"
+            )
         );
         let restored = session_instructions(
             None,
@@ -777,7 +807,9 @@ mod tests {
         );
         assert_eq!(
             restored.text.as_ref(),
-            format!("{stored}\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!(
+                "{stored}\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}"
+            )
         );
         assert_eq!(
             restored.skills.as_ref(),
@@ -845,7 +877,9 @@ mod tests {
             )
             .text
             .as_ref(),
-            format!("Old default.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!(
+                "Old default.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}"
+            )
         );
         assert_eq!(
             session_instructions(
@@ -858,7 +892,9 @@ mod tests {
             )
             .text
             .as_ref(),
-            format!("Old custom.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!(
+                "Old custom.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}"
+            )
         );
     }
 
@@ -913,7 +949,9 @@ mod tests {
         );
         assert_eq!(
             restored_disabled.text.as_ref(),
-            format!("Stored.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}")
+            format!(
+                "Stored.\n\n{TACT_INSTRUCTIONS}\n\n{TOOL_ORCHESTRATION_INSTRUCTIONS}\n\n{SESSION_REFERENCE_INSTRUCTIONS}"
+            )
         );
     }
 

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -669,7 +669,7 @@ fn benchmarks(criterion: &mut Criterion) {
 
     sessions.bench_function("catalog_semantic_archive", |bencher| {
         bencher.iter(|| {
-            black_box(session::list(&fixture.config_path, &fixture.workspace).unwrap());
+            black_box(session::list(&fixture.config_path, &fixture.workspace, true).unwrap());
         });
     });
 

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -755,7 +755,10 @@ fn is_control_c(event: &Event) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{AppEffect, AppEvent, AppNode, RootEffect, RootEvent, RootNode, SPLIT_HINT};
+    use super::{
+        super::SessionListKind, AppEffect, AppEvent, AppNode, RootEffect, RootEvent, RootNode,
+        SPLIT_HINT,
+    };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         core::extensions::memory::{MemoryKey, MemoryRecord},
@@ -871,7 +874,7 @@ mod tests {
             update.effects.as_slice(),
             [AppEffect::Pane {
                 pane: PaneId::Main,
-                effect: RootEffect::LoadSessions,
+                effect: RootEffect::LoadSessions(SessionListKind::Resume),
             }]
         ));
         assert_eq!(update.render, super::RenderRequest::Immediate);

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -39,7 +39,7 @@ use unicode_width::UnicodeWidthStr;
 
 const MIN_CONTENT_ROWS: usize = 3;
 const MAX_CONTENT_ROWS: usize = 6;
-const ENTRY_HINT: &str = " / actions · @ files ";
+const ENTRY_HINT: &str = " / actions · @ files · @@ sessions ";
 const DEVELOPMENT_BADGE: &str = " ◉ dev ";
 
 #[derive(Debug, Eq, PartialEq)]
@@ -1448,9 +1448,9 @@ mod tests {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         let terminal = render(&mut composer, 60, 5);
         let footer = if crate::app::installation::current().is_development() {
-            "╰─ / actions · @ files ───────────────────── ◉ dev  /work ─╯"
+            "╰─ / actions · @ files · @@ sessions ─────── ◉ dev  /work ─╯"
         } else {
-            "╰─ / actions · @ files ──────────────────────────── /work ─╯"
+            "╰─ / actions · @ files · @@ sessions ───────────────── /work ─╯"
         };
 
         assert_eq!(
@@ -1629,7 +1629,7 @@ mod tests {
     #[test]
     fn entry_hint_is_only_shown_for_an_empty_draft_with_room() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
-        assert!(rows(&render(&mut composer, 40, 5))[4].contains("/ actions · @ files"));
+        assert!(rows(&render(&mut composer, 60, 5))[4].contains("@@ sessions"));
 
         composer.replace_draft("hello".to_owned());
         assert!(!rows(&render(&mut composer, 40, 5))[4].contains("/ actions"));

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -26,4 +26,6 @@ mod waved_text;
 pub(crate) use app::{AppEffect, AppEvent, AppNode};
 pub(crate) use node::{ComponentUpdate, RenderRequest};
 pub(crate) use queue::QueueId;
-pub(crate) use root::{RecentPromptDraft, RestoredSessionProjection, RootEffect, RootNode};
+pub(crate) use root::{
+    RecentPromptDraft, RestoredSessionProjection, RootEffect, RootNode, SessionListKind,
+};

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -18,7 +18,7 @@ use super::{
         ReviewConfirmationEffect, ReviewConfirmationEvent, ReviewDownloadConfirmation,
     },
     selection::{Selection, Surface, TextSpan},
-    session_picker::{SessionPicker, SessionPickerEffect, SessionPickerEvent},
+    session_picker::{SessionPicker, SessionPickerEffect, SessionPickerEvent, SessionPickerMode},
     skill_picker::{SkillPicker, SkillPickerEffect, SkillPickerEvent},
     subagents::{SubagentEffect, SubagentOverlay, SubagentTree},
     theme_selector::{ThemeSelector, ThemeSelectorEffect, ThemeSelectorEvent},
@@ -211,6 +211,12 @@ pub(crate) struct RecentPromptDraft {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+pub(crate) enum SessionListKind {
+    Resume,
+    Mention,
+}
+
+#[derive(Debug, Eq, PartialEq)]
 pub(crate) enum RootEffect {
     Submit(Submission),
     RunShell(String),
@@ -223,7 +229,7 @@ pub(crate) enum RootEffect {
     OpenLink(String),
     ReloadConfig,
     NewSession,
-    LoadSessions,
+    LoadSessions(SessionListKind),
     LoadRecentPrompts(Vec<RecentPromptDraft>),
     LoadMemories,
     DeleteMemory(MemoryKey),
@@ -319,6 +325,7 @@ pub(crate) struct RootNode {
     subagents: SubagentTree,
     context_diagnostics: ContextDiagnostics,
     recent_prompts: Vec<RecentPromptDraft>,
+    pending_session_mention: Option<usize>,
 }
 
 impl RootNode {
@@ -352,6 +359,7 @@ impl RootNode {
             subagents: SubagentTree::new(thinking),
             context_diagnostics: ContextDiagnostics::default(),
             recent_prompts: Vec::new(),
+            pending_session_mention: None,
         }
     }
 
@@ -1195,6 +1203,18 @@ impl RootNode {
             return ComponentUpdate::none();
         }
 
+        let starts_session_mention = is_file_finder_trigger(&event)
+            && self
+                .mention_query(start, '@')
+                .is_some_and(|query| query.is_empty());
+        if starts_session_mention {
+            let composer =
+                self.update_composer(ComposerEvent::Terminal(event), RenderRequest::Immediate);
+            let mut sessions = self.load_session_mentions(start);
+            sessions.render = sessions.render.max(composer.render);
+            return sessions;
+        }
+
         if is_mention_edit(&event) {
             let keep_open = mention_edit_continues_query(&event, is_file_query_character);
             let update =
@@ -1562,6 +1582,7 @@ impl RootNode {
 
     pub(super) fn load_sessions(&mut self) -> ComponentUpdate<RootEffect> {
         self.overlay = None;
+        self.pending_session_mention = None;
         self.interactive = false;
         let _ = self
             .composer
@@ -1572,7 +1593,25 @@ impl RootNode {
                 now: Instant::now(),
             });
         ComponentUpdate {
-            effects: vec![RootEffect::LoadSessions],
+            effects: vec![RootEffect::LoadSessions(SessionListKind::Resume)],
+            render: RenderRequest::Immediate,
+        }
+    }
+
+    fn load_session_mentions(&mut self, start: usize) -> ComponentUpdate<RootEffect> {
+        self.overlay = None;
+        self.pending_session_mention = Some(start);
+        self.interactive = false;
+        let _ = self
+            .composer
+            .component_mut()
+            .update(ComposerEvent::Activity {
+                active: true,
+                status: Some("Loading sessions…".to_owned()),
+                now: Instant::now(),
+            });
+        ComponentUpdate {
+            effects: vec![RootEffect::LoadSessions(SessionListKind::Mention)],
             render: RenderRequest::Immediate,
         }
     }
@@ -1661,7 +1700,14 @@ impl RootNode {
                 status: None,
                 now: Instant::now(),
             });
-        self.overlay = Some(Overlay::Sessions(Node::new(SessionPicker::new(sessions))));
+        let mode = if self.pending_session_mention.is_some() {
+            SessionPickerMode::Mention
+        } else {
+            SessionPickerMode::Resume
+        };
+        self.overlay = Some(Overlay::Sessions(Node::new(SessionPicker::new(
+            sessions, mode,
+        ))));
         ComponentUpdate::render(RenderRequest::Immediate)
     }
 
@@ -1673,6 +1719,7 @@ impl RootNode {
         match update.effects.into_iter().next() {
             Some(SessionPickerEffect::Dismiss) => {
                 self.overlay = None;
+                self.pending_session_mention = None;
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
             Some(SessionPickerEffect::Resume(session_id)) => {
@@ -1691,6 +1738,19 @@ impl RootNode {
                     render: RenderRequest::Immediate,
                 }
             }
+            Some(SessionPickerEffect::Mention(session_id)) => {
+                self.overlay = None;
+                let Some(start) = self.pending_session_mention.take() else {
+                    return ComponentUpdate::none();
+                };
+                self.update_composer(
+                    ComposerEvent::ReplaceRange {
+                        range: start..self.composer.component().cursor(),
+                        text: format!("@@{session_id} "),
+                    },
+                    RenderRequest::Immediate,
+                )
+            }
             None => ComponentUpdate {
                 effects: Vec::new(),
                 render: update.render,
@@ -1699,6 +1759,7 @@ impl RootNode {
     }
 
     fn session_load_failed(&mut self, message: String) -> ComponentUpdate<RootEffect> {
+        self.pending_session_mention = None;
         self.interactive = true;
         let _ = self
             .composer
@@ -2704,7 +2765,7 @@ fn is_plain_key(event: &Event, character: char) -> bool {
 mod tests {
     use super::{
         Component, ComposerChromeTarget, ConfirmationAction, Overlay, RenderRequest, RootEffect,
-        RootEvent, RootNode, SubagentOverlay, ThreadState, TranscriptEvent,
+        RootEvent, RootNode, SessionListKind, SubagentOverlay, ThreadState, TranscriptEvent,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -2714,7 +2775,7 @@ mod tests {
             subagents::{AgentDescriptor, AgentId, AgentMessageUpdate, AgentStatus, AgentUpdate},
         },
         tui::{
-            session::RecentPrompt,
+            session::{RecentPrompt, SessionSummary},
             theme::{Theme, ThemeMode},
             transcript::{LocalEvent, TranscriptRecord, TurnId},
         },
@@ -3611,6 +3672,54 @@ mod tests {
         assert!(matches!(&root.overlay, Some(Overlay::FileFinder(_))));
         assert!(update.effects.is_empty());
         assert_eq!(update.render, super::RenderRequest::None);
+    }
+
+    #[test]
+    fn second_at_switches_from_files_to_session_mentions() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut root = RootNode::new(workspace.path(), ReasoningEffort::Medium);
+        for character in "compare ".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        root.update(key(KeyCode::Char('@'), KeyModifiers::NONE));
+
+        let loading = root.update(key(KeyCode::Char('@'), KeyModifiers::NONE));
+
+        assert_eq!(root.composer().draft(), "compare @@");
+        assert!(root.overlay.is_none());
+        assert_eq!(
+            loading.effects,
+            [RootEffect::LoadSessions(SessionListKind::Mention)]
+        );
+
+        root.update(RootEvent::SessionsLoaded(vec![SessionSummary {
+            session_id: "session-123".to_owned(),
+            started_at_unix_ms: 1,
+            model: "model".to_owned(),
+            effort: ReasoningEffort::Medium,
+            reasoning_mode: ReasoningMode::Standard,
+            workspace: workspace.path().to_path_buf(),
+            preview: "earlier investigation".to_owned(),
+        }]));
+        assert!(matches!(&root.overlay, Some(Overlay::Sessions(_))));
+
+        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(root.overlay.is_none());
+        assert_eq!(root.composer().draft(), "compare @@session-123 ");
+    }
+
+    #[test]
+    fn later_at_closes_file_suggestions_without_opening_sessions() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut root = RootNode::new(workspace.path(), ReasoningEffort::Medium);
+        for character in "@someone@".chars() {
+            let update = root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+            assert!(update.effects.is_empty());
+        }
+
+        assert!(root.overlay.is_none());
+        assert_eq!(root.composer().draft(), "@someone@");
     }
 
     #[test]

--- a/src/tui/components/session_picker.rs
+++ b/src/tui/components/session_picker.rs
@@ -19,7 +19,8 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab resume", "esc close"];
+const RESUME_KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab resume", "esc close"];
+const MENTION_KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab insert", "esc close"];
 const SEARCH_LABEL: &str = "Search: ";
 
 pub(super) enum SessionPickerEvent {
@@ -30,6 +31,13 @@ pub(super) enum SessionPickerEvent {
 pub(super) enum SessionPickerEffect {
     Dismiss,
     Resume(String),
+    Mention(String),
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum SessionPickerMode {
+    Resume,
+    Mention,
 }
 
 pub(super) struct SessionPicker {
@@ -37,16 +45,18 @@ pub(super) struct SessionPicker {
     query: String,
     matches: Vec<usize>,
     selected: usize,
+    mode: SessionPickerMode,
 }
 
 impl SessionPicker {
-    pub(super) fn new(sessions: Vec<SessionSummary>) -> Self {
+    pub(super) fn new(sessions: Vec<SessionSummary>, mode: SessionPickerMode) -> Self {
         let matches = (0..sessions.len()).collect();
         Self {
             sessions,
             query: String::new(),
             matches,
             selected: 0,
+            mode,
         }
     }
 
@@ -77,7 +87,7 @@ impl SessionPicker {
                 }
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
-            KeyCode::Enter | KeyCode::Tab => self.resume_selected(),
+            KeyCode::Enter | KeyCode::Tab => self.select(),
             KeyCode::Char(character)
                 if !key
                     .modifiers
@@ -98,13 +108,16 @@ impl SessionPicker {
         ComponentUpdate::render(RenderRequest::Immediate)
     }
 
-    fn resume_selected(&mut self) -> ComponentUpdate<SessionPickerEffect> {
+    fn select(&mut self) -> ComponentUpdate<SessionPickerEffect> {
         let Some(index) = self.matches.get(self.selected) else {
             return ComponentUpdate::none();
         };
-        Self::effect(SessionPickerEffect::Resume(
-            self.sessions[*index].session_id.clone(),
-        ))
+        let session_id = self.sessions[*index].session_id.clone();
+        let effect = match self.mode {
+            SessionPickerMode::Resume => SessionPickerEffect::Resume(session_id),
+            SessionPickerMode::Mention => SessionPickerEffect::Mention(session_id),
+        };
+        Self::effect(effect)
     }
 
     fn effect(effect: SessionPickerEffect) -> ComponentUpdate<SessionPickerEffect> {
@@ -150,9 +163,12 @@ impl SessionPicker {
             return;
         }
         if self.matches.is_empty() {
+            let message = match self.mode {
+                SessionPickerMode::Resume => "  No resumable sessions found",
+                SessionPickerMode::Mention => "  No other sessions found",
+            };
             frame.render_widget(
-                Paragraph::new("  No resumable sessions found")
-                    .style(Style::default().fg(theme.muted())),
+                Paragraph::new(message).style(Style::default().fg(theme.muted())),
                 area,
             );
             return;
@@ -217,8 +233,11 @@ impl Component for SessionPicker {
     }
 
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
-        let layout =
-            Floating::new("Resume session", 76, 18, &KEY_BINDINGS).render(frame, area, theme);
+        let (title, key_bindings) = match self.mode {
+            SessionPickerMode::Resume => ("Resume session", &RESUME_KEY_BINDINGS),
+            SessionPickerMode::Mention => ("Mention session", &MENTION_KEY_BINDINGS),
+        };
+        let layout = Floating::new(title, 76, 18, key_bindings).render(frame, area, theme);
         if layout.body.is_empty() {
             return;
         }
@@ -249,7 +268,9 @@ fn visible_tail(query: &str, width: usize) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{Component, SessionPicker, SessionPickerEffect, SessionPickerEvent};
+    use super::{
+        Component, SessionPicker, SessionPickerEffect, SessionPickerEvent, SessionPickerMode,
+    };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::session::SessionSummary,
@@ -275,10 +296,10 @@ mod tests {
 
     #[test]
     fn search_selects_a_session_by_preview() {
-        let mut picker = SessionPicker::new(vec![
-            summary("one", "fix parser"),
-            summary("two", "write docs"),
-        ]);
+        let mut picker = SessionPicker::new(
+            vec![summary("one", "fix parser"), summary("two", "write docs")],
+            SessionPickerMode::Resume,
+        );
         for character in "docs".chars() {
             picker.update(key(KeyCode::Char(character)));
         }
@@ -289,11 +310,24 @@ mod tests {
     }
 
     #[test]
+    fn mention_mode_returns_a_reference_instead_of_resuming() {
+        let mut picker = SessionPicker::new(
+            vec![summary("one", "fix parser")],
+            SessionPickerMode::Mention,
+        );
+
+        assert_eq!(
+            picker.update(key(KeyCode::Enter)).effects,
+            [SessionPickerEffect::Mention("one".to_owned())]
+        );
+    }
+
+    #[test]
     fn tab_resumes_the_selected_session() {
-        let mut picker = SessionPicker::new(vec![
-            summary("one", "fix parser"),
-            summary("two", "write docs"),
-        ]);
+        let mut picker = SessionPicker::new(
+            vec![summary("one", "fix parser"), summary("two", "write docs")],
+            SessionPickerMode::Resume,
+        );
         for character in "docs".chars() {
             picker.update(key(KeyCode::Char(character)));
         }
@@ -306,10 +340,10 @@ mod tests {
 
     #[test]
     fn arrows_navigate_while_typing_continues_to_search() {
-        let mut picker = SessionPicker::new(vec![
-            summary("one", "fix parser"),
-            summary("two", "write docs"),
-        ]);
+        let mut picker = SessionPicker::new(
+            vec![summary("one", "fix parser"), summary("two", "write docs")],
+            SessionPickerMode::Resume,
+        );
 
         picker.update(key(KeyCode::Down));
         assert_eq!(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,7 +14,7 @@ mod scheduler;
 pub(crate) mod session;
 mod shell;
 mod spinner;
-mod storage;
+pub(crate) mod storage;
 mod subagent_updates;
 mod terminal;
 pub(crate) mod theme;
@@ -2031,7 +2031,7 @@ fn apply_pane_effect(
                 (pane, effort, reasoning_mode, fast_mode, configured)
             }));
         }
-        components::RootEffect::LoadSessions => {
+        components::RootEffect::LoadSessions(kind) => {
             *context.input = None;
             let config_path = context.config.path().to_path_buf();
             let workspace = context.workspace.to_path_buf();
@@ -2042,7 +2042,8 @@ fn apply_pane_effect(
                 .session_id
                 .clone();
             *context.session_list_task = Some(tokio::spawn(async move {
-                let sessions = session::list_async(config_path, workspace)
+                let resumable_only = matches!(kind, components::SessionListKind::Resume);
+                let sessions = session::list_async(config_path, workspace, resumable_only)
                     .await
                     .map(|mut sessions| {
                     sessions.retain(|session| session.session_id != active_session_id);

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -145,12 +145,13 @@ pub(crate) fn load_checkpoint(
 pub(crate) fn list(
     config_path: &Path,
     workspace: &Path,
+    resumable_only: bool,
 ) -> Result<Vec<SessionSummary>, SessionError> {
     let Some(storage) = SessionStorage::open_read_only(config_path)? else {
         return Ok(Vec::new());
     };
     storage
-        .list_sessions(workspace)?
+        .list_sessions(workspace, resumable_only)?
         .into_iter()
         .map(|session| {
             Ok(SessionSummary {
@@ -169,8 +170,9 @@ pub(crate) fn list(
 pub(crate) async fn list_async(
     config_path: PathBuf,
     workspace: PathBuf,
+    resumable_only: bool,
 ) -> Result<Vec<SessionSummary>, SessionError> {
-    tokio::task::spawn_blocking(move || list(&config_path, &workspace))
+    tokio::task::spawn_blocking(move || list(&config_path, &workspace, resumable_only))
         .await
         .map_err(SessionError::StorageTask)?
 }

--- a/src/tui/storage.rs
+++ b/src/tui/storage.rs
@@ -75,6 +75,33 @@ pub(crate) struct StoredPrompt {
     pub(crate) workspace: PathBuf,
 }
 
+#[derive(Debug)]
+pub(crate) struct StoredRecord {
+    pub(crate) event_id: i64,
+    encoded: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub(crate) struct DecodedStoredRecord {
+    pub(crate) event_id: i64,
+    pub(crate) record: TranscriptRecord,
+}
+
+impl StoredRecord {
+    pub(crate) fn decode(self) -> Result<DecodedStoredRecord, StorageError> {
+        Ok(DecodedStoredRecord {
+            event_id: self.event_id,
+            record: decode_record(&self.encoded)?,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct StoredRecordPage {
+    pub(crate) records: Vec<StoredRecord>,
+    pub(crate) next_cursor: Option<i64>,
+}
+
 pub(crate) struct SessionStorage {
     path: PathBuf,
     connection: Connection,
@@ -138,7 +165,6 @@ impl SessionStorage {
             active_turns: HashMap::new(),
         }))
     }
-
     pub(crate) fn append_records(
         &mut self,
         session_id: &str,
@@ -230,6 +256,57 @@ impl SessionStorage {
         Ok(records)
     }
 
+    pub(crate) fn load_record_page(
+        &self,
+        session_id: &str,
+        after_event_id: Option<i64>,
+        limit: usize,
+    ) -> Result<Option<StoredRecordPage>, StorageError> {
+        let exists = self
+            .connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sessions WHERE session_id = ?1)",
+                [session_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(|source| query(&self.path, source))?;
+        if !exists {
+            return Ok(None);
+        }
+
+        let after_event_id = after_event_id.unwrap_or(0);
+        let row_limit = i64::try_from(limit.saturating_add(1)).unwrap_or(i64::MAX);
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT event_id, record_json FROM events\n\
+                 WHERE session_id = ?1 AND event_id > ?2\n\
+                 ORDER BY event_id LIMIT ?3",
+            )
+            .map_err(|source| query(&self.path, source))?;
+        let rows = statement
+            .query_map(params![session_id, after_event_id, row_limit], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?))
+            })
+            .map_err(|source| query(&self.path, source))?;
+        let mut encoded = rows
+            .map(|row| row.map_err(|source| query(&self.path, source)))
+            .collect::<Result<Vec<_>, StorageError>>()?;
+        let has_more = encoded.len() > limit;
+        encoded.truncate(limit);
+        let records = encoded
+            .into_iter()
+            .map(|(event_id, encoded)| StoredRecord { event_id, encoded })
+            .collect::<Vec<_>>();
+        let next_cursor = has_more
+            .then(|| records.last().map(|record| record.event_id))
+            .flatten();
+        Ok(Some(StoredRecordPage {
+            records,
+            next_cursor,
+        }))
+    }
+
     #[cfg(test)]
     pub(crate) fn save_resume_state(
         &mut self,
@@ -239,6 +316,21 @@ impl SessionStorage {
         let compressed =
             zstd::encode_all(encoded, STATE_COMPRESSION_LEVEL).map_err(StorageError::Compress)?;
         write_resume_state(&self.connection, &self.path, session_id, &compressed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn append_raw_record(
+        &self,
+        session_id: &str,
+        encoded: &[u8],
+    ) -> Result<(), StorageError> {
+        self.connection
+            .execute(
+                "INSERT INTO events(session_id, record_json) VALUES (?1, ?2)",
+                params![session_id, encoded],
+            )
+            .map_err(|source| query(&self.path, source))?;
+        Ok(())
     }
 
     pub(crate) fn load_resume_state(
@@ -262,17 +354,25 @@ impl SessionStorage {
     pub(crate) fn list_sessions(
         &self,
         workspace: &Path,
+        resumable_only: bool,
     ) -> Result<Vec<StoredSession>, StorageError> {
         let workspace = workspace.to_string_lossy();
+        let statement_sql = if resumable_only {
+            "SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
+                    s.workspace, s.preview\n\
+             FROM sessions s INNER JOIN resume_states r ON r.session_id = s.session_id\n\
+             WHERE s.workspace = ?1\n\
+             ORDER BY s.updated_at_ms DESC, s.session_id"
+        } else {
+            "SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
+                    s.workspace, s.preview\n\
+             FROM sessions s\n\
+             WHERE s.workspace = ?1\n\
+             ORDER BY s.updated_at_ms DESC, s.session_id"
+        };
         let mut statement = self
             .connection
-            .prepare(
-                "SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
-                        s.workspace, s.preview\n\
-                 FROM sessions s INNER JOIN resume_states r ON r.session_id = s.session_id\n\
-                 WHERE s.workspace = ?1\n\
-                 ORDER BY s.updated_at_ms DESC, s.session_id",
-            )
+            .prepare(statement_sql)
             .map_err(|source| query(&self.path, source))?;
         let rows = statement
             .query_map([workspace.as_ref()], decode_session)
@@ -650,7 +750,7 @@ mod tests {
         tui::transcript::{LocalEvent, SessionStarted, TranscriptRecord, TurnId},
     };
     use rusqlite::Connection;
-    use std::{fs, sync::Arc};
+    use std::{fs, path::Path, sync::Arc};
     use tempfile::tempdir;
 
     #[test]
@@ -697,6 +797,15 @@ mod tests {
     }
 
     #[test]
+    fn read_only_open_does_not_create_missing_v2_storage() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+
+        assert!(SessionStorage::open_read_only(&config).unwrap().is_none());
+        assert!(!database_path(&config).exists());
+    }
+
+    #[test]
     fn recent_prompts_use_occurrence_time_not_writer_commit_order() {
         let directory = tempdir().unwrap();
         let config = directory.path().join("config.toml");
@@ -707,6 +816,83 @@ mod tests {
         let prompts = storage.recent_prompts(10).unwrap();
         assert_eq!(prompts[0].text, "newer prompt");
         assert_eq!(prompts[1].text, "older prompt");
+    }
+
+    #[test]
+    fn transcript_pages_continue_by_event_id_without_loading_the_session() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        append_prompt(&mut storage, "session", 100, "first prompt");
+        append_prompt_record(&mut storage, "session", 3, 200, "second prompt");
+
+        let first = storage
+            .load_record_page("session", None, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.records.len(), 2);
+        assert!(first.next_cursor.is_some());
+
+        let second = storage
+            .load_record_page("session", first.next_cursor, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(second.records.len(), 1);
+        assert!(second.next_cursor.is_none());
+        assert!(second.records[0].event_id > first.records[1].event_id);
+    }
+
+    #[test]
+    fn transcript_page_does_not_decode_its_lookahead_record() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        append_prompt(&mut storage, "session", 100, "prompt");
+        storage.append_raw_record("session", b"not-json").unwrap();
+
+        let page = storage
+            .load_record_page("session", None, 2)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(page.records.len(), 2);
+        assert!(page.next_cursor.is_some());
+    }
+
+    #[test]
+    fn transcript_page_distinguishes_a_missing_session_from_an_empty_page() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let storage = SessionStorage::open(&config).unwrap();
+
+        assert!(
+            storage
+                .load_record_page("missing", None, 10)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn mentionable_sessions_include_sessions_without_resume_state() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        append_prompt(&mut storage, "resumable", 100, "resumable prompt");
+        append_prompt(&mut storage, "transcript-only", 200, "failed turn prompt");
+        storage.save_resume_state("resumable", b"state").unwrap();
+
+        let resumable = storage.list_sessions(Path::new("/work"), true).unwrap();
+        let mentionable = storage.list_sessions(Path::new("/work"), false).unwrap();
+
+        assert_eq!(
+            resumable
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            ["resumable"]
+        );
+        assert_eq!(mentionable.len(), 2);
     }
 
     fn append_prompt(storage: &mut SessionStorage, session_id: &str, at: u64, text: &str) {
@@ -741,5 +927,26 @@ mod tests {
             ),
         ];
         storage.append_records(session_id, &records).unwrap();
+    }
+
+    fn append_prompt_record(
+        storage: &mut SessionStorage,
+        session_id: &str,
+        sequence: u64,
+        at: u64,
+        text: &str,
+    ) {
+        let record = Arc::new(
+            TranscriptRecord::from_local(
+                sequence,
+                at,
+                LocalEvent::UserSubmitted {
+                    id: TurnId::new(sequence),
+                    text: text.to_owned(),
+                },
+            )
+            .unwrap(),
+        );
+        storage.append_records(session_id, &[record]).unwrap();
     }
 }

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -243,10 +243,6 @@ impl TranscriptRecord {
         self.schema_version
     }
 
-    pub(crate) const fn sequence(&self) -> u64 {
-        self.sequence
-    }
-
     pub(crate) const fn recorded_at_unix_ms(&self) -> u64 {
         self.recorded_at_unix_ms
     }

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -243,10 +243,6 @@ impl TranscriptRecord {
         self.schema_version
     }
 
-    #[allow(
-        dead_code,
-        reason = "used when the planned session picker loads transcripts"
-    )]
     pub(crate) const fn sequence(&self) -> u64 {
         self.sequence
     }
@@ -261,6 +257,10 @@ impl TranscriptRecord {
 
     pub(crate) fn source(&self) -> &str {
         &self.source
+    }
+
+    pub(crate) fn payload_json(&self) -> &str {
+        self.payload.get()
     }
 
     pub(crate) fn decode_payload<'a, T>(&'a self) -> Result<T, serde_json::Error>


### PR DESCRIPTION
## Summary
- switch the composer picker from files to sessions when the immediate second @ is entered
- show searchable session previews and insert stable @@session references
- add a read-only, filtered, bounded, pageable read_session tool so agents can inspect only the needed portion
- preserve the existing resume path and Nanocodex session behavior

## Stack
- Depends on #94
- Followed by #96

## Testing
- just check-fmt
- just clippy
- just test (740 tests passed)