### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.3.7"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary
- bump the Tact package version from 0.3.7 to 0.4.0
- update the matching root package entry in Cargo.lock
- preserve the established tag-triggered release workflow

## Stack
- Depends on #96
- Final PR in stack #98

## Testing
- cargo package --locked --allow-dirty --no-verify
- cargo check --all-features
- just check-fmt
- just clippy
- just test (740 tests passed)