### PR TITLE
feat(tui): support readline shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ development server watches browser sources, rebuilds them, and reloads connected
 
 ### Session Forking
 
-Press `Ctrl+F` or choose **Fork session** from the Actions menu to open an independent session next
+Press `Ctrl+T` or choose **Fork session** from the Actions menu to open an independent session next
 to the current one. The fork starts from the stable conversation history available at that point;
 new prompts, model responses, and transcripts then remain independent in each pane.
 

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -1167,7 +1167,7 @@ mod tests {
     #[test]
     fn closing_the_primary_promotes_the_fork() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
         terminal.draw(|frame| app.render(frame)).unwrap();
         app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
@@ -1196,7 +1196,7 @@ mod tests {
     #[test]
     fn promoted_fork_can_open_another_fork() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });
@@ -1211,7 +1211,7 @@ mod tests {
         app.update(control('c'));
         app.update(control('c'));
 
-        let fork = app.update(control('f'));
+        let fork = app.update(control('t'));
 
         assert!(matches!(
             fork.effects.as_slice(),
@@ -1227,7 +1227,7 @@ mod tests {
     #[test]
     fn failed_pending_fork_shuts_down_after_its_parent_closes() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
         terminal.draw(|frame| app.render(frame)).unwrap();
         app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -944,7 +944,7 @@ mod tests {
             record: Arc::new(record),
         });
 
-        let update = app.update(control('f'));
+        let update = app.update(control('t'));
 
         assert!(matches!(
             update.effects.as_slice(),
@@ -971,7 +971,7 @@ mod tests {
         let mut app = app();
         app.update_root(PaneId::Main, RootEvent::ContextTokens(136_000));
 
-        app.update(control('f'));
+        app.update(control('t'));
 
         assert_eq!(
             app.root(PaneId::Fork(1))
@@ -1006,7 +1006,7 @@ mod tests {
     #[test]
     fn fork_effort_changes_do_not_change_the_primary_composer() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });
@@ -1044,7 +1044,7 @@ mod tests {
     #[test]
     fn preferred_reasoning_mode_is_shared_without_changing_running_sessions() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });
@@ -1063,7 +1063,7 @@ mod tests {
         let mut app = app();
         assert!(!rendered(&mut app, 100, 20).contains(SPLIT_HINT.trim()));
 
-        app.update(control('f'));
+        app.update(control('t'));
         let rendered = rendered(&mut app, 100, 20);
 
         assert!(rendered.contains(SPLIT_HINT.trim()));
@@ -1072,7 +1072,7 @@ mod tests {
     #[test]
     fn split_hint_is_hidden_at_narrow_widths() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
 
         let rendered = rendered(&mut app, 40, 10);
 
@@ -1082,7 +1082,7 @@ mod tests {
     #[test]
     fn control_c_closes_only_the_focused_pane_when_multiplexed() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
 
         let confirmation = app.update(control('c'));
 
@@ -1102,7 +1102,7 @@ mod tests {
     #[test]
     fn control_c_clears_the_focused_fork_composer_before_closing_it() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });
@@ -1139,7 +1139,7 @@ mod tests {
     #[test]
     fn clicking_a_pane_focuses_the_session_that_control_c_closes() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
         terminal.draw(|frame| app.render(frame)).unwrap();
         app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
@@ -1250,7 +1250,7 @@ mod tests {
     #[test]
     fn a_second_fork_is_unavailable_until_the_first_closes() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
         terminal.draw(|frame| app.render(frame)).unwrap();
         app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
@@ -1260,7 +1260,7 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         })));
 
-        let update = app.update(control('f'));
+        let update = app.update(control('t'));
 
         assert!(update.effects.is_empty());
         assert!(app.root(PaneId::Fork(1)).is_some());
@@ -1270,7 +1270,7 @@ mod tests {
     #[test]
     fn fork_failure_closes_the_pending_pane_and_surfaces_the_error() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
 
         app.update(AppEvent::ForkFailed {
             pane: PaneId::Fork(1),
@@ -1294,7 +1294,7 @@ mod tests {
     fn memory_operations_and_completions_keep_their_pane_identity() {
         let mut app = app();
         app.set_memory_enabled(true);
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });
@@ -1327,7 +1327,7 @@ mod tests {
     #[test]
     fn config_reload_updates_memory_action_availability_for_every_root() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -1227,7 +1227,7 @@ mod tests {
     #[test]
     fn promoted_fork_refreshes_an_open_actions_menu() {
         let mut app = app();
-        app.update(control('f'));
+        app.update(control('t'));
         app.update(AppEvent::ForkReady {
             pane: PaneId::Fork(1),
         });

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -629,6 +629,9 @@ impl Composer {
         }
 
         if key.modifiers == KeyModifiers::CONTROL {
+            if matches!(key.code, KeyCode::Char('a' | 'b' | 'e' | 'f')) {
+                self.history.detach();
+            }
             return match key.code {
                 KeyCode::Char('a') => ComposerUpdate::from_change(self.move_to_logical_edge(false)),
                 KeyCode::Char('b') => ComposerUpdate::from_change(self.move_left()),
@@ -652,11 +655,17 @@ impl Composer {
             return ComposerUpdate::unchanged();
         }
 
-        let moves_by_word =
-            matches!(key.code, KeyCode::Char('b' | 'f')) && key.modifiers == KeyModifiers::ALT;
-        let detaches_history = matches!(key.code, KeyCode::Char(_)) && !moves_by_word
-            || matches!(key.code, KeyCode::Backspace | KeyCode::Delete)
-            || key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT);
+        let detaches_history = matches!(
+            key.code,
+            KeyCode::Char(_)
+                | KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Home
+                | KeyCode::End
+                | KeyCode::Backspace
+                | KeyCode::Delete
+        ) || key.code == KeyCode::Enter
+            && key.modifiers.contains(KeyModifiers::SHIFT);
         if detaches_history {
             self.history.detach();
         }
@@ -729,25 +738,27 @@ impl Composer {
     }
 
     fn move_up(&mut self) -> bool {
-        if self.history.should_navigate(&self.draft, self.cursor)
-            && let Some(prompt) = self.history.previous(&self.draft)
-        {
-            self.replace_draft(prompt);
+        if !self.history.is_browsing() && self.move_vertical(-1) {
             return true;
         }
 
-        self.move_vertical(-1)
+        let Some(prompt) = self.history.previous(&self.draft) else {
+            return false;
+        };
+        self.replace_draft(prompt);
+        true
     }
 
     fn move_down(&mut self) -> bool {
-        if self.history.should_navigate(&self.draft, self.cursor)
-            && let Some(prompt) = self.history.next()
-        {
-            self.replace_draft(prompt);
-            return true;
+        if !self.history.is_browsing() {
+            return self.move_vertical(1);
         }
 
-        self.move_vertical(1)
+        let Some(prompt) = self.history.next() else {
+            return false;
+        };
+        self.replace_draft(prompt);
+        true
     }
 
     fn insert(&mut self, text: &str) {
@@ -847,76 +858,33 @@ impl Composer {
     }
 
     fn move_by_word(&mut self, forward: bool) -> bool {
-        const SEPARATORS: &str = "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?";
-
-        #[derive(Clone, Copy, Eq, PartialEq)]
-        enum PieceKind {
-            Separator,
-            Word,
-        }
-
-        let character_kind = |character: char| {
-            if SEPARATORS.contains(character) {
-                PieceKind::Separator
-            } else {
-                PieceKind::Word
-            }
-        };
-
-        // Skip whitespace next to the cursor, then inspect only the adjacent non-whitespace run.
-        let (source, source_start) = if forward {
-            let suffix = &self.draft[self.cursor..];
-            let run_start = suffix.len() - suffix.trim_start_matches(char::is_whitespace).len();
-            let run = &suffix[run_start..];
-            let run_end = run.find(char::is_whitespace).unwrap_or(run.len());
-            (&run[..run_end], self.cursor + run_start)
-        } else {
-            let prefix = &self.draft[..self.cursor];
-            let run_end = prefix.trim_end_matches(char::is_whitespace).len();
-            let run_start = prefix[..run_end]
-                .char_indices()
-                .rfind(|&(_, character)| character.is_whitespace())
-                .map_or(0, |(index, character)| index + character.len_utf8());
-            (&prefix[run_start..run_end], run_start)
-        };
-        let mut candidate: Option<(Range<usize>, PieceKind)> = None;
-        let mut append_piece = |range: Range<usize>, kind: PieceKind| {
-            if kind == PieceKind::Separator
-                && let Some((previous, PieceKind::Separator)) = candidate.as_mut()
-                && previous.end == range.start
-            {
-                previous.end = range.end;
-                return;
-            }
-            if !forward || candidate.is_none() {
-                candidate = Some((range, kind));
-            }
-        };
-
-        // Use Unicode word boundaries, but keep adjacent punctuation together as one movement.
-        for (segment_start, segment) in source.split_word_bound_indices() {
-            let mut characters = segment.char_indices();
-            let Some((_, first_character)) = characters.next() else {
-                continue;
-            };
-            let mut piece_start = 0;
-            let mut kind = character_kind(first_character);
-            for (index, character) in characters {
-                let next_kind = character_kind(character);
-                if next_kind == kind {
-                    continue;
+        let is_word = |grapheme: &str| grapheme.chars().any(char::is_alphanumeric);
+        let target = if forward {
+            let mut found_word = false;
+            let mut target = self.draft.len();
+            for (offset, grapheme) in self.draft[self.cursor..].grapheme_indices(true) {
+                if is_word(grapheme) {
+                    found_word = true;
+                    target = self.cursor + offset + grapheme.len();
+                } else if found_word {
+                    break;
                 }
-                append_piece(segment_start + piece_start..segment_start + index, kind);
-                piece_start = index;
-                kind = next_kind;
             }
-            append_piece(
-                segment_start + piece_start..segment_start + segment.len(),
-                kind,
-            );
-        }
+            target
+        } else {
+            let mut found_word = false;
+            let mut target = 0;
+            for (offset, grapheme) in self.draft[..self.cursor].grapheme_indices(true).rev() {
+                if is_word(grapheme) {
+                    found_word = true;
+                    target = offset;
+                } else if found_word {
+                    break;
+                }
+            }
+            target
+        };
 
-        // Image labels participate in word segmentation, but the cursor cannot stop inside one.
         let adjust_position_out_of_image = |position: usize, prefer_start: bool| {
             let Some(image) = self
                 .images
@@ -931,10 +899,6 @@ impl Composer {
                 image.range.end
             }
         };
-        let boundary = candidate.map_or(if forward { source.len() } else { 0 }, |(span, _)| {
-            if forward { span.end } else { span.start }
-        });
-        let target = source_start + boundary;
         let target = adjust_position_out_of_image(target, !forward);
         if target == self.cursor {
             return false;
@@ -1002,17 +966,7 @@ impl Composer {
         let layout = VisualLayout::new(&self.draft, self.cursor, self.last_width.max(1));
         let target_row = layout.cursor_row.saturating_add_signed(direction);
         if target_row == layout.cursor_row || target_row >= layout.lines.len() {
-            let target = if direction.is_negative() {
-                0
-            } else {
-                self.draft.len()
-            };
-            if target == self.cursor {
-                return false;
-            }
-            self.cursor = target;
-            self.preferred_column = None;
-            return true;
+            return false;
         }
 
         let desired = *self.preferred_column.get_or_insert(layout.cursor_column);
@@ -1044,26 +998,15 @@ impl Composer {
     }
 
     fn move_to_logical_edge(&mut self, end: bool) -> bool {
-        let edge_at = |cursor: usize| {
-            if end {
-                self.draft[cursor..]
-                    .find('\n')
-                    .map_or(self.draft.len(), |offset| cursor + offset)
-            } else {
-                self.draft[..cursor]
-                    .rfind('\n')
-                    .map_or(0, |offset| offset + '\n'.len_utf8())
-            }
+        let target = if end {
+            self.draft[self.cursor..]
+                .find('\n')
+                .map_or(self.draft.len(), |offset| self.cursor + offset)
+        } else {
+            self.draft[..self.cursor]
+                .rfind('\n')
+                .map_or(0, |offset| offset + '\n'.len_utf8())
         };
-        let mut target = edge_at(self.cursor);
-        if target == self.cursor {
-            let adjacent = if end {
-                self.cursor.saturating_add(1).min(self.draft.len())
-            } else {
-                self.cursor.saturating_sub(1)
-            };
-            target = edge_at(adjacent);
-        }
         if target == self.cursor {
             return false;
         }
@@ -2043,19 +1986,21 @@ mod tests {
     }
 
     #[test]
-    fn readline_shortcuts_move_by_character_and_logical_line() {
+    fn readline_shortcuts_move_by_character_and_stay_on_the_logical_line() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         composer.replace_draft("one\ntwo\nthree".to_owned());
         composer.cursor = "one\nt".len();
 
         composer.update(key(KeyCode::Char('a'), KeyModifiers::CONTROL));
         assert_eq!(composer.cursor(), "one\n".len());
-        composer.update(key(KeyCode::Char('a'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), 0);
+        let update = composer.update(key(KeyCode::Char('a'), KeyModifiers::CONTROL));
+        assert!(!update.changed);
+        assert_eq!(composer.cursor(), "one\n".len());
 
         composer.update(key(KeyCode::Char('e'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), "one".len());
-        composer.update(key(KeyCode::Char('e'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "one\ntwo".len());
+        let update = composer.update(key(KeyCode::Char('e'), KeyModifiers::CONTROL));
+        assert!(!update.changed);
         assert_eq!(composer.cursor(), "one\ntwo".len());
 
         composer.update(key(KeyCode::Char('b'), KeyModifiers::CONTROL));
@@ -2087,21 +2032,17 @@ mod tests {
     }
 
     #[test]
-    fn readline_word_movement_stops_at_punctuation_and_cjk_boundaries() {
+    fn readline_word_movement_skips_delimiters_between_alphanumeric_words() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         composer.replace_draft("foo...bar".to_owned());
 
         composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
         assert_eq!(composer.cursor(), "foo...".len());
         composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
-        assert_eq!(composer.cursor(), "foo".len());
-        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
         assert_eq!(composer.cursor(), 0);
 
         composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
         assert_eq!(composer.cursor(), "foo".len());
-        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
-        assert_eq!(composer.cursor(), "foo...".len());
         composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
         assert_eq!(composer.cursor(), composer.draft().len());
 
@@ -2109,7 +2050,7 @@ mod tests {
         composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
         assert_eq!(composer.cursor(), "can'".len());
         composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
-        assert_eq!(composer.cursor(), "can".len());
+        assert_eq!(composer.cursor(), 0);
 
         composer.replace_draft("alpha   beta".to_owned());
         composer.cursor = "alpha ".len();
@@ -2122,11 +2063,9 @@ mod tests {
         composer.replace_draft("你好".to_owned());
         composer.cursor = 0;
         composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
-        assert_eq!(composer.cursor(), "你".len());
-        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
         assert_eq!(composer.cursor(), composer.draft().len());
         composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
-        assert_eq!(composer.cursor(), "你".len());
+        assert_eq!(composer.cursor(), 0);
     }
 
     #[test]
@@ -2149,14 +2088,13 @@ mod tests {
         composer.update(ComposerEvent::PasteImage(
             "data:image/png;base64,attached".to_owned(),
         ));
-        composer.last_width = 3;
-        let image = composer.images[0].range.clone();
+        render(&mut composer, 5, 5);
 
-        composer.cursor = image.start;
+        composer.update(key(KeyCode::Char('a'), KeyModifiers::CONTROL));
         composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), image.end);
+        assert_eq!(composer.cursor(), composer.draft().len());
         composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), image.start);
+        assert_eq!(composer.cursor(), 0);
 
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         composer.update(ComposerEvent::Terminal(Event::Paste("a".to_owned())));
@@ -2186,42 +2124,45 @@ mod tests {
     }
 
     #[test]
-    fn readline_vertical_movement_uses_history_only_for_empty_or_recalled_drafts() {
+    fn readline_vertical_shortcuts_restore_the_unsent_draft_after_history() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         composer.replace_draft("older".to_owned());
         composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
         composer.replace_draft("newer".to_owned());
         composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        composer.replace_draft("top\nbottom".to_owned());
 
-        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.draft(), "newer");
-        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
-        assert_eq!(composer.cursor(), 0);
-        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.draft(), "older");
-        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), 0);
-        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.draft(), "newer");
-        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert!(composer.draft().is_empty());
-
-        composer.update(ComposerEvent::ReplaceDraft("top\nbottom".to_owned()));
-
-        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), "top".len());
-        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), 0);
         composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
         assert_eq!(composer.draft(), "top\nbottom");
-        assert_eq!(composer.cursor(), 0);
+        assert_eq!(composer.cursor(), "top".len());
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "newer");
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "older");
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "newer");
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "top\nbottom");
+        assert_eq!(composer.cursor(), composer.draft().len());
+    }
 
-        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), "top\n".len());
-        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), composer.draft().len());
-        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
-        assert_eq!(composer.cursor(), composer.draft().len());
+    #[test]
+    fn readline_horizontal_shortcuts_detach_recalled_history() {
+        for (code, modifiers) in [
+            (KeyCode::Char('a'), KeyModifiers::CONTROL),
+            (KeyCode::Char('b'), KeyModifiers::CONTROL),
+            (KeyCode::Char('b'), KeyModifiers::ALT),
+        ] {
+            let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+            composer.replace_draft("previous".to_owned());
+            composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
+            composer.update(key(KeyCode::Up, KeyModifiers::NONE));
+
+            composer.update(key(code, modifiers));
+            composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+
+            assert_eq!(composer.draft(), "previous");
+        }
     }
 
     #[test]
@@ -2275,13 +2216,16 @@ mod tests {
     }
 
     #[test]
-    fn arrows_cycle_submitted_prompts_only_from_an_empty_or_recalled_draft() {
+    fn arrows_cycle_submitted_prompts_and_restore_the_unsent_draft() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         for prompt in ["first", "second"] {
             composer.replace_draft(prompt.to_owned());
             composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
         }
+        composer.replace_draft("unfinished\nline".to_owned());
 
+        composer.update(key(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(composer.draft(), "unfinished\nline");
         composer.update(key(KeyCode::Up, KeyModifiers::NONE));
         assert_eq!(composer.draft(), "second");
         composer.update(key(KeyCode::Up, KeyModifiers::NONE));
@@ -2289,13 +2233,7 @@ mod tests {
         composer.update(key(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(composer.draft(), "second");
         composer.update(key(KeyCode::Down, KeyModifiers::NONE));
-        assert!(composer.draft().is_empty());
-
-        composer.update(ComposerEvent::ReplaceDraft("unfinished\nline".to_owned()));
-        composer.update(key(KeyCode::Up, KeyModifiers::NONE));
-        composer.update(key(KeyCode::Up, KeyModifiers::NONE));
         assert_eq!(composer.draft(), "unfinished\nline");
-        assert_eq!(composer.cursor(), 0);
     }
 
     #[test]

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -628,31 +628,35 @@ impl Composer {
             return ComposerUpdate::unchanged();
         }
 
-        if key.modifiers.contains(KeyModifiers::CONTROL) {
-            match key.code {
+        if key.modifiers == KeyModifiers::CONTROL {
+            return match key.code {
+                KeyCode::Char('a') => ComposerUpdate::from_change(self.move_to_logical_edge(false)),
+                KeyCode::Char('b') => ComposerUpdate::from_change(self.move_left()),
+                KeyCode::Char('e') => ComposerUpdate::from_change(self.move_to_logical_edge(true)),
+                KeyCode::Char('f') => ComposerUpdate::from_change(self.move_right()),
                 KeyCode::Char('g') => {
-                    return ComposerUpdate::effect(ComposerEffect::OpenDraftEditor, false);
+                    ComposerUpdate::effect(ComposerEffect::OpenDraftEditor, false)
                 }
                 KeyCode::Char('j') => {
                     self.history.detach();
                     self.insert("\n");
-                    return ComposerUpdate::changed();
+                    ComposerUpdate::changed()
                 }
-                _ => return ComposerUpdate::unchanged(),
-            }
+                KeyCode::Char('n') => ComposerUpdate::from_change(self.move_down()),
+                KeyCode::Char('p') => ComposerUpdate::from_change(self.move_up()),
+                _ => ComposerUpdate::unchanged(),
+            };
+        }
+        // Prevent unsupported Ctrl chords from falling through as text input.
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            return ComposerUpdate::unchanged();
         }
 
-        let detaches_history = matches!(
-            key.code,
-            KeyCode::Char(_)
-                | KeyCode::Left
-                | KeyCode::Right
-                | KeyCode::Home
-                | KeyCode::End
-                | KeyCode::Backspace
-                | KeyCode::Delete
-        ) || key.code == KeyCode::Enter
-            && key.modifiers.contains(KeyModifiers::SHIFT);
+        let moves_by_word =
+            matches!(key.code, KeyCode::Char('b' | 'f')) && key.modifiers == KeyModifiers::ALT;
+        let detaches_history = matches!(key.code, KeyCode::Char(_)) && !moves_by_word
+            || matches!(key.code, KeyCode::Backspace | KeyCode::Delete)
+            || key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT);
         if detaches_history {
             self.history.detach();
         }
@@ -663,6 +667,12 @@ impl Composer {
                 ComposerUpdate::changed()
             }
             KeyCode::Enter => self.submit(),
+            KeyCode::Char('b') if key.modifiers == KeyModifiers::ALT => {
+                ComposerUpdate::from_change(self.move_by_word(false))
+            }
+            KeyCode::Char('f') if key.modifiers == KeyModifiers::ALT => {
+                ComposerUpdate::from_change(self.move_by_word(true))
+            }
             KeyCode::Char(character) => {
                 self.insert(&character.to_string());
                 ComposerUpdate::changed()
@@ -719,27 +729,25 @@ impl Composer {
     }
 
     fn move_up(&mut self) -> bool {
-        if !self.history.is_browsing() && self.move_vertical(-1) {
+        if self.history.should_navigate(&self.draft, self.cursor)
+            && let Some(prompt) = self.history.previous(&self.draft)
+        {
+            self.replace_draft(prompt);
             return true;
         }
 
-        let Some(prompt) = self.history.previous(&self.draft) else {
-            return false;
-        };
-        self.replace_draft(prompt);
-        true
+        self.move_vertical(-1)
     }
 
     fn move_down(&mut self) -> bool {
-        if !self.history.is_browsing() {
-            return self.move_vertical(1);
+        if self.history.should_navigate(&self.draft, self.cursor)
+            && let Some(prompt) = self.history.next()
+        {
+            self.replace_draft(prompt);
+            return true;
         }
 
-        let Some(prompt) = self.history.next() else {
-            return false;
-        };
-        self.replace_draft(prompt);
-        true
+        self.move_vertical(1)
     }
 
     fn insert(&mut self, text: &str) {
@@ -838,6 +846,104 @@ impl Composer {
         true
     }
 
+    fn move_by_word(&mut self, forward: bool) -> bool {
+        const SEPARATORS: &str = "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?";
+
+        #[derive(Clone, Copy, Eq, PartialEq)]
+        enum PieceKind {
+            Separator,
+            Word,
+        }
+
+        let character_kind = |character: char| {
+            if SEPARATORS.contains(character) {
+                PieceKind::Separator
+            } else {
+                PieceKind::Word
+            }
+        };
+
+        // Skip whitespace next to the cursor, then inspect only the adjacent non-whitespace run.
+        let (source, source_start) = if forward {
+            let suffix = &self.draft[self.cursor..];
+            let run_start = suffix.len() - suffix.trim_start_matches(char::is_whitespace).len();
+            let run = &suffix[run_start..];
+            let run_end = run.find(char::is_whitespace).unwrap_or(run.len());
+            (&run[..run_end], self.cursor + run_start)
+        } else {
+            let prefix = &self.draft[..self.cursor];
+            let run_end = prefix.trim_end_matches(char::is_whitespace).len();
+            let run_start = prefix[..run_end]
+                .char_indices()
+                .rfind(|&(_, character)| character.is_whitespace())
+                .map_or(0, |(index, character)| index + character.len_utf8());
+            (&prefix[run_start..run_end], run_start)
+        };
+        let mut candidate: Option<(Range<usize>, PieceKind)> = None;
+        let mut append_piece = |range: Range<usize>, kind: PieceKind| {
+            if kind == PieceKind::Separator
+                && let Some((previous, PieceKind::Separator)) = candidate.as_mut()
+                && previous.end == range.start
+            {
+                previous.end = range.end;
+                return;
+            }
+            if !forward || candidate.is_none() {
+                candidate = Some((range, kind));
+            }
+        };
+
+        // Use Unicode word boundaries, but keep adjacent punctuation together as one movement.
+        for (segment_start, segment) in source.split_word_bound_indices() {
+            let mut characters = segment.char_indices();
+            let Some((_, first_character)) = characters.next() else {
+                continue;
+            };
+            let mut piece_start = 0;
+            let mut kind = character_kind(first_character);
+            for (index, character) in characters {
+                let next_kind = character_kind(character);
+                if next_kind == kind {
+                    continue;
+                }
+                append_piece(segment_start + piece_start..segment_start + index, kind);
+                piece_start = index;
+                kind = next_kind;
+            }
+            append_piece(
+                segment_start + piece_start..segment_start + segment.len(),
+                kind,
+            );
+        }
+
+        // Image labels participate in word segmentation, but the cursor cannot stop inside one.
+        let adjust_position_out_of_image = |position: usize, prefer_start: bool| {
+            let Some(image) = self
+                .images
+                .iter()
+                .find(|image| image.range.start < position && position < image.range.end)
+            else {
+                return position;
+            };
+            if prefer_start {
+                image.range.start
+            } else {
+                image.range.end
+            }
+        };
+        let boundary = candidate.map_or(if forward { source.len() } else { 0 }, |(span, _)| {
+            if forward { span.end } else { span.start }
+        });
+        let target = source_start + boundary;
+        let target = adjust_position_out_of_image(target, !forward);
+        if target == self.cursor {
+            return false;
+        }
+        self.cursor = target;
+        self.preferred_column = None;
+        true
+    }
+
     fn delete(&mut self) -> bool {
         if let Some(index) = self
             .images
@@ -896,11 +1002,32 @@ impl Composer {
         let layout = VisualLayout::new(&self.draft, self.cursor, self.last_width.max(1));
         let target_row = layout.cursor_row.saturating_add_signed(direction);
         if target_row == layout.cursor_row || target_row >= layout.lines.len() {
-            return false;
+            let target = if direction.is_negative() {
+                0
+            } else {
+                self.draft.len()
+            };
+            if target == self.cursor {
+                return false;
+            }
+            self.cursor = target;
+            self.preferred_column = None;
+            return true;
         }
 
         let desired = *self.preferred_column.get_or_insert(layout.cursor_column);
-        self.cursor = byte_at_column(&self.draft, &layout.lines[target_row], desired);
+        let target = byte_at_column(&self.draft, &layout.lines[target_row], desired);
+        self.cursor = self
+            .images
+            .iter()
+            .find(|image| image.range.start < target && target < image.range.end)
+            .map_or(target, |image| {
+                if direction.is_negative() {
+                    image.range.start
+                } else {
+                    image.range.end
+                }
+            });
         true
     }
 
@@ -908,6 +1035,35 @@ impl Composer {
         let layout = VisualLayout::new(&self.draft, self.cursor, self.last_width.max(1));
         let line = &layout.lines[layout.cursor_row];
         let target = if end { line.end } else { line.start };
+        if target == self.cursor {
+            return false;
+        }
+        self.cursor = target;
+        self.preferred_column = None;
+        true
+    }
+
+    fn move_to_logical_edge(&mut self, end: bool) -> bool {
+        let edge_at = |cursor: usize| {
+            if end {
+                self.draft[cursor..]
+                    .find('\n')
+                    .map_or(self.draft.len(), |offset| cursor + offset)
+            } else {
+                self.draft[..cursor]
+                    .rfind('\n')
+                    .map_or(0, |offset| offset + '\n'.len_utf8())
+            }
+        };
+        let mut target = edge_at(self.cursor);
+        if target == self.cursor {
+            let adjacent = if end {
+                self.cursor.saturating_add(1).min(self.draft.len())
+            } else {
+                self.cursor.saturating_sub(1)
+            };
+            target = edge_at(adjacent);
+        }
         if target == self.cursor {
             return false;
         }
@@ -1887,6 +2043,188 @@ mod tests {
     }
 
     #[test]
+    fn readline_shortcuts_move_by_character_and_logical_line() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("one\ntwo\nthree".to_owned());
+        composer.cursor = "one\nt".len();
+
+        composer.update(key(KeyCode::Char('a'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "one\n".len());
+        composer.update(key(KeyCode::Char('a'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), 0);
+
+        composer.update(key(KeyCode::Char('e'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "one".len());
+        composer.update(key(KeyCode::Char('e'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "one\ntwo".len());
+
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "one\ntw".len());
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "one\ntwo".len());
+    }
+
+    #[test]
+    fn readline_shortcuts_require_exact_modifiers() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("abcd".to_owned());
+        composer.cursor = 2;
+
+        let update = composer.update(key(
+            KeyCode::Char('b'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+        assert!(!update.changed);
+        assert_eq!(composer.draft(), "abcd");
+        assert_eq!(composer.cursor(), 2);
+
+        composer.update(key(
+            KeyCode::Char('b'),
+            KeyModifiers::ALT | KeyModifiers::SHIFT,
+        ));
+        assert_eq!(composer.draft(), "abbcd");
+        assert_eq!(composer.cursor(), 3);
+    }
+
+    #[test]
+    fn readline_word_movement_stops_at_punctuation_and_cjk_boundaries() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("foo...bar".to_owned());
+
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "foo...".len());
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "foo".len());
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), 0);
+
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "foo".len());
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "foo...".len());
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), composer.draft().len());
+
+        composer.replace_draft("can't".to_owned());
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "can'".len());
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "can".len());
+
+        composer.replace_draft("alpha   beta".to_owned());
+        composer.cursor = "alpha ".len();
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), composer.draft().len());
+        composer.cursor = "alpha  ".len();
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), 0);
+
+        composer.replace_draft("你好".to_owned());
+        composer.cursor = 0;
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "你".len());
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), composer.draft().len());
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "你".len());
+    }
+
+    #[test]
+    fn readline_word_movement_treats_images_as_atomic() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::Terminal(Event::Paste("inspect ".to_owned())));
+        composer.update(ComposerEvent::PasteImage(
+            "data:image/png;base64,attached".to_owned(),
+        ));
+
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), "inspect ".len());
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), composer.draft().len());
+    }
+
+    #[test]
+    fn readline_vertical_movement_treats_images_as_atomic() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::PasteImage(
+            "data:image/png;base64,attached".to_owned(),
+        ));
+        composer.last_width = 3;
+        let image = composer.images[0].range.clone();
+
+        composer.cursor = image.start;
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), image.end);
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), image.start);
+
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::Terminal(Event::Paste("a".to_owned())));
+        composer.update(ComposerEvent::PasteImage(
+            "data:image/png;base64,attached".to_owned(),
+        ));
+        composer.update(ComposerEvent::Terminal(Event::Paste("\n12345".to_owned())));
+
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "a".len());
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), composer.draft().len());
+
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::Terminal(Event::Paste(
+            "123456789\na".to_owned(),
+        )));
+        composer.update(ComposerEvent::PasteImage(
+            "data:image/png;base64,attached".to_owned(),
+        ));
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        composer.update(key(KeyCode::Char('f'), KeyModifiers::CONTROL));
+
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), composer.draft().len());
+    }
+
+    #[test]
+    fn readline_vertical_movement_uses_history_only_for_empty_or_recalled_drafts() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("older".to_owned());
+        composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        composer.replace_draft("newer".to_owned());
+        composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
+
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "newer");
+        composer.update(key(KeyCode::Char('b'), KeyModifiers::ALT));
+        assert_eq!(composer.cursor(), 0);
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "older");
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), 0);
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "newer");
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert!(composer.draft().is_empty());
+
+        composer.update(ComposerEvent::ReplaceDraft("top\nbottom".to_owned()));
+
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "top".len());
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), 0);
+        composer.update(key(KeyCode::Char('p'), KeyModifiers::CONTROL));
+        assert_eq!(composer.draft(), "top\nbottom");
+        assert_eq!(composer.cursor(), 0);
+
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), "top\n".len());
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), composer.draft().len());
+        composer.update(key(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(composer.cursor(), composer.draft().len());
+    }
+
+    #[test]
     fn submission_trims_nonempty_prompts_and_preserves_empty_drafts() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         composer.replace_draft("  inspect this  \n".to_owned());
@@ -1937,16 +2275,13 @@ mod tests {
     }
 
     #[test]
-    fn arrows_cycle_submitted_prompts_and_restore_the_unsent_draft() {
+    fn arrows_cycle_submitted_prompts_only_from_an_empty_or_recalled_draft() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         for prompt in ["first", "second"] {
             composer.replace_draft(prompt.to_owned());
             composer.update(key(KeyCode::Enter, KeyModifiers::NONE));
         }
-        composer.replace_draft("unfinished\nline".to_owned());
 
-        composer.update(key(KeyCode::Up, KeyModifiers::NONE));
-        assert_eq!(composer.draft(), "unfinished\nline");
         composer.update(key(KeyCode::Up, KeyModifiers::NONE));
         assert_eq!(composer.draft(), "second");
         composer.update(key(KeyCode::Up, KeyModifiers::NONE));
@@ -1954,7 +2289,13 @@ mod tests {
         composer.update(key(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(composer.draft(), "second");
         composer.update(key(KeyCode::Down, KeyModifiers::NONE));
+        assert!(composer.draft().is_empty());
+
+        composer.update(ComposerEvent::ReplaceDraft("unfinished\nline".to_owned()));
+        composer.update(key(KeyCode::Up, KeyModifiers::NONE));
+        composer.update(key(KeyCode::Up, KeyModifiers::NONE));
         assert_eq!(composer.draft(), "unfinished\nline");
+        assert_eq!(composer.cursor(), 0);
     }
 
     #[test]

--- a/src/tui/components/composer/history.rs
+++ b/src/tui/components/composer/history.rs
@@ -44,9 +44,8 @@ impl PromptHistory {
         Some(self.browsing.take()?.saved_draft)
     }
 
-    pub(super) fn should_navigate(&self, draft: &str, cursor: usize) -> bool {
-        let at_draft_edge = cursor == 0 || cursor == draft.len();
-        draft.is_empty() || (self.browsing.is_some() && at_draft_edge)
+    pub(super) fn is_browsing(&self) -> bool {
+        self.browsing.is_some()
     }
 
     pub(super) fn detach(&mut self) {

--- a/src/tui/components/composer/history.rs
+++ b/src/tui/components/composer/history.rs
@@ -44,8 +44,9 @@ impl PromptHistory {
         Some(self.browsing.take()?.saved_draft)
     }
 
-    pub(super) fn is_browsing(&self) -> bool {
-        self.browsing.is_some()
+    pub(super) fn should_navigate(&self, draft: &str, cursor: usize) -> bool {
+        let at_draft_edge = cursor == 0 || cursor == draft.len();
+        draft.is_empty() || (self.browsing.is_some() && at_draft_edge)
     }
 
     pub(super) fn detach(&mut self) {

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -16,10 +16,10 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 const FOOTER: [&str; 1] = ["esc close"];
-const BINDINGS: [(&str, &str); 22] = [
+const BINDINGS: [(&str, &str); 25] = [
     ("ctrl+s", "change reasoning effort"),
     ("ctrl+d", "select model · before first prompt"),
-    ("ctrl+f", "fork session · when available"),
+    ("ctrl+t", "fork session · when available"),
     ("ctrl+g", "edit prompt in $EDITOR"),
     ("ctrl+r", "recent prompts"),
     ("ctrl+z", "restore the last cleared draft"),
@@ -33,8 +33,14 @@ const BINDINGS: [(&str, &str); 22] = [
     ("esc esc", "interrupt the active response"),
     ("enter", "submit prompt"),
     ("shift+enter/ctrl+j", "insert newline"),
+    ("ctrl+a/e", "move to line start · end"),
+    ("ctrl+b/f", "move to previous · next character"),
+    ("alt/option+b/f", "move to previous · next word"),
     ("alt/option+backspace", "delete previous word"),
-    ("↑/↓", "move cursor · prompt history at edge"),
+    (
+        "↑/↓ · ctrl+p/n",
+        "move lines · history for empty/recalled prompts",
+    ),
     ("tab", "focus queue · when present"),
     ("/", "open actions · empty prompt only"),
     ("@", "insert workspace file"),
@@ -76,7 +82,7 @@ impl Component for KeybindingsHelp {
 
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
         let layout =
-            Floating::new("Keyboard shortcuts", 72, 24, &FOOTER).render(frame, area, theme);
+            Floating::new("Keyboard shortcuts", 72, 27, &FOOTER).render(frame, area, theme);
         if layout.body.is_empty() {
             return;
         }
@@ -154,7 +160,7 @@ mod tests {
     #[test]
     fn popup_documents_context_sensitive_composer_shortcuts() {
         let mut help = KeybindingsHelp;
-        let mut terminal = Terminal::new(TestBackend::new(80, 26)).unwrap();
+        let mut terminal = Terminal::new(TestBackend::new(80, 29)).unwrap();
 
         terminal
             .draw(|frame| help.render(frame, frame.area(), &Theme::default()))
@@ -169,15 +175,24 @@ mod tests {
             .collect::<Vec<_>>();
         for expected in [
             "ctrl/cmd+v",
+            "ctrl+t",
+            "fork session · when available",
             "ctrl+r",
             "ctrl+z",
             "ctrl+c ctrl+c",
             "clear input · when composer is focused and nonempty",
             "split closes pane · else exit",
             "shift+enter/ctrl+j",
+            "ctrl+a/e",
+            "move to line start · end",
+            "ctrl+b/f",
+            "move to previous · next character",
+            "alt/option+b/f",
+            "move to previous · next word",
             "alt/option+backspace",
             "delete previous word",
-            "prompt history at edge",
+            "ctrl+p/n",
+            "history for empty/recalled prompts",
             "focus queue · when present",
             "open actions · empty prompt only",
             "insert workspace file",

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -15,7 +15,7 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-const FOOTER: [&str; 1] = ["esc close"];
+const FOOTER: [&str; 2] = ["↑↓ scroll", "esc close"];
 const BINDINGS: [(&str, &str); 25] = [
     ("ctrl+s", "change reasoning effort"),
     ("ctrl+d", "select model · before first prompt"),
@@ -37,10 +37,7 @@ const BINDINGS: [(&str, &str); 25] = [
     ("ctrl+b/f", "move to previous · next character"),
     ("alt/option+b/f", "move to previous · next word"),
     ("alt/option+backspace", "delete previous word"),
-    (
-        "↑/↓ · ctrl+p/n",
-        "move lines · history for empty/recalled prompts",
-    ),
+    ("↑/↓ · ctrl+p/n", "move lines · prompt history at edge"),
     ("tab", "focus queue · when present"),
     ("/", "open actions · empty prompt only"),
     ("@", "insert workspace file"),
@@ -59,38 +56,57 @@ pub(super) enum KeybindingsEffect {
     Dismiss,
 }
 
-pub(super) struct KeybindingsHelp;
+#[derive(Default)]
+pub(super) struct KeybindingsHelp {
+    scroll: u16,
+}
 
 impl Component for KeybindingsHelp {
     type Event = KeybindingsEvent;
     type Effect = KeybindingsEffect;
 
     fn update(&mut self, event: Self::Event) -> ComponentUpdate<Self::Effect> {
-        let KeybindingsEvent::Terminal(Event::Key(key)) = event else {
-            return ComponentUpdate::none();
-        };
-        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
-            || key.code != KeyCode::Esc
-        {
-            return ComponentUpdate::none();
+        match event {
+            KeybindingsEvent::Terminal(Event::Key(key))
+                if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+            {
+                match key.code {
+                    KeyCode::Esc => {
+                        return ComponentUpdate {
+                            effects: vec![KeybindingsEffect::Dismiss],
+                            render: RenderRequest::Immediate,
+                        };
+                    }
+                    KeyCode::Up => self.scroll = self.scroll.saturating_sub(1),
+                    KeyCode::Down => self.scroll = self.scroll.saturating_add(1),
+                    _ => return ComponentUpdate::none(),
+                }
+            }
+            KeybindingsEvent::Terminal(_) => return ComponentUpdate::none(),
         }
-        ComponentUpdate {
-            effects: vec![KeybindingsEffect::Dismiss],
-            render: RenderRequest::Immediate,
-        }
+        ComponentUpdate::render(RenderRequest::Immediate)
     }
 
     fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
+        let height = u16::try_from(BINDINGS.len())
+            .unwrap_or(u16::MAX)
+            .saturating_add(3);
         let layout =
-            Floating::new("Keyboard shortcuts", 72, 27, &FOOTER).render(frame, area, theme);
+            Floating::new("Keyboard shortcuts", 72, height, &FOOTER).render(frame, area, theme);
         if layout.body.is_empty() {
             return;
         }
+        let max_scroll = BINDINGS
+            .len()
+            .saturating_sub(usize::from(layout.body.height));
+        self.scroll = self
+            .scroll
+            .min(u16::try_from(max_scroll).unwrap_or(u16::MAX));
         let lines = BINDINGS
             .iter()
             .map(|&(key, description)| binding_line(key, description, layout.body.width, theme))
             .collect::<Vec<_>>();
-        frame.render_widget(Paragraph::new(lines), layout.body);
+        frame.render_widget(Paragraph::new(lines).scroll((self.scroll, 0)), layout.body);
     }
 }
 
@@ -116,14 +132,14 @@ fn binding_line(
 
 #[cfg(test)]
 mod tests {
-    use super::{Component, KeybindingsEffect, KeybindingsEvent, KeybindingsHelp};
+    use super::{BINDINGS, Component, KeybindingsEffect, KeybindingsEvent, KeybindingsHelp};
     use crate::tui::theme::Theme;
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend, style::Color};
 
     #[test]
     fn popup_right_aligns_muted_descriptions() {
-        let mut help = KeybindingsHelp;
+        let mut help = KeybindingsHelp::default();
         let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
 
         terminal
@@ -159,7 +175,7 @@ mod tests {
 
     #[test]
     fn popup_documents_context_sensitive_composer_shortcuts() {
-        let mut help = KeybindingsHelp;
+        let mut help = KeybindingsHelp::default();
         let mut terminal = Terminal::new(TestBackend::new(80, 29)).unwrap();
 
         terminal
@@ -192,12 +208,49 @@ mod tests {
             "alt/option+backspace",
             "delete previous word",
             "ctrl+p/n",
-            "history for empty/recalled prompts",
+            "prompt history at edge",
             "focus queue · when present",
             "open actions · empty prompt only",
             "insert workspace file",
             "local shell command · prompt start",
             "mouse click/drag",
+            "pgup/pgdn · wheel",
+            "scroll transcript",
+            "ctrl+home/end",
+            "jump to start · follow latest",
+            "↑↓ scroll",
+        ] {
+            assert!(rendered.iter().any(|line| line.contains(expected)));
+        }
+    }
+
+    #[test]
+    fn compact_popup_scrolls_to_late_shortcuts() {
+        let mut help = KeybindingsHelp::default();
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+
+        for _ in &BINDINGS {
+            help.update(KeybindingsEvent::Terminal(Event::Key(KeyEvent::new(
+                KeyCode::Down,
+                KeyModifiers::NONE,
+            ))));
+            terminal
+                .draw(|frame| help.render(frame, frame.area(), &Theme::default()))
+                .unwrap();
+        }
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(80)
+            .map(|cells| cells.iter().map(|cell| cell.symbol()).collect::<String>())
+            .collect::<Vec<_>>();
+        for expected in [
+            "local shell command · prompt start",
+            "mouse click/drag",
+            "scroll transcript",
+            "jump to start · follow latest",
         ] {
             assert!(rendered.iter().any(|line| line.contains(expected)));
         }
@@ -205,7 +258,7 @@ mod tests {
 
     #[test]
     fn narrow_terminals_do_not_overflow_the_popup() {
-        let mut help = KeybindingsHelp;
+        let mut help = KeybindingsHelp::default();
         let mut terminal = Terminal::new(TestBackend::new(8, 4)).unwrap();
 
         terminal
@@ -217,7 +270,7 @@ mod tests {
 
     #[test]
     fn escape_dismisses_the_popup() {
-        let mut help = KeybindingsHelp;
+        let mut help = KeybindingsHelp::default();
 
         let update = help.update(KeybindingsEvent::Terminal(Event::Key(KeyEvent::new(
             KeyCode::Esc,

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -1424,7 +1424,7 @@ impl RootNode {
             }
             Some(ActionsEffect::Trigger(Action::Fork)) => return self.open_fork(),
             Some(ActionsEffect::Trigger(Action::Keybindings)) => {
-                self.overlay = Some(Overlay::Keybindings(Node::new(KeybindingsHelp)));
+                self.overlay = Some(Overlay::Keybindings(Node::new(KeybindingsHelp::default())));
             }
             Some(ActionsEffect::Trigger(Action::ReloadConfig)) => {
                 self.overlay = None;

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -5809,7 +5809,7 @@ mod tests {
         });
         assert!(
             worker_before_started
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects
                 .is_empty()
         );
@@ -5825,7 +5825,7 @@ mod tests {
         )));
         assert_eq!(
             worker_before_started
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects,
             [RootEffect::Fork]
         );
@@ -5835,7 +5835,7 @@ mod tests {
 
         assert!(
             before_started
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects
                 .is_empty()
         );
@@ -5847,7 +5847,7 @@ mod tests {
         )));
         assert!(
             before_started
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects
                 .is_empty()
         );
@@ -5858,7 +5858,7 @@ mod tests {
         )));
         assert!(
             before_started
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects
                 .is_empty()
         );
@@ -5867,7 +5867,7 @@ mod tests {
         });
         assert_eq!(
             before_started
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects,
             [RootEffect::Fork]
         );
@@ -5885,7 +5885,7 @@ mod tests {
 
         assert!(
             before_terminal
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects
                 .is_empty()
         );
@@ -5896,7 +5896,7 @@ mod tests {
         )));
         assert_eq!(
             before_terminal
-                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects,
             [RootEffect::Fork]
         );

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -812,7 +812,7 @@ impl RootNode {
         if is_control_key(&event, 'r') {
             return self.load_recent_prompts();
         }
-        if is_control_key(&event, 'f') {
+        if is_control_key(&event, 't') {
             return self.open_fork();
         }
         if is_escape(&event) {
@@ -956,7 +956,7 @@ impl RootNode {
     }
 
     fn update_review_input(&mut self, event: Event) -> ComponentUpdate<RootEffect> {
-        if is_control_key(&event, 'f') {
+        if is_control_key(&event, 't') {
             self.key_confirmation = None;
             return self.open_fork();
         }
@@ -5791,11 +5791,11 @@ mod tests {
     }
 
     #[test]
-    fn control_f_can_fork_during_an_active_review() {
+    fn control_t_can_fork_during_an_active_review() {
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
         root.update(RootEvent::ReviewStarted);
 
-        let update = root.update(key(KeyCode::Char('f'), KeyModifiers::CONTROL));
+        let update = root.update(key(KeyCode::Char('t'), KeyModifiers::CONTROL));
 
         assert_eq!(update.effects, [RootEffect::Fork]);
     }


### PR DESCRIPTION
https://readline.kablamo.org/emacs.html

TUI apps (and terminals) generally support these shortcuts (codex and claude do as well). I only implemented movement shortcuts.