### PR TITLE
feat(subagents): configure Luna delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ enabled = false
 
 [subagents]
 enabled = true
+allow_luna = true
 
 [theme]
 mode = "auto" # auto, light, or dark
@@ -247,6 +248,14 @@ This setting applies when a session starts or is restored. Reloading the configu
 change the tool surface of an already-running session. `agent.max_subagents` controls concurrency
 when the feature is enabled; setting it does not enable or disable subagents. See the
 [subagent design](docs/subagents.md) for the tool, lifecycle, messaging, and authority contracts.
+
+By default, agents may choose Luna for straightforward delegated work where latency matters more
+than reasoning capability. Require every subagent to use the session's selected model with:
+
+```toml
+[subagents]
+allow_luna = false
+```
 
 ### Memory
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -21,6 +21,18 @@ The setting applies when an agent runtime is created. Reloading configuration do
 tool surface or instructions of an existing runtime. A later new or restored session uses the
 reloaded setting.
 
+Subagents may use Luna instead of the session's selected model by default. This lets the parent
+favor latency for straightforward delegated work. Disable that choice independently of the tool
+surface:
+
+```toml
+[subagents]
+allow_luna = false
+```
+
+When disabled, `spawn_agent` accepts only `selected` and the built-in delegation instructions no
+longer recommend Luna. If the session itself selected Luna, `selected` still resolves to Luna.
+
 `agent.max_subagents` is independent of the enable switch:
 
 ```toml
@@ -39,7 +51,7 @@ An enabled runtime installs seven tools:
 
 | Tool | Contract |
 | --- | --- |
-| `spawn_agent` | Create a clean child session with a role, focused task, and required output schema. |
+| `spawn_agent` | Create a clean child session with a role, focused task, model choice, and required output schema. |
 | `submit_result` | Submit the current subagent turn's final JSON value. The value must satisfy its output schema and use the current turn token. |
 | `send_agent_message` | Send a bounded directed message within the current task tree. |
 | `list_agents` | List visible agents, their status, topology, and the caller's messaging and management authority. |
@@ -199,6 +211,7 @@ checked in code.
 The implementation preserves these invariants:
 
 - disabling subagents removes both their tools and their fixed delegation instructions;
+- disabling `subagents.allow_luna` removes the explicit Luna choice from the tool and instructions;
 - memory remains independent from the subagent enable switch;
 - every child starts with clean conversation context and a caller-supplied output contract;
 - task-tree scope prevents cross-root access;

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -176,6 +176,7 @@ pub(crate) struct MemoryConfig {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct SubagentsConfig {
     enabled: bool,
+    allow_luna: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -237,6 +238,7 @@ struct MemoryConfigFile {
 #[serde(default, deny_unknown_fields)]
 struct SubagentsConfigFile {
     enabled: Option<bool>,
+    allow_luna: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -406,6 +408,7 @@ impl Config {
             },
             subagents: SubagentsConfig {
                 enabled: file.subagents.enabled.unwrap_or(true),
+                allow_luna: file.subagents.allow_luna.unwrap_or(true),
             },
             theme: file.theme,
             reload,
@@ -979,6 +982,10 @@ impl SubagentsConfig {
     pub(crate) const fn enabled(&self) -> bool {
         self.enabled
     }
+
+    pub(crate) const fn allow_luna(&self) -> bool {
+        self.allow_luna
+    }
 }
 
 impl ReasoningEffort {
@@ -1227,7 +1234,7 @@ mod tests {
         assert_table_fields(&rendered["mcp_servers"], &[]);
         assert_table_fields(&rendered["skills"], &["enabled", "roots"]);
         assert_table_fields(&rendered["memory"], &["enabled"]);
-        assert_table_fields(&rendered["subagents"], &["enabled"]);
+        assert_table_fields(&rendered["subagents"], &["enabled", "allow_luna"]);
         assert_table_fields(&rendered["theme"], &["mode", "light", "dark"]);
         let palette_fields = [
             "text",
@@ -1329,8 +1336,10 @@ mod tests {
             let config = load_config(contents).unwrap();
 
             assert!(config.subagents().enabled());
+            assert!(config.subagents().allow_luna());
             let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
             assert_eq!(rendered["subagents"]["enabled"].as_bool(), Some(true));
+            assert_eq!(rendered["subagents"]["allow_luna"].as_bool(), Some(true));
         }
     }
 
@@ -1344,8 +1353,19 @@ mod tests {
     }
 
     #[test]
+    fn luna_subagents_can_be_disabled_from_the_config_file() {
+        let config = load_config("[subagents]\nallow_luna = false\n").unwrap();
+
+        assert!(config.subagents().enabled());
+        assert!(!config.subagents().allow_luna());
+        let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+        assert_eq!(rendered["subagents"]["allow_luna"].as_bool(), Some(false));
+    }
+
+    #[test]
     fn unknown_subagent_fields_are_rejected() {
-        let error = load_config("[subagents]\nenabled = true\nlimit = 4\n").unwrap_err();
+        let error =
+            load_config("[subagents]\nenabled = true\nallow_luna = true\nlimit = 4\n").unwrap_err();
 
         assert!(matches!(error, Error::Config(ConfigError::Parse { .. })));
     }

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -22,6 +22,7 @@ use nanocodex::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{
+    io,
     path::PathBuf,
     sync::{Arc, Weak},
     time::Duration,
@@ -53,10 +54,14 @@ enum SubagentModel {
 }
 
 impl SubagentModel {
-    const fn resolve(self, selected: Model) -> Model {
+    fn resolve(self, selected: Model, allow_luna: bool) -> Result<Model, io::Error> {
         match self {
-            Self::Selected => selected,
-            Self::Luna => Model::Luna,
+            Self::Selected => Ok(selected),
+            Self::Luna if allow_luna => Ok(Model::Luna),
+            Self::Luna => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Luna subagents are disabled by `subagents.allow_luna`",
+            )),
         }
     }
 }
@@ -128,11 +133,23 @@ fn json_output(value: &impl Serialize) -> ToolResult {
 struct SpawnAgent {
     registry: Weak<Registry>,
     selected_model: Model,
+    allow_luna: bool,
 }
 
 #[async_trait]
 impl Tool for SpawnAgent {
     fn definition(&self) -> ToolDefinition {
+        let (models, model_description) = if self.allow_luna {
+            (
+                json!(["selected", "luna"]),
+                "Use `selected` for the session's selected model or `luna` when low latency matters more than reasoning capability.",
+            )
+        } else {
+            (
+                json!(["selected"]),
+                "Use `selected` for the session's selected model.",
+            )
+        };
         ToolDefinition::function(
             SPAWN_AGENT_TOOL,
             "Starts a reusable clean-room subagent without inherited conversation history and immediately returns its ID.",
@@ -149,8 +166,8 @@ impl Tool for SpawnAgent {
                     },
                     "model": {
                         "type": "string",
-                        "enum": ["selected", "luna"],
-                        "description": "Use `selected` for the session's selected model or `luna` when low latency matters more than reasoning capability."
+                        "enum": models,
+                        "description": model_description
                     },
                     "output_schema": {
                         "description": "The JSON Schema that every successful result from this agent must satisfy. Use an object with one string field for a free-form report."
@@ -170,7 +187,7 @@ impl Tool for SpawnAgent {
             model,
             output_schema,
         } = input.decode_json()?;
-        let model = model.resolve(self.selected_model);
+        let model = model.resolve(self.selected_model, self.allow_luna)?;
         let contract = OutputContract::compile(&output_schema)?;
         let registry = self
             .registry
@@ -525,6 +542,7 @@ pub(crate) fn install_tools(
     tools: Tools,
     registry: Weak<Registry>,
     selected_model: Model,
+    allow_luna: bool,
     memory: Option<MemoryStore>,
     subagents_enabled: bool,
     session_config_path: PathBuf,
@@ -537,6 +555,7 @@ pub(crate) fn install_tools(
             .tool(SpawnAgent {
                 registry: registry.clone(),
                 selected_model,
+                allow_luna,
             })
             .tool(SubmitResult {
                 registry: registry.clone(),
@@ -656,6 +675,7 @@ mod tests {
         let definition = SpawnAgent {
             registry: Weak::<Registry>::new(),
             selected_model: Model::Terra,
+            allow_luna: true,
         }
         .definition();
         let parameters = definition.parameters().unwrap().as_value();
@@ -671,13 +691,42 @@ mod tests {
                 .unwrap()
                 .contains(&json!("model"))
         );
-        assert_eq!(SubagentModel::Selected.resolve(Model::Terra), Model::Terra);
-        assert_eq!(SubagentModel::Luna.resolve(Model::Terra), Model::Luna);
+        assert_eq!(
+            SubagentModel::Selected.resolve(Model::Terra, true).unwrap(),
+            Model::Terra
+        );
+        assert_eq!(
+            SubagentModel::Luna.resolve(Model::Terra, true).unwrap(),
+            Model::Luna
+        );
         assert!(
             output.as_value()["required"]
                 .as_array()
                 .unwrap()
                 .contains(&json!("model"))
+        );
+    }
+
+    #[test]
+    fn spawn_agent_excludes_and_rejects_luna_when_disabled() {
+        let definition = SpawnAgent {
+            registry: Weak::<Registry>::new(),
+            selected_model: Model::Terra,
+            allow_luna: false,
+        }
+        .definition();
+        let parameters = definition.parameters().unwrap().as_value();
+
+        assert_eq!(
+            parameters["properties"]["model"]["enum"],
+            json!(["selected"])
+        );
+        assert!(
+            SubagentModel::Luna
+                .resolve(Model::Terra, false)
+                .unwrap_err()
+                .to_string()
+                .contains("subagents.allow_luna")
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -46,6 +46,17 @@ const SUBAGENT_INSTRUCTIONS: &str = concat!(
     "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
     "verification."
 );
+const SUBAGENT_INSTRUCTIONS_SELECTED_ONLY: &str = concat!(
+    "For larger tasks, delegate meaningful, separable work to subagents; handle trivial or tightly ",
+    "coupled work directly. Use code mode to build multi-agent pipelines: map independent subtasks ",
+    "across agents in parallel, await and reduce their results, then dispatch dependent stages. Do ",
+    "not repeat delegated work yourself; wait for delegated work to finish, then use its results for ",
+    "the next step. Double-check their results against the relevant evidence before relying on them. ",
+    "For each `spawn_agent` call, declare `model` as `selected`. ",
+    "Use schemas that expose the fields downstream stages need, and use loops to iterate until the ",
+    "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
+    "verification."
+);
 const SUBAGENT_INSTRUCTIONS_START: &str =
     "For larger tasks, delegate meaningful, separable work to subagents;";
 const SUBAGENT_INSTRUCTIONS_END: &str = "verification.";
@@ -227,6 +238,7 @@ impl ConfiguredAgent {
         let tools = tools.build().map_err(NanocodexError::from)?;
         let memory_enabled = config.memory().enabled();
         let subagents_enabled = config.subagents().enabled();
+        let allow_luna_subagents = config.subagents().allow_luna();
         let memory = memory_enabled.then(|| MemoryStore::new(config.memory_path()));
         let session_config_path = config.path().to_path_buf();
         let (subagents, subagent_control, subagent_updates) =
@@ -243,6 +255,7 @@ impl ConfiguredAgent {
                     tools.clone(),
                     subagent_registry.clone(),
                     model,
+                    allow_luna_subagents,
                     memory.clone(),
                     subagents_enabled,
                     session_config_path.clone(),
@@ -260,12 +273,13 @@ impl ConfiguredAgent {
         let SessionInstructions {
             text: instructions,
             skills,
-        } = session_instructions(
+        } = session_instructions_with_luna(
             agent_config.instructions(),
             agent_config.append_instructions(),
             config.skills(),
             restored_instructions,
             subagents_enabled,
+            allow_luna_subagents,
             memory_enabled,
         );
         builder = builder.instructions(Arc::clone(&instructions));
@@ -420,12 +434,33 @@ impl ConfiguredAgent {
     }
 }
 
+#[cfg(test)]
 fn session_instructions(
     custom: Option<&str>,
     appended: Option<&str>,
     skills: &SkillsConfig,
     restored: Option<(String, Option<bool>)>,
     subagents_enabled: bool,
+    memory_enabled: bool,
+) -> SessionInstructions {
+    session_instructions_with_luna(
+        custom,
+        appended,
+        skills,
+        restored,
+        subagents_enabled,
+        true,
+        memory_enabled,
+    )
+}
+
+fn session_instructions_with_luna(
+    custom: Option<&str>,
+    appended: Option<&str>,
+    skills: &SkillsConfig,
+    restored: Option<(String, Option<bool>)>,
+    subagents_enabled: bool,
+    allow_luna: bool,
     memory_enabled: bool,
 ) -> SessionInstructions {
     restored.map_or_else(
@@ -436,8 +471,13 @@ fn session_instructions(
                 .map(SkillCatalog::available_in)
                 .unwrap_or_default()
                 .into();
-            let mut instructions =
-                fresh_instructions_with_catalog(custom, appended, &catalog, subagents_enabled);
+            let mut instructions = fresh_instructions_with_catalog(
+                custom,
+                appended,
+                &catalog,
+                subagents_enabled,
+                allow_luna,
+            );
             if memory_enabled {
                 instructions.push_str("\n\n");
                 instructions.push_str(MEMORY_INSTRUCTIONS);
@@ -452,7 +492,8 @@ fn session_instructions(
             let instructions = reconcile_tact_instructions(instructions);
             let instructions = reconcile_tool_orchestration_instructions(instructions);
             let instructions = reconcile_session_reference_instructions(instructions);
-            let instructions = reconcile_subagent_instructions(instructions, subagents_enabled);
+            let instructions =
+                reconcile_subagent_instructions(instructions, subagents_enabled, allow_luna);
             let instructions = reconcile_memory_instructions(instructions, memory_enabled);
             let skills = if catalog_present.unwrap_or(true) {
                 SkillCatalog::available_in(&instructions).into()
@@ -495,7 +536,7 @@ fn fresh_instructions(
     skills: &SkillsConfig,
 ) -> String {
     let catalog = SkillCatalog::load(skills);
-    fresh_instructions_with_catalog(custom, appended, &catalog, true)
+    fresh_instructions_with_catalog(custom, appended, &catalog, true, true)
 }
 
 fn fresh_instructions_with_catalog(
@@ -503,6 +544,7 @@ fn fresh_instructions_with_catalog(
     appended: Option<&str>,
     catalog: &SkillCatalog,
     subagents_enabled: bool,
+    allow_luna: bool,
 ) -> String {
     let mut instructions = custom
         .map(str::to_owned)
@@ -512,7 +554,7 @@ fn fresh_instructions_with_catalog(
     instructions = reconcile_session_reference_instructions(instructions);
     if subagents_enabled {
         instructions.push_str("\n\n");
-        instructions.push_str(SUBAGENT_INSTRUCTIONS);
+        instructions.push_str(subagent_instructions(allow_luna));
     }
     if let Some(appended) = appended {
         instructions.push_str("\n\n");
@@ -570,7 +612,19 @@ fn reconcile_session_reference_instructions(mut instructions: String) -> String 
     instructions
 }
 
-fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> String {
+fn subagent_instructions(allow_luna: bool) -> &'static str {
+    if allow_luna {
+        SUBAGENT_INSTRUCTIONS
+    } else {
+        SUBAGENT_INSTRUCTIONS_SELECTED_ONLY
+    }
+}
+
+fn reconcile_subagent_instructions(
+    mut instructions: String,
+    enabled: bool,
+    allow_luna: bool,
+) -> String {
     let start_marker = format!("\n\n{SUBAGENT_INSTRUCTIONS_START}");
     while let Some(start) = instructions.find(&start_marker) {
         let body_start = start.saturating_add(2);
@@ -584,7 +638,7 @@ fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> S
     }
     if enabled {
         instructions.push_str("\n\n");
-        instructions.push_str(SUBAGENT_INSTRUCTIONS);
+        instructions.push_str(subagent_instructions(allow_luna));
     }
     instructions
 }
@@ -603,9 +657,9 @@ impl Cancellation {
 mod tests {
     use super::{
         ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT,
-        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, TACT_INSTRUCTIONS,
-        TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions, reconcile_tact_instructions,
-        session_instructions,
+        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS_SELECTED_ONLY,
+        TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions,
+        reconcile_tact_instructions, session_instructions, session_instructions_with_luna,
     };
     use crate::{
         app::{
@@ -1113,6 +1167,40 @@ mod tests {
         );
         assert!(restored_legacy.text.contains(SUBAGENT_INSTRUCTIONS));
         assert!(!restored_legacy.text.contains(&legacy));
+    }
+
+    #[test]
+    fn luna_delegation_instructions_follow_the_config() {
+        let skills = SkillsConfig::from_roots(false, Vec::new());
+        let luna_enabled =
+            session_instructions_with_luna(None, None, &skills, None, true, true, false);
+        let luna_disabled =
+            session_instructions_with_luna(None, None, &skills, None, true, false, false);
+
+        assert!(luna_enabled.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(
+            !luna_enabled
+                .text
+                .contains(SUBAGENT_INSTRUCTIONS_SELECTED_ONLY)
+        );
+        assert!(
+            luna_disabled
+                .text
+                .contains(SUBAGENT_INSTRUCTIONS_SELECTED_ONLY)
+        );
+        assert!(!luna_disabled.text.contains("use `luna`"));
+
+        let restored = session_instructions_with_luna(
+            None,
+            None,
+            &skills,
+            Some((luna_enabled.text.to_string(), Some(false))),
+            true,
+            false,
+            false,
+        );
+        assert!(restored.text.contains(SUBAGENT_INSTRUCTIONS_SELECTED_ONLY));
+        assert!(!restored.text.contains("use `luna`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add configuration for allowing Luna subagent delegation
- expose only permitted model choices in the spawn-agent tool schema
- document the configuration and delegation behavior

## Stack

- Depends on: #104
- Next: #108

## Testing

- cargo nextest run --no-fail-fast (763 passed)
- just check-fmt
- just clippy



