### PR TITLE
feat(tui): select model before session start

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,8 +17,8 @@ use crate::{
     tui::session::ResumeState,
 };
 use nanocodex::{
-    AgentEvents, Nanocodex, NanocodexError, OpenAi, Tools, TurnControl, agent::session::SessionId,
-    oai::tower::ResponsesServiceConfig,
+    AgentEvents, Model, Nanocodex, NanocodexError, OpenAi, Tools, TurnControl,
+    agent::session::SessionId, oai::tower::ResponsesServiceConfig,
 };
 #[cfg(feature = "harbor-evals")]
 use orchestration::{OrchestrationRecorder, RunOutcome};
@@ -149,10 +149,25 @@ impl ConfiguredAgent {
     }
 
     pub(crate) fn from_config(config: &Config) -> Result<Self> {
-        Self::from_config_with_session(
+        Self::from_config_with_model(
             config,
             config.agent().thinking(),
             config.agent().reasoning_mode(),
+            Model::Sol,
+        )
+    }
+
+    pub(crate) fn from_config_with_model(
+        config: &Config,
+        thinking: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        model: Model,
+    ) -> Result<Self> {
+        Self::from_config_with_session_and_model(
+            config,
+            thinking,
+            reasoning_mode,
+            model,
             None,
             None,
         )
@@ -162,6 +177,24 @@ impl ConfiguredAgent {
         config: &Config,
         thinking: ReasoningEffort,
         reasoning_mode: ReasoningMode,
+        session_id: Option<&str>,
+        resume: Option<ResumeState>,
+    ) -> Result<Self> {
+        Self::from_config_with_session_and_model(
+            config,
+            thinking,
+            reasoning_mode,
+            Model::Sol,
+            session_id,
+            resume,
+        )
+    }
+
+    fn from_config_with_session_and_model(
+        config: &Config,
+        thinking: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        model: Model,
         session_id: Option<&str>,
         resume: Option<ResumeState>,
     ) -> Result<Self> {
@@ -193,6 +226,7 @@ impl ConfiguredAgent {
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
         let mut builder = Nanocodex::builder(openai)
+            .model(model)
             .workspace(workspace)
             .thinking(thinking.into())
             .reasoning_mode(reasoning_mode.into())

--- a/src/tui/components/actions.rs
+++ b/src/tui/components/actions.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const ACTIONS: [Action; 14] = [
+const ACTIONS: [Action; 15] = [
     Action::Effort,
     Action::FastMode,
     Action::Theme,
@@ -31,6 +31,7 @@ const ACTIONS: [Action; 14] = [
     Action::DebugContext,
     Action::Handoff,
     Action::Review,
+    Action::Model,
 ];
 const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab open", "esc close"];
 const SEARCH_LABEL: &str = "Search: ";
@@ -45,6 +46,7 @@ pub(super) struct ActionAvailability {
     pub(super) fork: bool,
     pub(super) fast_mode: bool,
     pub(super) memory: bool,
+    pub(super) model: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -53,6 +55,7 @@ pub(super) enum Action {
     Review,
     Subagents,
     Effort,
+    Model,
     FastMode,
     Theme,
     NewSession,
@@ -259,6 +262,7 @@ impl ActionsMenu {
             Action::Handoff | Action::Review => self.availability.new_session,
             Action::Subagents => true,
             Action::Effort => true,
+            Action::Model => self.availability.model,
             Action::FastMode => true,
             Action::Theme => true,
             Action::NewSession => self.availability.new_session,
@@ -288,6 +292,7 @@ impl ActionsMenu {
                 "Prepare handoff · finish active work first"
             }
             Action::FastMode if self.availability.fast_mode => "Disable fast mode",
+            Action::Model if !self.availability.model => "Select model · start a new session first",
             Action::Memory if !self.availability.memory => {
                 "Memory · enable in config: memory.enabled = true"
             }
@@ -303,6 +308,7 @@ impl Action {
             Self::Review => "Review changes",
             Self::Subagents => "Subagents",
             Self::Effort => "Change effort",
+            Self::Model => "Select model",
             Self::FastMode => "Enable fast mode",
             Self::Theme => "Select theme",
             Self::NewSession => "New session",
@@ -322,6 +328,7 @@ impl Action {
             Self::Review => Some("review"),
             Self::Subagents => Some("agents"),
             Self::Effort => Some("thinking"),
+            Self::Model => Some("intelligence"),
             Self::FastMode => Some("priority"),
             Self::Theme => Some("appearance"),
             Self::NewSession => Some("clear"),
@@ -417,6 +424,7 @@ mod tests {
             fork: true,
             fast_mode: false,
             memory: true,
+            model: true,
         }
     }
 
@@ -588,6 +596,30 @@ mod tests {
             enabled.update(key(KeyCode::Enter)).effects,
             [ActionsEffect::Trigger(Action::Effort)]
         );
+    }
+
+    #[test]
+    fn model_action_is_available_only_before_the_first_prompt() {
+        let mut enabled = ActionsMenu::new(available());
+        for character in "intelligence".chars() {
+            enabled.update(key(KeyCode::Char(character)));
+        }
+        assert_eq!(
+            enabled.update(key(KeyCode::Enter)).effects,
+            [ActionsEffect::Trigger(Action::Model)]
+        );
+
+        let mut availability = available();
+        availability.model = false;
+        let mut disabled = ActionsMenu::new(availability);
+        for character in "intelligence".chars() {
+            disabled.update(key(KeyCode::Char(character)));
+        }
+        let terminal = render(&mut disabled);
+        assert!((0..20).any(|row| {
+            row_segment(&terminal, row, 0, 60).contains("Select model · start a new session first")
+        }));
+        assert!(disabled.update(key(KeyCode::Enter)).effects.is_empty());
     }
 
     #[test]

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -3,7 +3,7 @@
 use super::{
     node::{ComponentUpdate, Node, RenderRequest},
     queue::QueueId,
-    root::{RestoredSessionProjection, RootEffect, RootEvent, RootNode},
+    root::{DraftReset, RestoredSessionProjection, RootEffect, RootEvent, RootNode},
 };
 use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -102,6 +103,8 @@ pub(crate) enum AppEvent {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
+        draft_reset: DraftReset,
         skills: Arc<[Skill]>,
     },
     NewSessionFailed {
@@ -149,6 +152,7 @@ pub(crate) enum AppEvent {
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
         skills: Arc<[Skill]>,
     },
     NotifyError {
@@ -267,6 +271,7 @@ impl AppNode {
                         effort,
                         reasoning_mode,
                         reasoning_mode,
+                        DraftReset::Clear,
                     );
                     root.component_mut().set_fast_mode(fast_mode);
                     root.component_mut().set_skills(skills);
@@ -312,6 +317,8 @@ impl AppNode {
                 effort,
                 reasoning_mode,
                 fast_mode,
+                model,
+                draft_reset,
                 skills,
             } => {
                 let workspace = self.workspace.clone();
@@ -323,8 +330,10 @@ impl AppNode {
                     effort,
                     reasoning_mode,
                     reasoning_mode,
+                    draft_reset,
                 );
                 root.component_mut().set_fast_mode(fast_mode);
+                root.component_mut().set_model(model);
                 root.component_mut().set_skills(skills);
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
@@ -372,6 +381,7 @@ impl AppNode {
                 reasoning_mode,
                 preferred_reasoning_mode,
                 fast_mode,
+                model,
                 skills,
             } => self.update_root(
                 pane,
@@ -381,6 +391,7 @@ impl AppNode {
                     reasoning_mode,
                     preferred_reasoning_mode,
                     fast_mode,
+                    model,
                     skills,
                 },
             ),
@@ -756,8 +767,8 @@ fn is_control_c(event: &Event) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::SessionListKind, AppEffect, AppEvent, AppNode, RootEffect, RootEvent, RootNode,
-        SPLIT_HINT,
+        super::SessionListKind, AppEffect, AppEvent, AppNode, DraftReset, RootEffect, RootEvent,
+        RootNode, SPLIT_HINT,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -771,6 +782,7 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
+    use nanocodex::Model;
     use ratatui::{Terminal, backend::TestBackend};
     use semver::Version;
     use std::{path::PathBuf, sync::Arc};
@@ -786,6 +798,29 @@ mod tests {
             KeyCode::Char(character),
             KeyModifiers::CONTROL,
         )))
+    }
+
+    #[test]
+    fn model_session_replacement_preserves_the_draft_in_place() {
+        let mut app = app();
+        app.update(AppEvent::EditorDraft {
+            pane: PaneId::Main,
+            draft: "send with luna".to_owned(),
+        });
+
+        app.update(AppEvent::NewSessionReady {
+            pane: PaneId::Main,
+            effort: ReasoningEffort::Low,
+            reasoning_mode: ReasoningMode::Standard,
+            fast_mode: false,
+            model: Model::Luna,
+            draft_reset: DraftReset::Preserve,
+            skills: Arc::from([]),
+        });
+
+        let root = app.root(PaneId::Main).unwrap();
+        assert_eq!(root.composer().draft(), "send with luna");
+        assert_eq!(root.composer().model(), Model::Luna);
     }
 
     fn memory_record(id: i64, content: &str) -> MemoryRecord {

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -20,7 +20,7 @@ use crate::{
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use history::PromptHistory;
 use layout::{VisualLayout, byte_at_column, grapheme_at_column};
-use nanocodex::oai::MODEL;
+use nanocodex::Model;
 use ratatui::{
     Frame,
     buffer::Buffer,
@@ -65,6 +65,7 @@ pub(crate) enum ComposerEvent {
     },
     ReplaceDraft(String),
     SetEffort(ReasoningEffort),
+    SetModel(Model),
     SetReasoningMode(ReasoningMode),
     SetFastMode(bool),
     Activity {
@@ -101,6 +102,7 @@ pub(crate) struct Composer {
     context_tokens: u64,
     workspace: String,
     thinking: ReasoningEffort,
+    model: Model,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
     activity_wave: Option<WavedText>,
@@ -197,6 +199,7 @@ impl Composer {
             context_tokens: 0,
             workspace: shorten_home(workspace),
             thinking,
+            model: Model::Sol,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
             activity_wave: None,
@@ -254,6 +257,13 @@ impl Composer {
                     return ComposerUpdate::unchanged();
                 }
                 self.thinking = effort;
+                ComposerUpdate::changed()
+            }
+            ComposerEvent::SetModel(model) => {
+                if self.model == model {
+                    return ComposerUpdate::unchanged();
+                }
+                self.model = model;
                 ComposerUpdate::changed()
             }
             ComposerEvent::SetReasoningMode(mode) => {
@@ -540,6 +550,10 @@ impl Composer {
 
     pub(crate) const fn effort(&self) -> ReasoningEffort {
         self.thinking
+    }
+
+    pub(crate) const fn model(&self) -> Model {
+        self.model
     }
 
     pub(crate) const fn fast_mode(&self) -> bool {
@@ -1031,7 +1045,7 @@ impl Composer {
         } else {
             format!("{usage_before_subagents}{} ", subagent_segment.trim_start())
         };
-        let model = format!(" {MODEL} ");
+        let model = format!(" {} ", self.model);
         let timer = self
             .turn_timers
             .front()
@@ -1387,7 +1401,10 @@ mod tests {
         tui::theme::Theme,
     };
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-    use nanocodex::agent::input::{PromptInput, UserInput};
+    use nanocodex::{
+        Model,
+        agent::input::{PromptInput, UserInput},
+    };
     use ratatui::{
         Terminal,
         backend::TestBackend,
@@ -1463,6 +1480,17 @@ mod tests {
                 footer,
             ]
         );
+    }
+
+    #[test]
+    fn composer_chrome_uses_the_selected_session_model() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::SetModel(Model::Luna));
+
+        let terminal = render(&mut composer, 60, 5);
+
+        assert!(rows(&terminal)[0].contains(" gpt-5.6-luna "));
+        assert!(!rows(&terminal)[0].contains(" gpt-5.6-sol "));
     }
 
     #[test]

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -16,8 +16,9 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 const FOOTER: [&str; 1] = ["esc close"];
-const BINDINGS: [(&str, &str); 21] = [
+const BINDINGS: [(&str, &str); 22] = [
     ("ctrl+s", "change reasoning effort"),
+    ("ctrl+m", "select model · before first prompt"),
     ("ctrl+f", "fork session · when available"),
     ("ctrl+g", "edit prompt in $EDITOR"),
     ("ctrl+r", "recent prompts"),

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -9,6 +9,7 @@ mod file_finder;
 mod floating;
 mod keybindings;
 mod memory;
+mod model_selector;
 mod node;
 mod queue;
 mod recent_prompt_picker;
@@ -27,5 +28,5 @@ pub(crate) use app::{AppEffect, AppEvent, AppNode};
 pub(crate) use node::{ComponentUpdate, RenderRequest};
 pub(crate) use queue::QueueId;
 pub(crate) use root::{
-    RecentPromptDraft, RestoredSessionProjection, RootEffect, RootNode, SessionListKind,
+    DraftReset, RecentPromptDraft, RestoredSessionProjection, RootEffect, RootNode, SessionListKind,
 };

--- a/src/tui/components/model_selector.rs
+++ b/src/tui/components/model_selector.rs
@@ -1,0 +1,341 @@
+//! Animated linear selector for the model fixed to a new session.
+
+use super::{
+    floating::Floating,
+    node::{Component, ComponentUpdate, RenderRequest},
+};
+use crate::tui::theme::Theme;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use nanocodex::Model;
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+use std::time::{Duration, Instant};
+
+const MODELS: [Model; 3] = [Model::Luna, Model::Terra, Model::Sol];
+const ANIMATION_DURATION: Duration = Duration::from_millis(280);
+const ANIMATION_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+const KEY_BINDINGS: [&str; 3] = ["←/→ model", "enter apply", "esc cancel"];
+
+pub(super) enum ModelSelectorEvent {
+    Terminal { event: Event, now: Instant },
+    AnimationFrame(Instant),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum ModelSelectorEffect {
+    Apply(Model),
+    Dismiss,
+}
+
+pub(super) struct ModelSelector {
+    selected: usize,
+    displayed_position: f64,
+    animation: Option<Animation>,
+}
+
+struct Animation {
+    from: f64,
+    to: f64,
+    started_at: Instant,
+    next_frame: Instant,
+}
+
+impl ModelSelector {
+    pub(super) fn new(initial: Model) -> Self {
+        let selected = model_index(initial);
+        Self {
+            selected,
+            displayed_position: selected as f64,
+            animation: None,
+        }
+    }
+
+    pub(super) fn animation_deadline(&self) -> Option<Instant> {
+        self.animation
+            .as_ref()
+            .map(|animation| animation.next_frame)
+    }
+
+    fn update_key(&mut self, key: KeyEvent, now: Instant) -> ComponentUpdate<ModelSelectorEffect> {
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return ComponentUpdate::none();
+        }
+
+        match key.code {
+            KeyCode::Left | KeyCode::Up => self.select_relative(-1, now),
+            KeyCode::Right | KeyCode::Down => self.select_relative(1, now),
+            KeyCode::Enter => ComponentUpdate {
+                effects: vec![ModelSelectorEffect::Apply(MODELS[self.selected])],
+                render: RenderRequest::Immediate,
+            },
+            KeyCode::Esc | KeyCode::Backspace => ComponentUpdate {
+                effects: vec![ModelSelectorEffect::Dismiss],
+                render: RenderRequest::Immediate,
+            },
+            _ => ComponentUpdate::none(),
+        }
+    }
+
+    fn select_relative(
+        &mut self,
+        direction: isize,
+        now: Instant,
+    ) -> ComponentUpdate<ModelSelectorEffect> {
+        self.advance_animation(now);
+        let next = self
+            .selected
+            .saturating_add_signed(direction)
+            .min(MODELS.len() - 1);
+        if next == self.selected {
+            return ComponentUpdate::none();
+        }
+        self.selected = next;
+        self.animation = Some(Animation {
+            from: self.displayed_position,
+            to: next as f64,
+            started_at: now,
+            next_frame: now + ANIMATION_FRAME_INTERVAL,
+        });
+        ComponentUpdate::render(RenderRequest::Immediate)
+    }
+
+    fn advance_animation(&mut self, now: Instant) -> bool {
+        let Some(animation) = &mut self.animation else {
+            return false;
+        };
+        let elapsed = now.saturating_duration_since(animation.started_at);
+        let progress = (elapsed.as_secs_f64() / ANIMATION_DURATION.as_secs_f64()).min(1.0);
+        let eased = 1.0 - (1.0 - progress).powi(3);
+        self.displayed_position = animation.from + (animation.to - animation.from) * eased;
+        if progress >= 1.0 {
+            self.displayed_position = self.selected as f64;
+            self.animation = None;
+        } else {
+            animation.next_frame = now + ANIMATION_FRAME_INTERVAL;
+        }
+        true
+    }
+
+    fn render_slider(&self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
+        if area.width < 5 || area.height < 2 {
+            return;
+        }
+        let left = area.x.saturating_add(2);
+        let right = area.right().saturating_sub(3).max(left);
+        let width = right.saturating_sub(left);
+        let indicator_column = left.saturating_add(
+            (f64::from(width) * self.displayed_position / (MODELS.len() - 1) as f64).round() as u16,
+        );
+        let selected_color = model_color(theme, MODELS[self.selected]);
+        let buffer = frame.buffer_mut();
+        for column in left..=right {
+            let color = if column <= indicator_column {
+                selected_color
+            } else {
+                theme.muted()
+            };
+            buffer.set_string(column, area.y, "━", Style::default().fg(color));
+        }
+        for index in 0..MODELS.len() {
+            let column = model_column(left, width, index);
+            let color = if index <= self.displayed_position.round() as usize {
+                selected_color
+            } else {
+                theme.muted()
+            };
+            buffer.set_string(column, area.y, "●", Style::default().fg(color));
+        }
+        buffer.set_string(
+            indicator_column,
+            area.y,
+            "◆",
+            Style::default()
+                .fg(selected_color)
+                .add_modifier(Modifier::BOLD),
+        );
+
+        let labels = [
+            (model_column(left, width, 0), "Luna"),
+            (model_column(left, width, 1), "Terra"),
+            (model_column(left, width, 2), "Sol"),
+        ];
+        for (column, label) in labels {
+            let label_width = u16::try_from(label.len()).unwrap_or(u16::MAX);
+            let start = column.saturating_sub(label_width / 2).max(area.x);
+            buffer.set_string(
+                start,
+                area.y.saturating_add(1),
+                label,
+                Style::default().fg(theme.text()),
+            );
+        }
+    }
+}
+
+fn model_column(left: u16, width: u16, index: usize) -> u16 {
+    left.saturating_add(
+        (f64::from(width) * index as f64 / (MODELS.len() - 1) as f64).round() as u16,
+    )
+}
+
+impl Component for ModelSelector {
+    type Event = ModelSelectorEvent;
+    type Effect = ModelSelectorEffect;
+
+    fn update(&mut self, event: Self::Event) -> ComponentUpdate<Self::Effect> {
+        match event {
+            ModelSelectorEvent::Terminal {
+                event: Event::Key(key),
+                now,
+            } => self.update_key(key, now),
+            ModelSelectorEvent::Terminal { .. } => ComponentUpdate::none(),
+            ModelSelectorEvent::AnimationFrame(now) => {
+                if self.advance_animation(now) {
+                    ComponentUpdate::render(RenderRequest::Streaming)
+                } else {
+                    ComponentUpdate::none()
+                }
+            }
+        }
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
+        let layout = Floating::new("Select model", 52, 7, &KEY_BINDINGS).render(frame, area, theme);
+        if layout.body.is_empty() {
+            return;
+        }
+        let model = MODELS[self.selected];
+        let title = Line::from(vec![
+            Span::styled("Selected: ", Style::default().fg(theme.border())),
+            Span::styled(
+                model_name(model),
+                Style::default()
+                    .fg(model_color(theme, model))
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ·  smarter →", Style::default().fg(Color::Green)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(title).alignment(Alignment::Center),
+            Rect {
+                height: 1,
+                ..layout.body
+            },
+        );
+        self.render_slider(
+            frame,
+            Rect {
+                y: layout.body.y.saturating_add(2),
+                height: 2,
+                ..layout.body
+            },
+            theme,
+        );
+    }
+}
+
+fn model_index(model: Model) -> usize {
+    MODELS
+        .iter()
+        .position(|candidate| *candidate == model)
+        .unwrap_or(2)
+}
+
+fn model_name(model: Model) -> &'static str {
+    match model {
+        Model::Luna => "Luna",
+        Model::Terra => "Terra",
+        Model::Sol => "Sol",
+        _ => "Sol",
+    }
+}
+
+fn model_color(theme: &Theme, model: Model) -> Color {
+    match model {
+        Model::Luna => theme.thinking_low(),
+        Model::Terra => theme.thinking_high(),
+        Model::Sol => theme.thinking_max(),
+        _ => theme.thinking_max(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEvent, KeyModifiers};
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn render(selector: &mut ModelSelector) -> Terminal<TestBackend> {
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        terminal
+            .draw(|frame| selector.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        terminal
+    }
+
+    #[test]
+    fn terra_label_is_centered_under_the_middle_stop() {
+        let terminal = render(&mut ModelSelector::new(Model::Terra));
+        let buffer = terminal.backend().buffer();
+        let stop = buffer
+            .content
+            .iter()
+            .position(|cell| cell.symbol() == "◆")
+            .unwrap();
+        let width = usize::from(buffer.area.width);
+        let label_row = stop / width + 1;
+        let terra = buffer.content[label_row * width..(label_row + 1) * width]
+            .windows(5)
+            .position(|cells| cells.iter().map(|cell| cell.symbol()).collect::<String>() == "Terra")
+            .unwrap();
+
+        assert_eq!(terra + 2, stop % width);
+    }
+
+    #[test]
+    fn selection_moves_linearly_and_does_not_wrap() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Sol);
+
+        selector.update_key(key(KeyCode::Right), now);
+        assert_eq!(selector.selected, 2);
+        selector.update_key(key(KeyCode::Left), now);
+        assert_eq!(selector.selected, 1);
+        selector.update_key(key(KeyCode::Left), now);
+        selector.update_key(key(KeyCode::Left), now);
+        assert_eq!(selector.selected, 0);
+    }
+
+    #[test]
+    fn applying_returns_the_selected_model() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Sol);
+        selector.update_key(key(KeyCode::Left), now);
+
+        let update = selector.update_key(key(KeyCode::Enter), now);
+
+        assert_eq!(update.effects, [ModelSelectorEffect::Apply(Model::Terra)]);
+    }
+
+    #[test]
+    fn animation_reaches_the_selected_stop() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Luna);
+        selector.update_key(key(KeyCode::Right), now);
+        assert!(selector.animation_deadline().is_some());
+
+        selector.update(ModelSelectorEvent::AnimationFrame(now + ANIMATION_DURATION));
+
+        assert_eq!(selector.displayed_position, 1.0);
+        assert!(selector.animation_deadline().is_none());
+    }
+}

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -11,6 +11,7 @@ use super::{
     floating::Floating,
     keybindings::{KeybindingsEffect, KeybindingsEvent, KeybindingsHelp},
     memory::{MemoryBrowser, MemoryBrowserEffect, MemoryBrowserEvent},
+    model_selector::{ModelSelector, ModelSelectorEffect, ModelSelectorEvent},
     node::{Component, ComponentUpdate, Node, RenderRequest},
     queue::{MessageQueue, QueueEffect, QueueEvent, QueueId},
     recent_prompt_picker::{RecentPromptPicker, RecentPromptPickerEffect, RecentPromptPickerEvent},
@@ -40,6 +41,7 @@ use crate::{
     },
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -183,6 +185,7 @@ pub(crate) enum RootEvent {
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
         skills: Arc<[Skill]>,
     },
     NotifyError(String),
@@ -248,6 +251,7 @@ pub(crate) enum RootEffect {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
     },
+    SetModel(Model),
     SetFastMode(bool),
     SetMaxSubagents(usize),
     SetTheme(ThemeMode),
@@ -262,6 +266,7 @@ enum Overlay {
     Actions(Node<ActionsMenu>),
     ContextDiagnostics(Node<ContextDiagnosticsPanel>),
     Effort(Node<EffortSelector>),
+    Model(Node<ModelSelector>),
     Theme(Node<ThemeSelector>),
     FileFinder(FileMention),
     Skills(SkillMention),
@@ -293,6 +298,12 @@ struct SkillMention {
 enum ThreadState {
     New,
     Started,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum DraftReset {
+    Clear,
+    Preserve,
 }
 
 /// Owns layout and routing so future screen components do not widen the event loop.
@@ -372,6 +383,7 @@ impl RootNode {
                 self.composer.component().context_tokens(),
             ));
         root.set_fast_mode(self.composer.component().fast_mode());
+        root.set_model(self.composer.component().model());
         root.set_reasoning_modes(
             self.composer.component().reasoning_mode(),
             self.preferred_reasoning_mode,
@@ -423,6 +435,13 @@ impl RootNode {
             .update(ComposerEvent::SetFastMode(enabled));
     }
 
+    pub(crate) fn set_model(&mut self, model: Model) {
+        let _ = self
+            .composer
+            .component_mut()
+            .update(ComposerEvent::SetModel(model));
+    }
+
     pub(crate) fn set_reasoning_modes(&mut self, actual: ReasoningMode, preferred: ReasoningMode) {
         self.preferred_reasoning_mode = preferred;
         let _ = self
@@ -450,10 +469,15 @@ impl RootNode {
         thinking: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
+        draft_reset: DraftReset,
     ) {
         let current_draft = self.composer.component_mut().take_draft();
-        let replaced_draft = current_draft.is_some();
-        let discarded_draft = current_draft.or_else(|| self.discarded_draft.take());
+        let previous_discarded_draft = self.discarded_draft.take();
+        let replaced_draft = current_draft.is_some() && matches!(draft_reset, DraftReset::Clear);
+        let (preserved_draft, discarded_draft) = match draft_reset {
+            DraftReset::Clear => (None, current_draft.or(previous_discarded_draft)),
+            DraftReset::Preserve => (current_draft, previous_discarded_draft),
+        };
         let fork_available = self.fork_available;
         let memory_enabled = self.memory_enabled;
         let theme_mode = self.theme_mode;
@@ -465,6 +489,9 @@ impl RootNode {
         self.memory_enabled = memory_enabled;
         self.theme_mode = theme_mode;
         self.set_max_subagents(max_subagents);
+        if let Some(draft) = preserved_draft {
+            self.composer.component_mut().restore_draft(draft);
+        }
         if replaced_draft {
             self.show_draft_saved();
         }
@@ -532,6 +559,7 @@ impl RootNode {
             thinking,
             reasoning_mode,
             preferred_reasoning_mode,
+            DraftReset::Clear,
         );
         self.set_fast_mode(fast_mode);
         self.transcript = Node::new(projection.transcript);
@@ -561,12 +589,13 @@ impl RootNode {
     }
 
     pub(crate) fn animation_deadline(&self) -> Option<Instant> {
-        let effort = match &self.overlay {
+        let selector = match &self.overlay {
             Some(Overlay::Effort(selector)) => selector.component().animation_deadline(),
+            Some(Overlay::Model(selector)) => selector.component().animation_deadline(),
             _ => None,
         };
         [
-            effort,
+            selector,
             self.transcript.component().animation_deadline(),
             self.composer.component().animation_deadline(),
             self.queue.component().animation_deadline(),
@@ -660,6 +689,7 @@ impl RootNode {
                 Overlay::Actions(actions) => actions.render(frame, area, theme),
                 Overlay::ContextDiagnostics(panel) => panel.render(frame, area, theme),
                 Overlay::Effort(selector) => selector.render(frame, area, theme),
+                Overlay::Model(selector) => selector.render(frame, area, theme),
                 Overlay::Theme(selector) => selector.render(frame, area, theme),
                 Overlay::FileFinder(mention) => mention.finder.render(frame, area, theme),
                 Overlay::Skills(mention) => mention.picker.render(frame, area, theme),
@@ -769,6 +799,9 @@ impl RootNode {
         }
         if is_control_key(&event, 's') {
             return self.open_effort();
+        }
+        if is_control_key(&event, 'm') {
+            return self.open_model();
         }
         if is_control_key(&event, 'r') {
             return self.load_recent_prompts();
@@ -897,6 +930,7 @@ impl RootNode {
                     fork: self.fork_available,
                     fast_mode: self.composer.component().fast_mode(),
                     memory: self.memory_enabled,
+                    model: self.thread == ThreadState::New,
                 },
             ))));
             return ComponentUpdate::render(RenderRequest::Immediate);
@@ -1138,6 +1172,9 @@ impl RootNode {
             Some(Overlay::Actions(_)) => self.update_actions(event),
             Some(Overlay::ContextDiagnostics(_)) => self.update_context_diagnostics(event),
             Some(Overlay::Effort(_)) => self.update_effort(EffortEvent::Terminal { event, now }),
+            Some(Overlay::Model(_)) => {
+                self.update_model(ModelSelectorEvent::Terminal { event, now })
+            }
             Some(Overlay::Theme(_)) => {
                 self.update_theme_selector(ThemeSelectorEvent::Terminal(event))
             }
@@ -1355,6 +1392,9 @@ impl RootNode {
             Some(ActionsEffect::Trigger(Action::Effort)) => {
                 return self.open_effort();
             }
+            Some(ActionsEffect::Trigger(Action::Model)) => {
+                return self.open_model();
+            }
             Some(ActionsEffect::Trigger(Action::FastMode)) => {
                 self.overlay = None;
                 let enabled = !self.composer.component().fast_mode();
@@ -1521,6 +1561,16 @@ impl RootNode {
         self.overlay = Some(Overlay::Effort(Node::new(EffortSelector::new(
             self.composer.component().effort(),
             self.preferred_reasoning_mode == ReasoningMode::Pro,
+        ))));
+        ComponentUpdate::render(RenderRequest::Immediate)
+    }
+
+    fn open_model(&mut self) -> ComponentUpdate<RootEffect> {
+        if self.thread != ThreadState::New {
+            return ComponentUpdate::none();
+        }
+        self.overlay = Some(Overlay::Model(Node::new(ModelSelector::new(
+            self.composer.component().model(),
         ))));
         ComponentUpdate::render(RenderRequest::Immediate)
     }
@@ -1865,6 +1915,42 @@ impl RootNode {
         }
     }
 
+    fn update_model(&mut self, event: ModelSelectorEvent) -> ComponentUpdate<RootEffect> {
+        let Some(Overlay::Model(selector)) = &mut self.overlay else {
+            return ComponentUpdate::none();
+        };
+        let update = selector.update(event);
+        let Some(effect) = update.effects.into_iter().next() else {
+            return ComponentUpdate {
+                effects: Vec::new(),
+                render: update.render,
+            };
+        };
+
+        self.overlay = None;
+        match effect {
+            ModelSelectorEffect::Dismiss => ComponentUpdate::render(RenderRequest::Immediate),
+            ModelSelectorEffect::Apply(model) if model == self.composer.component().model() => {
+                ComponentUpdate::render(RenderRequest::Immediate)
+            }
+            ModelSelectorEffect::Apply(model) => {
+                self.interactive = false;
+                let _ = self
+                    .composer
+                    .component_mut()
+                    .update(ComposerEvent::Activity {
+                        active: true,
+                        status: Some(format!("Starting {} session…", model_name(model))),
+                        now: Instant::now(),
+                    });
+                ComponentUpdate {
+                    effects: vec![RootEffect::SetModel(model)],
+                    render: RenderRequest::Immediate,
+                }
+            }
+        }
+    }
+
     fn update_focus(&mut self) -> ComponentUpdate<RootEffect> {
         let focus_queue = !self.queue.component().focused() && !self.queue.component().is_empty();
         self.queue.component_mut().set_focused(focus_queue);
@@ -2081,6 +2167,7 @@ impl RootNode {
             RenderRequest::None
         };
         let effort = self.update_effort(EffortEvent::AnimationFrame(now));
+        let model = self.update_model(ModelSelectorEvent::AnimationFrame(now));
         let transcript = self.update_transcript(TranscriptEvent::AnimationFrame(now));
         let composer =
             self.update_composer(ComposerEvent::AnimationFrame(now), RenderRequest::Streaming);
@@ -2103,9 +2190,15 @@ impl RootNode {
             RenderRequest::None
         };
         ComponentUpdate {
-            effects: effort.effects.into_iter().chain(composer.effects).collect(),
+            effects: effort
+                .effects
+                .into_iter()
+                .chain(model.effects)
+                .chain(composer.effects)
+                .collect(),
             render: effort
                 .render
+                .max(model.render)
                 .max(transcript.render)
                 .max(composer.render)
                 .max(queue.render)
@@ -2419,6 +2512,7 @@ impl Component for RootNode {
                 reasoning_mode,
                 preferred_reasoning_mode,
                 fast_mode,
+                model,
                 skills,
             } => {
                 let workspace = self.workspace.clone();
@@ -2430,6 +2524,7 @@ impl Component for RootNode {
                     fast_mode,
                     *projection,
                 );
+                self.set_model(model);
                 self.set_skills(skills);
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
@@ -2678,6 +2773,15 @@ fn is_file_query_character(character: char) -> bool {
     character.is_alphanumeric() || matches!(character, '_' | '-' | '.' | '/')
 }
 
+fn model_name(model: Model) -> &'static str {
+    match model {
+        Model::Luna => "Luna",
+        Model::Terra => "Terra",
+        Model::Sol => "Sol",
+        _ => "Sol",
+    }
+}
+
 fn is_skill_query_character(character: char) -> bool {
     character.is_ascii_alphanumeric() || character == '-'
 }
@@ -2764,8 +2868,9 @@ fn is_plain_key(event: &Event, character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        Component, ComposerChromeTarget, ConfirmationAction, Overlay, RenderRequest, RootEffect,
-        RootEvent, RootNode, SessionListKind, SubagentOverlay, ThreadState, TranscriptEvent,
+        Component, ComposerChromeTarget, ConfirmationAction, DraftReset, Overlay, RenderRequest,
+        RootEffect, RootEvent, RootNode, SessionListKind, SubagentOverlay, ThreadState,
+        TranscriptEvent,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -2784,9 +2889,12 @@ mod tests {
         Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
         MouseEventKind,
     };
-    use nanocodex::agent::{
-        events::{AgentEvent, AgentEventKind},
-        input::{PromptInput, UserInput},
+    use nanocodex::{
+        Model,
+        agent::{
+            events::{AgentEvent, AgentEventKind},
+            input::{PromptInput, UserInput},
+        },
     };
     use ratatui::{
         Terminal,
@@ -4000,6 +4108,7 @@ mod tests {
             ReasoningEffort::High,
             ReasoningMode::Standard,
             ReasoningMode::Standard,
+            DraftReset::Clear,
         );
         root.update(key(KeyCode::Char('z'), KeyModifiers::CONTROL));
 
@@ -4966,6 +5075,7 @@ mod tests {
             ReasoningEffort::Medium,
             ReasoningMode::Pro,
             ReasoningMode::Pro,
+            DraftReset::Clear,
         );
         assert_eq!(root.composer().reasoning_mode(), ReasoningMode::Pro);
 
@@ -5041,6 +5151,59 @@ mod tests {
         let reopened = root.update(key(KeyCode::Char('s'), KeyModifiers::CONTROL));
         assert!(matches!(&root.overlay, Some(Overlay::Effort(_))));
         assert_eq!(reopened.render, super::RenderRequest::Immediate);
+    }
+
+    #[test]
+    fn control_m_selects_a_model_only_before_the_first_prompt() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+
+        let opened = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        assert!(matches!(&root.overlay, Some(Overlay::Model(_))));
+        assert_eq!(opened.render, super::RenderRequest::Immediate);
+
+        root.update(key(KeyCode::Left, KeyModifiers::NONE));
+        let selected = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(selected.effects, [RootEffect::SetModel(Model::Terra)]);
+
+        root.interactive = true;
+        root.thread = super::ThreadState::Started;
+        let blocked = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        assert!(blocked.effects.is_empty());
+        assert!(root.overlay.is_none());
+    }
+
+    #[test]
+    fn fork_inherits_the_model_and_cannot_change_it() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.set_model(Model::Luna);
+
+        let mut fork = root.fork(Path::new("/work"), ReasoningEffort::Medium);
+
+        assert_eq!(fork.composer().model(), Model::Luna);
+        let update = fork.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        assert!(update.effects.is_empty());
+        assert!(fork.overlay.is_none());
+    }
+
+    #[test]
+    fn model_action_opens_only_for_a_new_thread() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "intelligence".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(root.overlay, Some(Overlay::Model(_))));
+
+        root.overlay = None;
+        root.thread = ThreadState::Started;
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "intelligence".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        let blocked = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(blocked.effects.is_empty());
+        assert!(matches!(root.overlay, Some(Overlay::Actions(_))));
     }
 
     #[test]
@@ -5291,6 +5454,7 @@ mod tests {
             ReasoningEffort::Low,
             ReasoningMode::Standard,
             ReasoningMode::Standard,
+            DraftReset::Clear,
         );
         let fork = root.fork(Path::new("/work"), ReasoningEffort::Low);
         assert!(root.memory_enabled);
@@ -5332,6 +5496,7 @@ mod tests {
             ReasoningEffort::Medium,
             ReasoningMode::Standard,
             ReasoningMode::Standard,
+            DraftReset::Clear,
         );
 
         assert!(root.interactive);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -59,6 +59,7 @@ use crate::{
 };
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
 use futures_util::StreamExt;
+use nanocodex::Model;
 use std::{
     collections::HashMap,
     io::{self, IsTerminal},
@@ -94,6 +95,8 @@ type NewSessionTask = JoinHandle<(
     ReasoningEffort,
     ReasoningMode,
     bool,
+    Model,
+    components::DraftReset,
     Result<ConfiguredAgent>,
 )>;
 
@@ -145,6 +148,7 @@ struct RestoredSession {
     configured: ConfiguredAgent,
     projection: RestoredSessionProjection,
     reasoning_mode: ReasoningMode,
+    model: Model,
 }
 
 enum EditorTarget {
@@ -210,14 +214,21 @@ struct PaneSettings {
     effort: ReasoningEffort,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
+    model: Model,
 }
 
 impl PaneSettings {
-    const fn new(effort: ReasoningEffort, reasoning_mode: ReasoningMode, fast_mode: bool) -> Self {
+    const fn new(
+        effort: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        fast_mode: bool,
+        model: Model,
+    ) -> Self {
         Self {
             effort,
             reasoning_mode,
             fast_mode,
+            model,
         }
     }
 }
@@ -258,6 +269,7 @@ struct PaneRuntime {
     current_effort: ReasoningEffort,
     reasoning_mode: ReasoningMode,
     current_fast_mode: bool,
+    current_model: Model,
     active_shells: usize,
     generation: u64,
     subagent_control: SubagentControl,
@@ -429,7 +441,7 @@ pub(crate) async fn run(
         StartupMode::NewSession | StartupMode::ResumeSelector => None,
     };
     let resuming = resume_session_id.is_some();
-    let (configured, restored_projection, reasoning_mode) =
+    let (configured, restored_projection, reasoning_mode, model) =
         if let Some(session_id) = resume_session_id {
             let restored_config = config.clone();
             let config_path = restored_config.path().to_path_buf();
@@ -446,6 +458,7 @@ pub(crate) async fn run(
             let records = records?;
             tokio::task::spawn_blocking(move || -> Result<_> {
                 let reasoning_mode = session::reasoning_mode(&records);
+                let model = session::model(&records);
                 let projection = RootNode::project_session(initial_effort, records);
                 let configured = ConfiguredAgent::from_config_with_session(
                     &restored_config,
@@ -454,7 +467,7 @@ pub(crate) async fn run(
                     Some(&session_id),
                     Some(snapshot),
                 )?;
-                Ok((configured, Some(projection), reasoning_mode))
+                Ok((configured, Some(projection), reasoning_mode, model))
             })
             .await
             .map_err(RuntimeError::SessionTask)??
@@ -463,6 +476,7 @@ pub(crate) async fn run(
                 ConfiguredAgent::from_config(&config)?,
                 None,
                 preferred_reasoning_mode,
+                Model::Sol,
             )
         };
     let mut terminal = TerminalSession::enter().map_err(RuntimeError::Terminal)?;
@@ -491,7 +505,7 @@ pub(crate) async fn run(
                 PaneSession::new(&main_session_id, None, !skills.is_empty())
             },
             &config,
-            PaneSettings::new(initial_effort, reasoning_mode, initial_fast_mode),
+            PaneSettings::new(initial_effort, reasoning_mode, initial_fast_mode, model),
             instructions,
             subagent_control.clone(),
             &writer_sender,
@@ -528,6 +542,7 @@ pub(crate) async fn run(
             projection,
         );
     }
+    root.set_model(model);
     root.set_skills(skills);
     let mut theme = config.theme().clone();
     if let Some(scheme) = theme::detect_system_scheme() {
@@ -938,6 +953,10 @@ pub(crate) async fn run(
                             .get(&PaneId::Main)
                             .expect("main pane must exist")
                             .reasoning_mode;
+                        let model = panes
+                            .get(&PaneId::Main)
+                            .expect("main pane must exist")
+                            .current_model;
                         let subagent_control = panes
                             .get(&PaneId::Main)
                             .expect("main pane must exist")
@@ -966,7 +985,7 @@ pub(crate) async fn run(
                                     skills_catalog_present,
                                 ),
                                 &config,
-                                PaneSettings::new(effort, reasoning_mode, fast_mode),
+                                PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                                 instructions,
                                 subagent_control.clone(),
                                 &writer_sender,
@@ -1171,7 +1190,7 @@ pub(crate) async fn run(
                         let skills = install_configured_agent(
                             pane,
                             configured,
-                            PaneSettings::new(effort, reasoning_mode, fast_mode),
+                            PaneSettings::new(effort, reasoning_mode, fast_mode, Model::Sol),
                             &config,
                             &mut panes,
                             &commands,
@@ -1211,14 +1230,14 @@ pub(crate) async fn run(
             }, if new_session_task.is_some() && !stopping => {
                 new_session_task = None;
                 input = Some(EventStream::new());
-                let (pane, effort, reasoning_mode, fast_mode, configured) =
+                let (pane, effort, reasoning_mode, fast_mode, model, draft_reset, configured) =
                     result.map_err(RuntimeError::NewSessionTask)?;
                 match configured {
                     Ok(configured) => {
                         let skills = install_configured_agent(
                             pane,
                             configured,
-                            PaneSettings::new(effort, reasoning_mode, fast_mode),
+                            PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                             &config,
                             &mut panes,
                             &commands,
@@ -1235,6 +1254,8 @@ pub(crate) async fn run(
                                 effort,
                                 reasoning_mode,
                                 fast_mode,
+                                model,
+                                draft_reset,
                                 skills,
                             }),
                             &mut scheduler,
@@ -1357,6 +1378,7 @@ pub(crate) async fn run(
                         configured,
                         projection,
                         reasoning_mode,
+                        model,
                     }) => {
                         let ConfiguredAgent {
                             agent,
@@ -1388,7 +1410,7 @@ pub(crate) async fn run(
                                 PaneGeneration { pane, generation },
                                 PaneSession::persisted(&session_id, !skills.is_empty()),
                                 &config,
-                                PaneSettings::new(effort, reasoning_mode, fast_mode),
+                                PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                                 instructions,
                                 subagent_control.clone(),
                                 &writer_sender,
@@ -1421,6 +1443,7 @@ pub(crate) async fn run(
                                 reasoning_mode,
                                 preferred_reasoning_mode,
                                 fast_mode,
+                                model,
                                 skills,
                             }),
                             &mut scheduler,
@@ -1568,6 +1591,7 @@ fn open_pane(
         effort,
         reasoning_mode,
         fast_mode,
+        model,
     } = settings;
     let PaneSession {
         id: session_id,
@@ -1581,7 +1605,7 @@ fn open_pane(
     journal.defer_start(SessionStarted {
         session_id: session_id.to_owned(),
         parent_session_id: parent_session_id.map(str::to_owned),
-        model: nanocodex::oai::MODEL.to_owned(),
+        model: model.to_string(),
         effort,
         reasoning_mode,
         fast_mode,
@@ -1621,6 +1645,7 @@ fn open_pane(
         current_effort: effort,
         reasoning_mode,
         current_fast_mode: fast_mode,
+        current_model: model,
         active_shells: 0,
         generation,
         subagent_control,
@@ -1923,6 +1948,43 @@ fn apply_pane_effect(
                 })
             }));
         }
+        components::RootEffect::SetModel(model) => {
+            *context.input = None;
+            let effort = context
+                .app
+                .root(pane)
+                .expect("model pane must exist")
+                .composer()
+                .effort();
+            let reasoning_mode = context
+                .panes
+                .get(&pane)
+                .expect("model pane must have a runtime")
+                .reasoning_mode;
+            let fast_mode = context
+                .panes
+                .get(&pane)
+                .expect("model pane must have a runtime")
+                .current_fast_mode;
+            let config = context.config.clone();
+            *context.new_session_task = Some(tokio::task::spawn_blocking(move || {
+                let configured = ConfiguredAgent::from_config_with_model(
+                    &config,
+                    effort,
+                    reasoning_mode,
+                    model,
+                );
+                (
+                    pane,
+                    effort,
+                    reasoning_mode,
+                    fast_mode,
+                    model,
+                    components::DraftReset::Preserve,
+                    configured,
+                )
+            }));
+        }
         components::RootEffect::SetFastMode(enabled) => {
             *context.input = None;
             let config = (pane == PaneId::Main).then(|| context.config.clone());
@@ -2028,7 +2090,15 @@ fn apply_pane_effect(
                     None,
                     None,
                 );
-                (pane, effort, reasoning_mode, fast_mode, configured)
+                (
+                    pane,
+                    effort,
+                    reasoning_mode,
+                    fast_mode,
+                    Model::Sol,
+                    components::DraftReset::Clear,
+                    configured,
+                )
             }));
         }
         components::RootEffect::LoadSessions(kind) => {
@@ -2164,6 +2234,7 @@ fn apply_pane_effect(
                     let records = records?;
                     tokio::task::spawn_blocking(move || -> Result<_> {
                     let reasoning_mode = session::reasoning_mode(&records);
+                    let model = session::model(&records);
                     let projection = RootNode::project_session(effort, records);
                     let configured = ConfiguredAgent::from_config_with_session(
                         &config,
@@ -2176,6 +2247,7 @@ fn apply_pane_effect(
                         configured,
                         projection,
                         reasoning_mode,
+                        model,
                     })
                     })
                     .await
@@ -2567,6 +2639,7 @@ mod tests {
             worker::WorkerCommand,
         },
     };
+    use nanocodex::Model;
     use std::{collections::HashMap, fs, path::Path, sync::Arc};
     use tempfile::tempdir;
 
@@ -2794,7 +2867,12 @@ mod tests {
             },
             PaneSession::new("main-session", None, false),
             &config,
-            PaneSettings::new(ReasoningEffort::Low, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Low,
+                ReasoningMode::Standard,
+                false,
+                Model::Luna,
+            ),
             Arc::from("instructions"),
             subagent_control.clone(),
             &sender,
@@ -2807,7 +2885,12 @@ mod tests {
             },
             PaneSession::new("fork-session", Some("main-session"), false),
             &config,
-            PaneSettings::new(ReasoningEffort::Low, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Low,
+                ReasoningMode::Standard,
+                false,
+                Model::Luna,
+            ),
             Arc::from("instructions"),
             subagent_control.clone(),
             &sender,
@@ -2867,6 +2950,7 @@ mod tests {
             .decode_payload::<crate::tui::transcript::SessionStarted>()
             .unwrap();
         assert_eq!(started.parent_session_id.as_deref(), Some("main-session"));
+        assert_eq!(started.model, Model::Luna.to_string());
         assert_eq!(records[1].kind(), "user.submitted");
     }
 
@@ -2891,7 +2975,12 @@ mod tests {
             },
             PaneSession::new("old-session", None, false),
             &config,
-            PaneSettings::new(ReasoningEffort::Medium, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Medium,
+                ReasoningMode::Standard,
+                false,
+                Model::Sol,
+            ),
             Arc::from("instructions"),
             subagent_control.clone(),
             &sender,
@@ -2913,7 +3002,12 @@ mod tests {
             },
             PaneSession::new("new-session", None, false),
             &config,
-            PaneSettings::new(ReasoningEffort::Medium, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Medium,
+                ReasoningMode::Standard,
+                false,
+                Model::Sol,
+            ),
             Arc::from("instructions"),
             subagent_control,
             &sender,

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -7,7 +7,7 @@ use crate::{
         transcript::{SessionStarted, TranscriptRecord},
     },
 };
-use nanocodex::agent::session::SessionSnapshot;
+use nanocodex::{Model, agent::session::SessionSnapshot};
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
@@ -227,6 +227,15 @@ pub(crate) fn reasoning_mode(records: &[Arc<TranscriptRecord>]) -> ReasoningMode
         .map_or(ReasoningMode::Standard, |started| started.reasoning_mode)
 }
 
+pub(crate) fn model(records: &[Arc<TranscriptRecord>]) -> Model {
+    records
+        .iter()
+        .find(|record| record.source() == "tact" && record.kind() == "session.started")
+        .and_then(|record| record.decode_payload::<SessionStarted>().ok())
+        .and_then(|started| started.model.parse().ok())
+        .unwrap_or(Model::Sol)
+}
+
 pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -244,7 +253,7 @@ pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{encode_checkpoint, load_checkpoint, load_transcript, save_checkpoint};
+    use super::{encode_checkpoint, load_checkpoint, load_transcript, model, save_checkpoint};
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::{
@@ -252,7 +261,7 @@ mod tests {
             transcript::{LocalEvent, SessionStarted, TranscriptJournal, TranscriptRecord, TurnId},
         },
     };
-    use nanocodex::agent::session::SessionSnapshot;
+    use nanocodex::{Model, agent::session::SessionSnapshot};
     use rusqlite::Connection;
     use serde_json::{Value, json};
     use std::sync::Arc;
@@ -288,6 +297,28 @@ mod tests {
 
         assert!(load_transcript(&config, "missing").unwrap().is_empty());
         assert!(!database_path(&config).exists());
+    }
+
+    #[test]
+    fn restored_model_comes_from_the_session_start_record() {
+        let record = TranscriptRecord::from_local(
+            1,
+            1,
+            LocalEvent::SessionStarted(SessionStarted {
+                session_id: "session".to_owned(),
+                parent_session_id: None,
+                model: Model::Luna.to_string(),
+                effort: ReasoningEffort::Medium,
+                reasoning_mode: ReasoningMode::Standard,
+                fast_mode: false,
+                workspace: "/work".into(),
+                application_version: "test".to_owned(),
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(model(&[Arc::new(record)]), Model::Luna);
+        assert_eq!(model(&[]), Model::Sol);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a Luna/Terra/Sol selector available only before the first prompt
- carry the selected model into session startup, forks, persistence, and actions
- keep Sol as the default model

## Stack

- Depends on: #100
- Next: #102

## Testing

- cargo nextest run --no-fail-fast (763 passed)
- just check-fmt
- just clippy
