### PR TITLE
feat(subagents): choose Luna for fast tasks

### DIFF
--- a/src/core/extensions/subagents/model.rs
+++ b/src/core/extensions/subagents/model.rs
@@ -1,4 +1,4 @@
-use nanocodex::agent::events::AgentEvent;
+use nanocodex::{Model, agent::events::AgentEvent};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,
@@ -264,6 +264,7 @@ impl AgentStatus {
 pub(crate) struct AgentDescriptor {
     pub(crate) id: AgentId,
     pub(crate) session_id: String,
+    pub(crate) model: Model,
     pub(crate) role: String,
     pub(crate) task: String,
     pub(crate) parent: Option<AgentId>,

--- a/src/core/extensions/subagents/runtime.rs
+++ b/src/core/extensions/subagents/runtime.rs
@@ -13,12 +13,12 @@ use super::{
 };
 use futures_util::future::join_all;
 use jsonschema::Validator;
-use nanocodex::{AgentEvents, Nanocodex, NanocodexError};
+use nanocodex::{AgentEvents, Model, Nanocodex, NanocodexError, Thinking};
 use serde::Serialize;
 use serde_json::Value;
 use std::{
     collections::HashMap,
-    sync::{Arc, Weak},
+    sync::{Arc, Mutex, OnceLock, Weak},
     time::Duration,
 };
 use tokio::{
@@ -74,6 +74,23 @@ pub(crate) struct Registry {
     revision: watch::Sender<u64>,
     capacity: Capacity,
     message_lock: tokio::sync::Mutex<()>,
+    agent_factory: OnceLock<AgentFactory>,
+}
+
+/// Owns the clean-agent recipe and the settings inherited by the next spawn.
+/// Per-agent tool factories hold only a weak registry reference, keeping this ownership acyclic.
+struct AgentFactory {
+    build: Box<AgentBuilder>,
+    settings: Mutex<AgentSettings>,
+}
+
+type AgentBuilder =
+    dyn Fn(Model, Thinking, bool) -> Result<(Nanocodex, AgentEvents), NanocodexError> + Send + Sync;
+
+#[derive(Clone, Copy)]
+struct AgentSettings {
+    thinking: Thinking,
+    fast_mode: bool,
 }
 
 /// Identifies whether a tool call belongs to a coordinating root agent.
@@ -120,6 +137,7 @@ pub(super) struct ClosedSessions {
 #[derive(Clone, Serialize)]
 pub(super) struct AgentSummary {
     pub(super) agent_id: AgentId,
+    pub(super) model: Model,
     pub(super) role: String,
     pub(super) task: String,
     pub(super) parent_agent_id: Option<AgentId>,
@@ -131,6 +149,7 @@ pub(super) struct AgentSummary {
 #[derive(Serialize)]
 pub(super) struct AgentDirectoryEntry {
     pub(super) agent_id: AgentId,
+    pub(super) model: Model,
     pub(super) role: String,
     pub(super) task: String,
     pub(super) parent_agent_id: Option<AgentId>,
@@ -380,6 +399,7 @@ impl RegistryState {
                 let can_manage = can_message && scope.topology.authorize(session_id, id).is_ok();
                 Some(AgentDirectoryEntry {
                     agent_id: id,
+                    model: session.descriptor.model,
                     role: bounded_summary(&session.descriptor.role),
                     task: bounded_summary(&session.descriptor.task),
                     parent_agent_id: session.descriptor.parent,
@@ -741,6 +761,66 @@ impl Registry {
             revision,
             capacity: Capacity::new(max_concurrency),
             message_lock: tokio::sync::Mutex::new(()),
+            agent_factory: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn set_agent_factory<F>(
+        &self,
+        thinking: Thinking,
+        fast_mode: bool,
+        factory: F,
+    ) -> Result<(), NanocodexError>
+    where
+        F: Fn(Model, Thinking, bool) -> Result<(Nanocodex, AgentEvents), NanocodexError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.agent_factory
+            .set(AgentFactory {
+                build: Box::new(factory),
+                settings: Mutex::new(AgentSettings {
+                    thinking,
+                    fast_mode,
+                }),
+            })
+            .map_err(|_| {
+                NanocodexError::InvalidRequest("subagent factory is already configured".to_owned())
+            })
+    }
+
+    pub(super) fn spawn_agent(
+        &self,
+        model: Model,
+    ) -> Result<(Nanocodex, AgentEvents), NanocodexError> {
+        let factory = self.agent_factory.get().ok_or_else(|| {
+            NanocodexError::InvalidRequest("subagent factory is not configured".to_owned())
+        })?;
+        let settings = *factory
+            .settings
+            .lock()
+            .expect("subagent settings lock should not be poisoned");
+        (factory.build)(model, settings.thinking, settings.fast_mode)
+    }
+
+    fn set_agent_thinking(&self, thinking: Thinking) {
+        if let Some(factory) = self.agent_factory.get() {
+            factory
+                .settings
+                .lock()
+                .expect("subagent settings lock should not be poisoned")
+                .thinking = thinking;
+        }
+    }
+
+    fn set_agent_fast_mode(&self, fast_mode: bool) {
+        if let Some(factory) = self.agent_factory.get() {
+            factory
+                .settings
+                .lock()
+                .expect("subagent settings lock should not be poisoned")
+                .fast_mode = fast_mode;
         }
     }
 
@@ -1439,10 +1519,13 @@ impl Registry {
 }
 
 impl RootAgentGuard {
+    #[cfg(test)]
     pub(crate) fn new(registry: &Arc<Registry>) -> Self {
-        Self {
-            registry: Arc::downgrade(registry),
-        }
+        Self::from_weak(Arc::downgrade(registry))
+    }
+
+    pub(crate) fn from_weak(registry: Weak<Registry>) -> Self {
+        Self { registry }
     }
 
     pub(crate) async fn require_root(&self, session_id: &str) -> std::io::Result<()> {
@@ -1496,6 +1579,7 @@ impl ChildSession {
         };
         AgentSummary {
             agent_id: self.descriptor.id,
+            model: self.descriptor.model,
             role: self.descriptor.role.clone(),
             task: self.descriptor.task.clone(),
             parent_agent_id: self.descriptor.parent,
@@ -1513,6 +1597,14 @@ pub(crate) struct SubagentControl {
 impl SubagentControl {
     pub(crate) fn set_max_concurrency(&self, limit: usize) {
         self.registry.set_max_concurrency(limit);
+    }
+
+    pub(crate) fn set_thinking(&self, thinking: Thinking) {
+        self.registry.set_agent_thinking(thinking);
+    }
+
+    pub(crate) fn set_fast_mode(&self, enabled: bool) {
+        self.registry.set_agent_fast_mode(enabled);
     }
 
     pub(crate) async fn cancel_all(&self, root_session_id: &str) {
@@ -1589,7 +1681,7 @@ mod tests {
         AgentUpdate, MessageDeliveryState, MessageDisposition, MessagePriority, MessagePurpose,
     };
     use nanocodex::{
-        Nanocodex, OpenAi,
+        Model, Nanocodex, NanocodexError, OpenAi, Thinking,
         oai::{
             ResponseError,
             tower::{ResponsesAttempt, ResponsesServiceResponse},
@@ -1599,7 +1691,7 @@ mod tests {
     use std::{
         future::{Pending, pending},
         result::Result as StdResult,
-        sync::Arc,
+        sync::{Arc, Mutex},
         task::{Context, Poll},
         time::Duration,
     };
@@ -1608,6 +1700,34 @@ mod tests {
         time::timeout,
     };
     use tower::Service;
+
+    #[test]
+    fn agent_factory_receives_the_declared_model() {
+        let (updates, _receiver) = mpsc::unbounded_channel();
+        let registry = Registry::new(updates, 1);
+        let seen = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&seen);
+        registry
+            .set_agent_factory(
+                Thinking::Medium,
+                false,
+                move |model, thinking, fast_mode| {
+                    *captured.lock().unwrap() = Some((model, thinking, fast_mode));
+                    Err(NanocodexError::InvalidRequest(
+                        "stop after capture".to_owned(),
+                    ))
+                },
+            )
+            .unwrap();
+        registry.set_agent_thinking(Thinking::Low);
+        registry.set_agent_fast_mode(true);
+
+        assert!(registry.spawn_agent(Model::Luna).is_err());
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some((Model::Luna, Thinking::Low, true))
+        );
+    }
 
     #[derive(Clone)]
     struct PendingService {
@@ -1695,6 +1815,7 @@ mod tests {
         let descriptor = AgentDescriptor {
             id: reservation.id,
             session_id: session_id.clone(),
+            model: Model::Sol,
             role: format!("agent-{}", reservation.id),
             task: "wait forever".to_owned(),
             parent,
@@ -1774,6 +1895,7 @@ mod tests {
         let descriptor = AgentDescriptor {
             id,
             session_id: session_id.to_owned(),
+            model: Model::Sol,
             role: format!("agent-{id}"),
             task: "test lifecycle".to_owned(),
             parent,

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -13,8 +13,7 @@ use crate::core::extensions::{
     sessions::SessionTool,
 };
 use nanocodex::{
-    Tool, Tools,
-    agent::AgentHandle,
+    Model, Tool, Tools,
     tools::{
         ToolsBuildError,
         contract::{ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, async_trait},
@@ -42,12 +41,30 @@ const WAIT_AGENT_TOOL: &str = "wait_agent";
 struct AgentTask {
     role: String,
     task: String,
+    model: SubagentModel,
     output_schema: Value,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SubagentModel {
+    Selected,
+    Luna,
+}
+
+impl SubagentModel {
+    const fn resolve(self, selected: Model) -> Model {
+        match self {
+            Self::Selected => selected,
+            Self::Luna => Model::Luna,
+        }
+    }
 }
 
 #[derive(Serialize)]
 struct AgentStartReport {
     agent_id: AgentId,
+    model: Model,
     role: String,
     status: AgentStatus,
 }
@@ -109,8 +126,8 @@ fn json_output(value: &impl Serialize) -> ToolResult {
 }
 
 struct SpawnAgent {
-    parent: AgentHandle,
     registry: Weak<Registry>,
+    selected_model: Model,
 }
 
 #[async_trait]
@@ -130,11 +147,16 @@ impl Tool for SpawnAgent {
                         "type": "string",
                         "description": "A complete, focused task for the subagent."
                     },
+                    "model": {
+                        "type": "string",
+                        "enum": ["selected", "luna"],
+                        "description": "Use `selected` for the session's selected model or `luna` when low latency matters more than reasoning capability."
+                    },
                     "output_schema": {
                         "description": "The JSON Schema that every successful result from this agent must satisfy. Use an object with one string field for a free-form report."
                     }
                 },
-                "required": ["role", "task", "output_schema"],
+                "required": ["role", "task", "model", "output_schema"],
                 "additionalProperties": false
             }),
         )
@@ -145,8 +167,10 @@ impl Tool for SpawnAgent {
         let AgentTask {
             role,
             task,
+            model,
             output_schema,
         } = input.decode_json()?;
+        let model = model.resolve(self.selected_model);
         let contract = OutputContract::compile(&output_schema)?;
         let registry = self
             .registry
@@ -155,11 +179,12 @@ impl Tool for SpawnAgent {
         let capacity = registry.reserve_turn()?;
         let reservation = registry.reserve(context.session_id()).await?;
         let id = reservation.id;
-        let (child, events) = self.parent.spawn().await?;
+        let (child, events) = registry.spawn_agent(model)?;
         let session_id = child.session_id().to_string();
         let descriptor = AgentDescriptor {
             id,
             session_id,
+            model,
             role: role.clone(),
             task: task.clone(),
             parent: reservation.parent,
@@ -195,6 +220,7 @@ impl Tool for SpawnAgent {
             .await?;
         json_output(&AgentStartReport {
             agent_id: id,
+            model,
             role,
             status: AgentStatus::Running,
         })
@@ -497,8 +523,8 @@ impl Tool for ChangeAgentLifecycle {
 
 pub(crate) fn install_tools(
     tools: Tools,
-    parent: AgentHandle,
-    registry: Arc<Registry>,
+    registry: Weak<Registry>,
+    selected_model: Model,
     memory: Option<MemoryStore>,
     subagents_enabled: bool,
     session_config_path: PathBuf,
@@ -509,32 +535,32 @@ pub(crate) fn install_tools(
     if subagents_enabled {
         tools = tools
             .tool(SpawnAgent {
-                parent,
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
+                selected_model,
             })
             .tool(SubmitResult {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(SendAgentMessage {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(ListAgents {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(WaitAgent {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(ChangeAgentLifecycle {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
                 operation: LifecycleOperation::Interrupt,
             })
             .tool(ChangeAgentLifecycle {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
                 operation: LifecycleOperation::Close,
             });
     }
     if let Some(store) = memory {
-        tools = tools.tool(MemoryTool::new(store, RootAgentGuard::new(&registry)));
+        tools = tools.tool(MemoryTool::new(store, RootAgentGuard::from_weak(registry)));
     }
     tools.build()
 }
@@ -544,6 +570,7 @@ fn spawn_agent_output_schema() -> Value {
         "type": "object",
         "properties": {
             "agent_id": { "type": "integer" },
+            "model": { "type": "string" },
             "role": { "type": "string" },
             "status": {
                 "type": "object",
@@ -552,7 +579,7 @@ fn spawn_agent_output_schema() -> Value {
                 "additionalProperties": false
             }
         },
-        "required": ["agent_id", "role", "status"],
+        "required": ["agent_id", "model", "role", "status"],
         "additionalProperties": false
     })
 }
@@ -567,13 +594,14 @@ fn wait_agent_output_schema() -> Value {
                     "type": "object",
                     "properties": {
                         "agent_id": { "type": "integer" },
+                        "model": { "type": "string" },
                         "role": { "type": "string" },
                         "task": { "type": "string" },
                         "parent_agent_id": { "type": ["integer", "null"] },
                         "status": agent_status_schema(),
                         "last_output": {}
                     },
-                    "required": ["agent_id", "role", "task", "parent_agent_id", "status"],
+                    "required": ["agent_id", "model", "role", "task", "parent_agent_id", "status"],
                     "additionalProperties": false
                 }
             },
@@ -617,11 +645,41 @@ fn agent_status_schema() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{SendAgentMessage, SubmitResult, WaitAgent};
+    use super::{SendAgentMessage, SpawnAgent, SubagentModel, SubmitResult, WaitAgent};
     use crate::core::extensions::subagents::runtime::Registry;
-    use nanocodex::Tool;
+    use nanocodex::{Model, Tool};
     use serde_json::json;
     use std::sync::Weak;
+
+    #[test]
+    fn spawn_agent_requires_an_explicit_bounded_model_choice() {
+        let definition = SpawnAgent {
+            registry: Weak::<Registry>::new(),
+            selected_model: Model::Terra,
+        }
+        .definition();
+        let parameters = definition.parameters().unwrap().as_value();
+        let output = definition.output_schema().unwrap();
+
+        assert_eq!(
+            parameters["properties"]["model"]["enum"],
+            json!(["selected", "luna"])
+        );
+        assert!(
+            parameters["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("model"))
+        );
+        assert_eq!(SubagentModel::Selected.resolve(Model::Terra), Model::Terra);
+        assert_eq!(SubagentModel::Luna.resolve(Model::Terra), Model::Luna);
+        assert!(
+            output.as_value()["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("model"))
+        );
+    }
 
     #[test]
     fn send_message_definition_names_deferred_delivery_and_queued_waiting() {
@@ -658,8 +716,17 @@ mod tests {
         .definition();
         let description =
             &definition.parameters().unwrap().as_value()["properties"]["agent_ids"]["description"];
+        let output = definition.output_schema().unwrap();
+        let agent = &output.as_value()["properties"]["agents"]["items"];
 
         assert!(description.as_str().unwrap().contains("spawn_agent"));
         assert!(!description.as_str().unwrap().contains("fork_agent"));
+        assert_eq!(agent["properties"]["model"], json!({ "type": "string" }));
+        assert!(
+            agent["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("model"))
+        );
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -40,10 +40,15 @@ const SUBAGENT_INSTRUCTIONS: &str = concat!(
     "across agents in parallel, await and reduce their results, then dispatch dependent stages. Do ",
     "not repeat delegated work yourself; wait for delegated work to finish, then use its results for ",
     "the next step. Double-check their results against the relevant evidence before relying on them. ",
+    "For each `spawn_agent` call, declare `model`: use `luna` for straightforward tasks that need ",
+    "little reasoning when speed matters more, and use `selected` otherwise. ",
     "Use schemas that expose the fields downstream stages need, and use loops to iterate until the ",
     "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
     "verification."
 );
+const SUBAGENT_INSTRUCTIONS_START: &str =
+    "For larger tasks, delegate meaningful, separable work to subagents;";
+const SUBAGENT_INSTRUCTIONS_END: &str = "verification.";
 
 const TOOL_ORCHESTRATION_INSTRUCTIONS: &str = concat!(
     "Use code mode to orchestrate related tool calls when the next calls can be determined from ",
@@ -177,6 +182,7 @@ impl ConfiguredAgent {
         config: &Config,
         thinking: ReasoningEffort,
         reasoning_mode: ReasoningMode,
+        model: Model,
         session_id: Option<&str>,
         resume: Option<ResumeState>,
     ) -> Result<Self> {
@@ -184,7 +190,7 @@ impl ConfiguredAgent {
             config,
             thinking,
             reasoning_mode,
-            Model::Sol,
+            model,
             session_id,
             resume,
         )
@@ -225,17 +231,18 @@ impl ConfiguredAgent {
         let session_config_path = config.path().to_path_buf();
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
+        let subagent_registry = Arc::downgrade(&subagents);
         let mut builder = Nanocodex::builder(openai)
             .model(model)
             .workspace(workspace)
             .thinking(thinking.into())
             .reasoning_mode(reasoning_mode.into())
             .fast_mode(agent_config.fast_mode())
-            .tools_factory(move |agent| {
+            .tools_factory(move |_agent| {
                 subagents::install_tools(
                     tools.clone(),
-                    agent,
-                    Arc::clone(&subagents),
+                    subagent_registry.clone(),
+                    model,
                     memory.clone(),
                     subagents_enabled,
                     session_config_path.clone(),
@@ -262,6 +269,19 @@ impl ConfiguredAgent {
             memory_enabled,
         );
         builder = builder.instructions(Arc::clone(&instructions));
+        let subagent_builder = builder.clone();
+        subagents.set_agent_factory(
+            thinking.into(),
+            agent_config.fast_mode(),
+            move |model, thinking, fast_mode| {
+                subagent_builder
+                    .clone()
+                    .model(model)
+                    .thinking(thinking)
+                    .fast_mode(fast_mode)
+                    .build()
+            },
+        )?;
         if let Some(session_id) = session_id {
             let session_id = session_id
                 .parse::<SessionId>()
@@ -551,18 +571,20 @@ fn reconcile_session_reference_instructions(mut instructions: String) -> String 
 }
 
 fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> String {
-    let separator_and_instructions = format!("\n\n{SUBAGENT_INSTRUCTIONS}");
-    if enabled {
-        if instructions.contains(&separator_and_instructions) {
-            return instructions;
-        }
-        instructions.push_str(&separator_and_instructions);
-        return instructions;
-    }
-
-    while let Some(start) = instructions.find(&separator_and_instructions) {
-        let end = start.saturating_add(separator_and_instructions.len());
+    let start_marker = format!("\n\n{SUBAGENT_INSTRUCTIONS_START}");
+    while let Some(start) = instructions.find(&start_marker) {
+        let body_start = start.saturating_add(2);
+        let Some(relative_end) = instructions[body_start..].find(SUBAGENT_INSTRUCTIONS_END) else {
+            break;
+        };
+        let end = body_start
+            .saturating_add(relative_end)
+            .saturating_add(SUBAGENT_INSTRUCTIONS_END.len());
         instructions.replace_range(start..end, "");
+    }
+    if enabled {
+        instructions.push_str("\n\n");
+        instructions.push_str(SUBAGENT_INSTRUCTIONS);
     }
     instructions
 }
@@ -1029,6 +1051,8 @@ mod tests {
         assert!(SUBAGENT_INSTRUCTIONS.contains("wait for delegated work to finish"));
         assert!(SUBAGENT_INSTRUCTIONS.contains("Do not repeat delegated work yourself"));
         assert!(SUBAGENT_INSTRUCTIONS.contains("Double-check their results"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("use `luna` for straightforward tasks"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("use `selected` otherwise"));
     }
 
     #[test]
@@ -1073,6 +1097,22 @@ mod tests {
         );
         assert!(restored_enabled.text.contains(SUBAGENT_INSTRUCTIONS));
         assert!(restored_enabled.text.ends_with(MEMORY_INSTRUCTIONS));
+
+        let legacy = SUBAGENT_INSTRUCTIONS.replace(
+            "For each `spawn_agent` call, declare `model`: use `luna` for straightforward tasks \
+             that need little reasoning when speed matters more, and use `selected` otherwise. ",
+            "",
+        );
+        let restored_legacy = session_instructions(
+            None,
+            None,
+            &skills,
+            Some((format!("Stored.\n\n{legacy}"), Some(false))),
+            true,
+            false,
+        );
+        assert!(restored_legacy.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(!restored_legacy.text.contains(&legacy));
     }
 
     #[test]

--- a/src/core/orchestration.rs
+++ b/src/core/orchestration.rs
@@ -6,8 +6,11 @@ use crate::{
         AgentDescriptor, AgentId, AgentMessageUpdate, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     },
 };
-use nanocodex::agent::events::{
-    AgentEvent, AgentEventData, AgentEventKind, EventUsage, RunEvent, RunTerminal,
+use nanocodex::{
+    Model,
+    agent::events::{
+        AgentEvent, AgentEventData, AgentEventKind, EventUsage, RunEvent, RunTerminal,
+    },
 };
 use serde::Serialize;
 use std::{
@@ -93,6 +96,7 @@ enum UpdateRecord<'a> {
 struct AgentRecord<'a> {
     id: AgentId,
     session_id: &'a str,
+    model: Model,
     role: &'a str,
     task: &'a str,
     origin: AgentOrigin,
@@ -116,6 +120,7 @@ enum SummaryRecord {
 #[derive(Serialize)]
 struct AgentSummary {
     id: AgentId,
+    model: Model,
     role: String,
     parent_id: Option<AgentId>,
     origin: AgentOrigin,
@@ -283,6 +288,7 @@ impl Recorder {
             .values()
             .map(|agent| AgentSummary {
                 id: agent.descriptor.id,
+                model: agent.descriptor.model,
                 role: agent.descriptor.role.clone(),
                 parent_id: agent.descriptor.parent,
                 origin: AgentOrigin::Spawn,
@@ -384,6 +390,7 @@ impl<'a> From<&'a AgentDescriptor> for AgentRecord<'a> {
         Self {
             id: descriptor.id,
             session_id: &descriptor.session_id,
+            model: descriptor.model,
             role: &descriptor.role,
             task: &descriptor.task,
             origin: AgentOrigin::Spawn,
@@ -398,7 +405,10 @@ mod tests {
     use crate::core::extensions::subagents::{
         AgentDescriptor, AgentId, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     };
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use serde_json::{Value, json, value::to_raw_value};
     use std::{fs, sync::Arc};
     use tempfile::tempdir;
@@ -422,6 +432,7 @@ mod tests {
             "websocket_reconnects": 0,
             "response_attempts": model_calls,
             "response_retries": 0,
+            "billing_uncertain_response_attempts": 0,
             "connection_duration_ns": 100,
             "retry_backoff_duration_ns": 0,
             "model_duration_ns": 900_000,
@@ -463,6 +474,7 @@ mod tests {
                 update: AgentUpdate::Added(AgentDescriptor {
                     id,
                     session_id: "child".to_owned(),
+                    model: Model::Sol,
                     role: "researcher".to_owned(),
                     task: "inspect the task".to_owned(),
                     parent: None,

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -3183,6 +3183,7 @@ mod tests {
             AgentDescriptor {
                 id: AgentId::new(1),
                 session_id: "child".to_owned(),
+                model: Model::Sol,
                 role: "worker".to_owned(),
                 task: "work".to_owned(),
                 parent: None,
@@ -3210,6 +3211,7 @@ mod tests {
         root.update(RootEvent::Subagent(AgentUpdate::Added(AgentDescriptor {
             id: AgentId::new(1),
             session_id: "child".to_owned(),
+            model: Model::Sol,
             role: "worker".to_owned(),
             task: "verify ordering".to_owned(),
             parent: None,
@@ -3296,6 +3298,7 @@ mod tests {
             root.update(RootEvent::Subagent(AgentUpdate::Added(AgentDescriptor {
                 id: AgentId::new(id),
                 session_id: format!("child-{id}"),
+                model: Model::Sol,
                 role: role.to_owned(),
                 task: "coordinate with a peer".to_owned(),
                 parent: None,
@@ -3338,6 +3341,7 @@ mod tests {
             AgentDescriptor {
                 id: AgentId::new(1),
                 session_id: "child".to_owned(),
+                model: Model::Sol,
                 role: "worker".to_owned(),
                 task: "work".to_owned(),
                 parent: None,

--- a/src/tui/components/subagents.rs
+++ b/src/tui/components/subagents.rs
@@ -16,6 +16,7 @@ use crate::{
     tui::{theme::Theme, transcript::TranscriptRecord},
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind};
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::Rect,
@@ -423,14 +424,19 @@ impl SubagentTree {
         let Some(node) = self.node_mut(id) else {
             return;
         };
-        let title = format!("{} · #{}", node.descriptor.role, node.descriptor.id);
+        let title = format!(
+            "{} · {} · #{}",
+            node.descriptor.role,
+            model_name(node.descriptor.model),
+            node.descriptor.id
+        );
         let keys: &[&str] = if node.transcript.component().expandables_focused() {
             &FOCUSED_ENTRY_KEYS
         } else {
             &TRANSCRIPT_KEYS
         };
         let layout = Floating::new(&title, area.width, area.height, keys)
-            .colors(theme.border(), theme.accent())
+            .colors(theme.border(), theme.model(node.descriptor.model))
             .render(frame, area, theme);
         node.transcript.render(frame, layout.body, theme);
     }
@@ -673,6 +679,13 @@ impl SubagentTree {
                     self.nodes.len(),
                     self.filter.label()
                 )),
+                Span::styled("    Model  ", Style::default().fg(theme.muted())),
+                Span::styled(
+                    model_name(node.descriptor.model),
+                    Style::default()
+                        .fg(theme.model(node.descriptor.model))
+                        .add_modifier(Modifier::BOLD),
+                ),
             ]),
             Line::from(vec![
                 Span::styled("Session  ", Style::default().fg(theme.muted())),
@@ -1045,6 +1058,15 @@ fn unix_time_ms() -> u64 {
         })
 }
 
+fn model_name(model: Model) -> &'static str {
+    match model {
+        Model::Luna => "Luna",
+        Model::Terra => "Terra",
+        Model::Sol => "Sol",
+        _ => "Sol",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{SubagentEffect, SubagentTree};
@@ -1058,7 +1080,10 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use ratatui::{Terminal, backend::TestBackend, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{
@@ -1070,6 +1095,7 @@ mod tests {
         AgentDescriptor {
             id: AgentId::new(1),
             session_id: "child-session".to_owned(),
+            model: Model::Luna,
             role: "researcher".to_owned(),
             task: "Trace the event lifecycle".to_owned(),
             parent: None,
@@ -1205,6 +1231,7 @@ mod tests {
         AgentDescriptor {
             id: AgentId::new(2),
             session_id: "second-session".to_owned(),
+            model: Model::Sol,
             role: "reviewer".to_owned(),
             task: "Verify the event ordering".to_owned(),
             parent: None,
@@ -1215,6 +1242,7 @@ mod tests {
         AgentDescriptor {
             id: AgentId::new(id),
             session_id: format!("agent-{id}"),
+            model: Model::Sol,
             role: role.to_owned(),
             task: format!("Task for {role}"),
             parent: parent.map(AgentId::new),
@@ -1419,7 +1447,19 @@ mod tests {
         assert!(rendered.contains("researcher"));
         assert!(rendered.contains("running · 0 children"));
         assert!(rendered.contains("Trace the event lifecycle"));
+        assert!(rendered.contains("Model  Luna"));
         let buffer = terminal.backend().buffer();
+        let luna = buffer
+            .content
+            .windows(4)
+            .find(|cells| {
+                cells
+                    .iter()
+                    .map(|cell| cell.symbol())
+                    .eq(["L", "u", "n", "a"])
+            })
+            .unwrap();
+        assert_eq!(luna[0].fg, Color::White);
         assert_eq!(buffer[(0, 0)].symbol(), "╭");
         assert_eq!(buffer[(89, 39)].symbol(), "╯");
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -464,6 +464,7 @@ pub(crate) async fn run(
                     &restored_config,
                     initial_effort,
                     reasoning_mode,
+                    model,
                     Some(&session_id),
                     Some(snapshot),
                 )?;
@@ -1017,6 +1018,7 @@ pub(crate) async fn run(
                             schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                         }
                         runtime.current_effort = effort;
+                        runtime.subagent_control.set_thinking(effort.into());
                         if pane == PaneId::Main {
                             config.set_thinking(effort);
                         }
@@ -1038,6 +1040,7 @@ pub(crate) async fn run(
                             schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                         }
                         runtime.current_fast_mode = enabled;
+                        runtime.subagent_control.set_fast_mode(enabled);
                         if pane == PaneId::Main {
                             config.set_fast_mode(enabled);
                         }
@@ -2087,6 +2090,7 @@ fn apply_pane_effect(
                     &config,
                     effort,
                     reasoning_mode,
+                    Model::Sol,
                     None,
                     None,
                 );
@@ -2240,6 +2244,7 @@ fn apply_pane_effect(
                         &config,
                         effort,
                         reasoning_mode,
+                        model,
                         Some(&session_id),
                         Some(snapshot),
                     )?;
@@ -2434,7 +2439,14 @@ async fn prepare_handoff(
     let reasoning_mode = config.agent().reasoning_mode();
     let fast_mode = config.agent().fast_mode();
     let task = tokio::task::spawn_blocking(move || {
-        ConfiguredAgent::from_config_with_session(&config, effort, reasoning_mode, None, None)
+        ConfiguredAgent::from_config_with_session(
+            &config,
+            effort,
+            reasoning_mode,
+            Model::Sol,
+            None,
+            None,
+        )
     });
     let configured = tokio::select! {
         result = task => result


### PR DESCRIPTION
## Summary

- let subagent calls choose either the session-selected model or Luna
- describe Luna as the low-latency option for tasks requiring less reasoning
- retain the chosen model in subagent descriptors and display it in the subagent TUI using semantic colors

## Stack

- Depends on: #103
- Next: #105

## Testing

- cargo nextest run --no-fail-fast (763 passed)
- just check-fmt
- just clippy
