### PR TITLE
fix(tui): open model selector from composer

### DIFF
--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -52,6 +52,7 @@ pub(crate) enum ComposerEffect {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ComposerChromeTarget {
     Effort,
+    Model,
     Subagents,
 }
 
@@ -113,6 +114,7 @@ pub(crate) struct Composer {
     subagent_wave: Option<WavedText>,
     turn_timers: VecDeque<TurnTimer>,
     effort_hit_area: Option<Rect>,
+    model_hit_area: Option<Rect>,
     subagent_hit_area: Option<Rect>,
     layout: Option<CachedLayout>,
     history: PromptHistory,
@@ -210,6 +212,7 @@ impl Composer {
             subagent_wave: None,
             turn_timers: VecDeque::new(),
             effort_hit_area: None,
+            model_hit_area: None,
             subagent_hit_area: None,
             layout: None,
             history: PromptHistory::default(),
@@ -374,6 +377,12 @@ impl Composer {
             .is_some_and(|area| area.contains(position))
         {
             return Some(ComposerChromeTarget::Subagents);
+        }
+        if self
+            .model_hit_area
+            .is_some_and(|area| area.contains(position))
+        {
+            return Some(ComposerChromeTarget::Model);
         }
         self.effort_hit_area
             .is_some_and(|area| area.contains(position))
@@ -1001,6 +1010,7 @@ impl Composer {
 
     fn render_chrome(&mut self, buffer: &mut Buffer, area: Rect, theme: &Theme) {
         self.effort_hit_area = None;
+        self.model_hit_area = None;
         self.subagent_hit_area = None;
         let shell_mode = self.draft.starts_with('!');
         let border = self.border_style(theme);
@@ -1121,6 +1131,16 @@ impl Composer {
             Style::default().fg(theme.muted()),
         );
         let model_start = right_start + u16::try_from(timer.width()).unwrap_or(u16::MAX);
+        if model_start < content_end {
+            self.model_hit_area = Some(Rect::new(
+                model_start,
+                top,
+                u16::try_from(model.width())
+                    .unwrap_or(u16::MAX)
+                    .min(content_end.saturating_sub(model_start)),
+                1,
+            ));
+        }
         buffer.set_stringn(
             model_start,
             top,

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -18,7 +18,7 @@ use unicode_width::UnicodeWidthStr;
 const FOOTER: [&str; 1] = ["esc close"];
 const BINDINGS: [(&str, &str); 22] = [
     ("ctrl+s", "change reasoning effort"),
-    ("ctrl+m", "select model · before first prompt"),
+    ("ctrl+d", "select model · before first prompt"),
     ("ctrl+f", "fork session · when available"),
     ("ctrl+g", "edit prompt in $EDITOR"),
     ("ctrl+r", "recent prompts"),

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -800,7 +800,7 @@ impl RootNode {
         if is_control_key(&event, 's') {
             return self.open_effort();
         }
-        if is_control_key(&event, 'm') {
+        if is_control_key(&event, 'd') {
             return self.open_model();
         }
         if is_control_key(&event, 'r') {
@@ -847,6 +847,7 @@ impl RootNode {
             let position = Position::new(mouse.column, mouse.row);
             match self.composer.component().chrome_target(position) {
                 Some(ComposerChromeTarget::Effort) => return self.open_effort(),
+                Some(ComposerChromeTarget::Model) => return self.open_model(),
                 Some(ComposerChromeTarget::Subagents) => {
                     self.overlay = Some(Overlay::Subagents(SubagentOverlay::Tree));
                     return ComponentUpdate::render(RenderRequest::Immediate);
@@ -3144,14 +3145,21 @@ mod tests {
     }
 
     #[test]
-    fn clicking_composer_chrome_opens_effort_and_subagents() {
+    fn clicking_composer_chrome_opens_model_effort_and_subagents() {
         let mut terminal = Terminal::new(TestBackend::new(100, 16)).unwrap();
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
         terminal
             .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
             .unwrap();
         let top = root.composer_area.y;
+        let model_x = text_column(terminal.backend().buffer(), top, "gpt-5.6-sol");
         let effort_x = text_column(terminal.backend().buffer(), top, "medium");
+        assert_eq!(
+            root.composer
+                .component()
+                .chrome_target(Position::new(model_x, top)),
+            Some(ComposerChromeTarget::Model)
+        );
         assert_eq!(
             root.composer
                 .component()
@@ -3159,6 +3167,10 @@ mod tests {
             Some(ComposerChromeTarget::Effort)
         );
 
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), model_x, top));
+        assert!(matches!(root.overlay, Some(Overlay::Model(_))));
+
+        root.overlay = None;
         root.update(mouse(
             MouseEventKind::Down(MouseButton::Left),
             effort_x,
@@ -5154,10 +5166,10 @@ mod tests {
     }
 
     #[test]
-    fn control_m_selects_a_model_only_before_the_first_prompt() {
+    fn control_d_selects_a_model_only_before_the_first_prompt() {
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
 
-        let opened = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        let opened = root.update(key(KeyCode::Char('d'), KeyModifiers::CONTROL));
         assert!(matches!(&root.overlay, Some(Overlay::Model(_))));
         assert_eq!(opened.render, super::RenderRequest::Immediate);
 
@@ -5167,7 +5179,7 @@ mod tests {
 
         root.interactive = true;
         root.thread = super::ThreadState::Started;
-        let blocked = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        let blocked = root.update(key(KeyCode::Char('d'), KeyModifiers::CONTROL));
         assert!(blocked.effects.is_empty());
         assert!(root.overlay.is_none());
     }
@@ -5180,7 +5192,7 @@ mod tests {
         let mut fork = root.fork(Path::new("/work"), ReasoningEffort::Medium);
 
         assert_eq!(fork.composer().model(), Model::Luna);
-        let update = fork.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        let update = fork.update(key(KeyCode::Char('d'), KeyModifiers::CONTROL));
         assert!(update.effects.is_empty());
         assert!(fork.overlay.is_none());
     }


### PR DESCRIPTION
## Summary

- open the pre-session model selector with Ctrl+D
- make the model label in composer chrome clickable
- route both interactions through the same new-session availability guard

## Stack

- Depends on: #102
- Next: #104

## Testing

- model shortcut and composer-click interaction tests
- cargo nextest run --no-fail-fast (763 passed)
- just check-fmt
- just clippy
