### PR TITLE
feat(tui): animate model artwork on home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ enabled = false
 
 [subagents]
 enabled = true
+allow_luna = true
 
 [theme]
 mode = "auto" # auto, light, or dark
@@ -247,6 +248,14 @@ This setting applies when a session starts or is restored. Reloading the configu
 change the tool surface of an already-running session. `agent.max_subagents` controls concurrency
 when the feature is enabled; setting it does not enable or disable subagents. See the
 [subagent design](docs/subagents.md) for the tool, lifecycle, messaging, and authority contracts.
+
+By default, agents may choose Luna for straightforward delegated work where latency matters more
+than reasoning capability. Require every subagent to use the session's selected model with:
+
+```toml
+[subagents]
+allow_luna = false
+```
 
 ### Memory
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -21,6 +21,18 @@ The setting applies when an agent runtime is created. Reloading configuration do
 tool surface or instructions of an existing runtime. A later new or restored session uses the
 reloaded setting.
 
+Subagents may use Luna instead of the session's selected model by default. This lets the parent
+favor latency for straightforward delegated work. Disable that choice independently of the tool
+surface:
+
+```toml
+[subagents]
+allow_luna = false
+```
+
+When disabled, `spawn_agent` accepts only `selected` and the built-in delegation instructions no
+longer recommend Luna. If the session itself selected Luna, `selected` still resolves to Luna.
+
 `agent.max_subagents` is independent of the enable switch:
 
 ```toml
@@ -39,7 +51,7 @@ An enabled runtime installs seven tools:
 
 | Tool | Contract |
 | --- | --- |
-| `spawn_agent` | Create a clean child session with a role, focused task, and required output schema. |
+| `spawn_agent` | Create a clean child session with a role, focused task, model choice, and required output schema. |
 | `submit_result` | Submit the current subagent turn's final JSON value. The value must satisfy its output schema and use the current turn token. |
 | `send_agent_message` | Send a bounded directed message within the current task tree. |
 | `list_agents` | List visible agents, their status, topology, and the caller's messaging and management authority. |
@@ -199,6 +211,7 @@ checked in code.
 The implementation preserves these invariants:
 
 - disabling subagents removes both their tools and their fixed delegation instructions;
+- disabling `subagents.allow_luna` removes the explicit Luna choice from the tool and instructions;
 - memory remains independent from the subagent enable switch;
 - every child starts with clean conversation context and a caller-supplied output contract;
 - task-tree scope prevents cross-root access;

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -176,6 +176,7 @@ pub(crate) struct MemoryConfig {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct SubagentsConfig {
     enabled: bool,
+    allow_luna: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -237,6 +238,7 @@ struct MemoryConfigFile {
 #[serde(default, deny_unknown_fields)]
 struct SubagentsConfigFile {
     enabled: Option<bool>,
+    allow_luna: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -406,6 +408,7 @@ impl Config {
             },
             subagents: SubagentsConfig {
                 enabled: file.subagents.enabled.unwrap_or(true),
+                allow_luna: file.subagents.allow_luna.unwrap_or(true),
             },
             theme: file.theme,
             reload,
@@ -979,6 +982,10 @@ impl SubagentsConfig {
     pub(crate) const fn enabled(&self) -> bool {
         self.enabled
     }
+
+    pub(crate) const fn allow_luna(&self) -> bool {
+        self.allow_luna
+    }
 }
 
 impl ReasoningEffort {
@@ -1227,7 +1234,7 @@ mod tests {
         assert_table_fields(&rendered["mcp_servers"], &[]);
         assert_table_fields(&rendered["skills"], &["enabled", "roots"]);
         assert_table_fields(&rendered["memory"], &["enabled"]);
-        assert_table_fields(&rendered["subagents"], &["enabled"]);
+        assert_table_fields(&rendered["subagents"], &["enabled", "allow_luna"]);
         assert_table_fields(&rendered["theme"], &["mode", "light", "dark"]);
         let palette_fields = [
             "text",
@@ -1329,8 +1336,10 @@ mod tests {
             let config = load_config(contents).unwrap();
 
             assert!(config.subagents().enabled());
+            assert!(config.subagents().allow_luna());
             let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
             assert_eq!(rendered["subagents"]["enabled"].as_bool(), Some(true));
+            assert_eq!(rendered["subagents"]["allow_luna"].as_bool(), Some(true));
         }
     }
 
@@ -1344,8 +1353,19 @@ mod tests {
     }
 
     #[test]
+    fn luna_subagents_can_be_disabled_from_the_config_file() {
+        let config = load_config("[subagents]\nallow_luna = false\n").unwrap();
+
+        assert!(config.subagents().enabled());
+        assert!(!config.subagents().allow_luna());
+        let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+        assert_eq!(rendered["subagents"]["allow_luna"].as_bool(), Some(false));
+    }
+
+    #[test]
     fn unknown_subagent_fields_are_rejected() {
-        let error = load_config("[subagents]\nenabled = true\nlimit = 4\n").unwrap_err();
+        let error =
+            load_config("[subagents]\nenabled = true\nallow_luna = true\nlimit = 4\n").unwrap_err();
 
         assert!(matches!(error, Error::Config(ConfigError::Parse { .. })));
     }

--- a/src/core/extensions/subagents/model.rs
+++ b/src/core/extensions/subagents/model.rs
@@ -1,4 +1,4 @@
-use nanocodex::agent::events::AgentEvent;
+use nanocodex::{Model, agent::events::AgentEvent};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,
@@ -264,6 +264,7 @@ impl AgentStatus {
 pub(crate) struct AgentDescriptor {
     pub(crate) id: AgentId,
     pub(crate) session_id: String,
+    pub(crate) model: Model,
     pub(crate) role: String,
     pub(crate) task: String,
     pub(crate) parent: Option<AgentId>,

--- a/src/core/extensions/subagents/runtime.rs
+++ b/src/core/extensions/subagents/runtime.rs
@@ -13,12 +13,12 @@ use super::{
 };
 use futures_util::future::join_all;
 use jsonschema::Validator;
-use nanocodex::{AgentEvents, Nanocodex, NanocodexError};
+use nanocodex::{AgentEvents, Model, Nanocodex, NanocodexError, Thinking};
 use serde::Serialize;
 use serde_json::Value;
 use std::{
     collections::HashMap,
-    sync::{Arc, Weak},
+    sync::{Arc, Mutex, OnceLock, Weak},
     time::Duration,
 };
 use tokio::{
@@ -74,6 +74,23 @@ pub(crate) struct Registry {
     revision: watch::Sender<u64>,
     capacity: Capacity,
     message_lock: tokio::sync::Mutex<()>,
+    agent_factory: OnceLock<AgentFactory>,
+}
+
+/// Owns the clean-agent recipe and the settings inherited by the next spawn.
+/// Per-agent tool factories hold only a weak registry reference, keeping this ownership acyclic.
+struct AgentFactory {
+    build: Box<AgentBuilder>,
+    settings: Mutex<AgentSettings>,
+}
+
+type AgentBuilder =
+    dyn Fn(Model, Thinking, bool) -> Result<(Nanocodex, AgentEvents), NanocodexError> + Send + Sync;
+
+#[derive(Clone, Copy)]
+struct AgentSettings {
+    thinking: Thinking,
+    fast_mode: bool,
 }
 
 /// Identifies whether a tool call belongs to a coordinating root agent.
@@ -120,6 +137,7 @@ pub(super) struct ClosedSessions {
 #[derive(Clone, Serialize)]
 pub(super) struct AgentSummary {
     pub(super) agent_id: AgentId,
+    pub(super) model: Model,
     pub(super) role: String,
     pub(super) task: String,
     pub(super) parent_agent_id: Option<AgentId>,
@@ -131,6 +149,7 @@ pub(super) struct AgentSummary {
 #[derive(Serialize)]
 pub(super) struct AgentDirectoryEntry {
     pub(super) agent_id: AgentId,
+    pub(super) model: Model,
     pub(super) role: String,
     pub(super) task: String,
     pub(super) parent_agent_id: Option<AgentId>,
@@ -380,6 +399,7 @@ impl RegistryState {
                 let can_manage = can_message && scope.topology.authorize(session_id, id).is_ok();
                 Some(AgentDirectoryEntry {
                     agent_id: id,
+                    model: session.descriptor.model,
                     role: bounded_summary(&session.descriptor.role),
                     task: bounded_summary(&session.descriptor.task),
                     parent_agent_id: session.descriptor.parent,
@@ -741,6 +761,66 @@ impl Registry {
             revision,
             capacity: Capacity::new(max_concurrency),
             message_lock: tokio::sync::Mutex::new(()),
+            agent_factory: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn set_agent_factory<F>(
+        &self,
+        thinking: Thinking,
+        fast_mode: bool,
+        factory: F,
+    ) -> Result<(), NanocodexError>
+    where
+        F: Fn(Model, Thinking, bool) -> Result<(Nanocodex, AgentEvents), NanocodexError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.agent_factory
+            .set(AgentFactory {
+                build: Box::new(factory),
+                settings: Mutex::new(AgentSettings {
+                    thinking,
+                    fast_mode,
+                }),
+            })
+            .map_err(|_| {
+                NanocodexError::InvalidRequest("subagent factory is already configured".to_owned())
+            })
+    }
+
+    pub(super) fn spawn_agent(
+        &self,
+        model: Model,
+    ) -> Result<(Nanocodex, AgentEvents), NanocodexError> {
+        let factory = self.agent_factory.get().ok_or_else(|| {
+            NanocodexError::InvalidRequest("subagent factory is not configured".to_owned())
+        })?;
+        let settings = *factory
+            .settings
+            .lock()
+            .expect("subagent settings lock should not be poisoned");
+        (factory.build)(model, settings.thinking, settings.fast_mode)
+    }
+
+    fn set_agent_thinking(&self, thinking: Thinking) {
+        if let Some(factory) = self.agent_factory.get() {
+            factory
+                .settings
+                .lock()
+                .expect("subagent settings lock should not be poisoned")
+                .thinking = thinking;
+        }
+    }
+
+    fn set_agent_fast_mode(&self, fast_mode: bool) {
+        if let Some(factory) = self.agent_factory.get() {
+            factory
+                .settings
+                .lock()
+                .expect("subagent settings lock should not be poisoned")
+                .fast_mode = fast_mode;
         }
     }
 
@@ -1439,10 +1519,13 @@ impl Registry {
 }
 
 impl RootAgentGuard {
+    #[cfg(test)]
     pub(crate) fn new(registry: &Arc<Registry>) -> Self {
-        Self {
-            registry: Arc::downgrade(registry),
-        }
+        Self::from_weak(Arc::downgrade(registry))
+    }
+
+    pub(crate) fn from_weak(registry: Weak<Registry>) -> Self {
+        Self { registry }
     }
 
     pub(crate) async fn require_root(&self, session_id: &str) -> std::io::Result<()> {
@@ -1496,6 +1579,7 @@ impl ChildSession {
         };
         AgentSummary {
             agent_id: self.descriptor.id,
+            model: self.descriptor.model,
             role: self.descriptor.role.clone(),
             task: self.descriptor.task.clone(),
             parent_agent_id: self.descriptor.parent,
@@ -1513,6 +1597,14 @@ pub(crate) struct SubagentControl {
 impl SubagentControl {
     pub(crate) fn set_max_concurrency(&self, limit: usize) {
         self.registry.set_max_concurrency(limit);
+    }
+
+    pub(crate) fn set_thinking(&self, thinking: Thinking) {
+        self.registry.set_agent_thinking(thinking);
+    }
+
+    pub(crate) fn set_fast_mode(&self, enabled: bool) {
+        self.registry.set_agent_fast_mode(enabled);
     }
 
     pub(crate) async fn cancel_all(&self, root_session_id: &str) {
@@ -1589,7 +1681,7 @@ mod tests {
         AgentUpdate, MessageDeliveryState, MessageDisposition, MessagePriority, MessagePurpose,
     };
     use nanocodex::{
-        Nanocodex, OpenAi,
+        Model, Nanocodex, NanocodexError, OpenAi, Thinking,
         oai::{
             ResponseError,
             tower::{ResponsesAttempt, ResponsesServiceResponse},
@@ -1599,7 +1691,7 @@ mod tests {
     use std::{
         future::{Pending, pending},
         result::Result as StdResult,
-        sync::Arc,
+        sync::{Arc, Mutex},
         task::{Context, Poll},
         time::Duration,
     };
@@ -1608,6 +1700,34 @@ mod tests {
         time::timeout,
     };
     use tower::Service;
+
+    #[test]
+    fn agent_factory_receives_the_declared_model() {
+        let (updates, _receiver) = mpsc::unbounded_channel();
+        let registry = Registry::new(updates, 1);
+        let seen = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&seen);
+        registry
+            .set_agent_factory(
+                Thinking::Medium,
+                false,
+                move |model, thinking, fast_mode| {
+                    *captured.lock().unwrap() = Some((model, thinking, fast_mode));
+                    Err(NanocodexError::InvalidRequest(
+                        "stop after capture".to_owned(),
+                    ))
+                },
+            )
+            .unwrap();
+        registry.set_agent_thinking(Thinking::Low);
+        registry.set_agent_fast_mode(true);
+
+        assert!(registry.spawn_agent(Model::Luna).is_err());
+        assert_eq!(
+            *seen.lock().unwrap(),
+            Some((Model::Luna, Thinking::Low, true))
+        );
+    }
 
     #[derive(Clone)]
     struct PendingService {
@@ -1695,6 +1815,7 @@ mod tests {
         let descriptor = AgentDescriptor {
             id: reservation.id,
             session_id: session_id.clone(),
+            model: Model::Sol,
             role: format!("agent-{}", reservation.id),
             task: "wait forever".to_owned(),
             parent,
@@ -1774,6 +1895,7 @@ mod tests {
         let descriptor = AgentDescriptor {
             id,
             session_id: session_id.to_owned(),
+            model: Model::Sol,
             role: format!("agent-{id}"),
             task: "test lifecycle".to_owned(),
             parent,

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -13,8 +13,7 @@ use crate::core::extensions::{
     sessions::SessionTool,
 };
 use nanocodex::{
-    Tool, Tools,
-    agent::AgentHandle,
+    Model, Tool, Tools,
     tools::{
         ToolsBuildError,
         contract::{ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, async_trait},
@@ -42,12 +41,30 @@ const WAIT_AGENT_TOOL: &str = "wait_agent";
 struct AgentTask {
     role: String,
     task: String,
+    model: SubagentModel,
     output_schema: Value,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SubagentModel {
+    Selected,
+    Luna,
+}
+
+impl SubagentModel {
+    const fn resolve(self, selected: Model) -> Model {
+        match self {
+            Self::Selected => selected,
+            Self::Luna => Model::Luna,
+        }
+    }
 }
 
 #[derive(Serialize)]
 struct AgentStartReport {
     agent_id: AgentId,
+    model: Model,
     role: String,
     status: AgentStatus,
 }
@@ -109,8 +126,8 @@ fn json_output(value: &impl Serialize) -> ToolResult {
 }
 
 struct SpawnAgent {
-    parent: AgentHandle,
     registry: Weak<Registry>,
+    selected_model: Model,
 }
 
 #[async_trait]
@@ -130,11 +147,16 @@ impl Tool for SpawnAgent {
                         "type": "string",
                         "description": "A complete, focused task for the subagent."
                     },
+                    "model": {
+                        "type": "string",
+                        "enum": ["selected", "luna"],
+                        "description": "Use `selected` for the session's selected model or `luna` when low latency matters more than reasoning capability."
+                    },
                     "output_schema": {
                         "description": "The JSON Schema that every successful result from this agent must satisfy. Use an object with one string field for a free-form report."
                     }
                 },
-                "required": ["role", "task", "output_schema"],
+                "required": ["role", "task", "model", "output_schema"],
                 "additionalProperties": false
             }),
         )
@@ -145,8 +167,10 @@ impl Tool for SpawnAgent {
         let AgentTask {
             role,
             task,
+            model,
             output_schema,
         } = input.decode_json()?;
+        let model = model.resolve(self.selected_model);
         let contract = OutputContract::compile(&output_schema)?;
         let registry = self
             .registry
@@ -155,11 +179,12 @@ impl Tool for SpawnAgent {
         let capacity = registry.reserve_turn()?;
         let reservation = registry.reserve(context.session_id()).await?;
         let id = reservation.id;
-        let (child, events) = self.parent.spawn().await?;
+        let (child, events) = registry.spawn_agent(model)?;
         let session_id = child.session_id().to_string();
         let descriptor = AgentDescriptor {
             id,
             session_id,
+            model,
             role: role.clone(),
             task: task.clone(),
             parent: reservation.parent,
@@ -195,6 +220,7 @@ impl Tool for SpawnAgent {
             .await?;
         json_output(&AgentStartReport {
             agent_id: id,
+            model,
             role,
             status: AgentStatus::Running,
         })
@@ -497,8 +523,8 @@ impl Tool for ChangeAgentLifecycle {
 
 pub(crate) fn install_tools(
     tools: Tools,
-    parent: AgentHandle,
-    registry: Arc<Registry>,
+    registry: Weak<Registry>,
+    selected_model: Model,
     memory: Option<MemoryStore>,
     subagents_enabled: bool,
     session_config_path: PathBuf,
@@ -509,32 +535,32 @@ pub(crate) fn install_tools(
     if subagents_enabled {
         tools = tools
             .tool(SpawnAgent {
-                parent,
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
+                selected_model,
             })
             .tool(SubmitResult {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(SendAgentMessage {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(ListAgents {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(WaitAgent {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
             })
             .tool(ChangeAgentLifecycle {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
                 operation: LifecycleOperation::Interrupt,
             })
             .tool(ChangeAgentLifecycle {
-                registry: Arc::downgrade(&registry),
+                registry: registry.clone(),
                 operation: LifecycleOperation::Close,
             });
     }
     if let Some(store) = memory {
-        tools = tools.tool(MemoryTool::new(store, RootAgentGuard::new(&registry)));
+        tools = tools.tool(MemoryTool::new(store, RootAgentGuard::from_weak(registry)));
     }
     tools.build()
 }
@@ -544,6 +570,7 @@ fn spawn_agent_output_schema() -> Value {
         "type": "object",
         "properties": {
             "agent_id": { "type": "integer" },
+            "model": { "type": "string" },
             "role": { "type": "string" },
             "status": {
                 "type": "object",
@@ -552,7 +579,7 @@ fn spawn_agent_output_schema() -> Value {
                 "additionalProperties": false
             }
         },
-        "required": ["agent_id", "role", "status"],
+        "required": ["agent_id", "model", "role", "status"],
         "additionalProperties": false
     })
 }
@@ -567,13 +594,14 @@ fn wait_agent_output_schema() -> Value {
                     "type": "object",
                     "properties": {
                         "agent_id": { "type": "integer" },
+                        "model": { "type": "string" },
                         "role": { "type": "string" },
                         "task": { "type": "string" },
                         "parent_agent_id": { "type": ["integer", "null"] },
                         "status": agent_status_schema(),
                         "last_output": {}
                     },
-                    "required": ["agent_id", "role", "task", "parent_agent_id", "status"],
+                    "required": ["agent_id", "model", "role", "task", "parent_agent_id", "status"],
                     "additionalProperties": false
                 }
             },
@@ -617,11 +645,41 @@ fn agent_status_schema() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{SendAgentMessage, SubmitResult, WaitAgent};
+    use super::{SendAgentMessage, SpawnAgent, SubagentModel, SubmitResult, WaitAgent};
     use crate::core::extensions::subagents::runtime::Registry;
-    use nanocodex::Tool;
+    use nanocodex::{Model, Tool};
     use serde_json::json;
     use std::sync::Weak;
+
+    #[test]
+    fn spawn_agent_requires_an_explicit_bounded_model_choice() {
+        let definition = SpawnAgent {
+            registry: Weak::<Registry>::new(),
+            selected_model: Model::Terra,
+        }
+        .definition();
+        let parameters = definition.parameters().unwrap().as_value();
+        let output = definition.output_schema().unwrap();
+
+        assert_eq!(
+            parameters["properties"]["model"]["enum"],
+            json!(["selected", "luna"])
+        );
+        assert!(
+            parameters["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("model"))
+        );
+        assert_eq!(SubagentModel::Selected.resolve(Model::Terra), Model::Terra);
+        assert_eq!(SubagentModel::Luna.resolve(Model::Terra), Model::Luna);
+        assert!(
+            output.as_value()["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("model"))
+        );
+    }
 
     #[test]
     fn send_message_definition_names_deferred_delivery_and_queued_waiting() {
@@ -658,8 +716,17 @@ mod tests {
         .definition();
         let description =
             &definition.parameters().unwrap().as_value()["properties"]["agent_ids"]["description"];
+        let output = definition.output_schema().unwrap();
+        let agent = &output.as_value()["properties"]["agents"]["items"];
 
         assert!(description.as_str().unwrap().contains("spawn_agent"));
         assert!(!description.as_str().unwrap().contains("fork_agent"));
+        assert_eq!(agent["properties"]["model"], json!({ "type": "string" }));
+        assert!(
+            agent["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("model"))
+        );
     }
 }

--- a/src/core/extensions/subagents/tools.rs
+++ b/src/core/extensions/subagents/tools.rs
@@ -22,6 +22,7 @@ use nanocodex::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{
+    io,
     path::PathBuf,
     sync::{Arc, Weak},
     time::Duration,
@@ -53,10 +54,14 @@ enum SubagentModel {
 }
 
 impl SubagentModel {
-    const fn resolve(self, selected: Model) -> Model {
+    fn resolve(self, selected: Model, allow_luna: bool) -> Result<Model, io::Error> {
         match self {
-            Self::Selected => selected,
-            Self::Luna => Model::Luna,
+            Self::Selected => Ok(selected),
+            Self::Luna if allow_luna => Ok(Model::Luna),
+            Self::Luna => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Luna subagents are disabled by `subagents.allow_luna`",
+            )),
         }
     }
 }
@@ -128,11 +133,23 @@ fn json_output(value: &impl Serialize) -> ToolResult {
 struct SpawnAgent {
     registry: Weak<Registry>,
     selected_model: Model,
+    allow_luna: bool,
 }
 
 #[async_trait]
 impl Tool for SpawnAgent {
     fn definition(&self) -> ToolDefinition {
+        let (models, model_description) = if self.allow_luna {
+            (
+                json!(["selected", "luna"]),
+                "Use `selected` for the session's selected model or `luna` when low latency matters more than reasoning capability.",
+            )
+        } else {
+            (
+                json!(["selected"]),
+                "Use `selected` for the session's selected model.",
+            )
+        };
         ToolDefinition::function(
             SPAWN_AGENT_TOOL,
             "Starts a reusable clean-room subagent without inherited conversation history and immediately returns its ID.",
@@ -149,8 +166,8 @@ impl Tool for SpawnAgent {
                     },
                     "model": {
                         "type": "string",
-                        "enum": ["selected", "luna"],
-                        "description": "Use `selected` for the session's selected model or `luna` when low latency matters more than reasoning capability."
+                        "enum": models,
+                        "description": model_description
                     },
                     "output_schema": {
                         "description": "The JSON Schema that every successful result from this agent must satisfy. Use an object with one string field for a free-form report."
@@ -170,7 +187,7 @@ impl Tool for SpawnAgent {
             model,
             output_schema,
         } = input.decode_json()?;
-        let model = model.resolve(self.selected_model);
+        let model = model.resolve(self.selected_model, self.allow_luna)?;
         let contract = OutputContract::compile(&output_schema)?;
         let registry = self
             .registry
@@ -525,6 +542,7 @@ pub(crate) fn install_tools(
     tools: Tools,
     registry: Weak<Registry>,
     selected_model: Model,
+    allow_luna: bool,
     memory: Option<MemoryStore>,
     subagents_enabled: bool,
     session_config_path: PathBuf,
@@ -537,6 +555,7 @@ pub(crate) fn install_tools(
             .tool(SpawnAgent {
                 registry: registry.clone(),
                 selected_model,
+                allow_luna,
             })
             .tool(SubmitResult {
                 registry: registry.clone(),
@@ -656,6 +675,7 @@ mod tests {
         let definition = SpawnAgent {
             registry: Weak::<Registry>::new(),
             selected_model: Model::Terra,
+            allow_luna: true,
         }
         .definition();
         let parameters = definition.parameters().unwrap().as_value();
@@ -671,13 +691,42 @@ mod tests {
                 .unwrap()
                 .contains(&json!("model"))
         );
-        assert_eq!(SubagentModel::Selected.resolve(Model::Terra), Model::Terra);
-        assert_eq!(SubagentModel::Luna.resolve(Model::Terra), Model::Luna);
+        assert_eq!(
+            SubagentModel::Selected.resolve(Model::Terra, true).unwrap(),
+            Model::Terra
+        );
+        assert_eq!(
+            SubagentModel::Luna.resolve(Model::Terra, true).unwrap(),
+            Model::Luna
+        );
         assert!(
             output.as_value()["required"]
                 .as_array()
                 .unwrap()
                 .contains(&json!("model"))
+        );
+    }
+
+    #[test]
+    fn spawn_agent_excludes_and_rejects_luna_when_disabled() {
+        let definition = SpawnAgent {
+            registry: Weak::<Registry>::new(),
+            selected_model: Model::Terra,
+            allow_luna: false,
+        }
+        .definition();
+        let parameters = definition.parameters().unwrap().as_value();
+
+        assert_eq!(
+            parameters["properties"]["model"]["enum"],
+            json!(["selected"])
+        );
+        assert!(
+            SubagentModel::Luna
+                .resolve(Model::Terra, false)
+                .unwrap_err()
+                .to_string()
+                .contains("subagents.allow_luna")
         );
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -40,10 +40,15 @@ const SUBAGENT_INSTRUCTIONS: &str = concat!(
     "across agents in parallel, await and reduce their results, then dispatch dependent stages. Do ",
     "not repeat delegated work yourself; wait for delegated work to finish, then use its results for ",
     "the next step. Double-check their results against the relevant evidence before relying on them. ",
+    "For each `spawn_agent` call, declare `model`: use `luna` for straightforward tasks that need ",
+    "little reasoning when speed matters more, and use `selected` otherwise. ",
     "Use schemas that expose the fields downstream stages need, and use loops to iterate until the ",
     "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
     "verification."
 );
+const SUBAGENT_INSTRUCTIONS_START: &str =
+    "For larger tasks, delegate meaningful, separable work to subagents;";
+const SUBAGENT_INSTRUCTIONS_END: &str = "verification.";
 
 const TOOL_ORCHESTRATION_INSTRUCTIONS: &str = concat!(
     "Use code mode to orchestrate related tool calls when the next calls can be determined from ",
@@ -177,6 +182,7 @@ impl ConfiguredAgent {
         config: &Config,
         thinking: ReasoningEffort,
         reasoning_mode: ReasoningMode,
+        model: Model,
         session_id: Option<&str>,
         resume: Option<ResumeState>,
     ) -> Result<Self> {
@@ -184,7 +190,7 @@ impl ConfiguredAgent {
             config,
             thinking,
             reasoning_mode,
-            Model::Sol,
+            model,
             session_id,
             resume,
         )
@@ -225,17 +231,18 @@ impl ConfiguredAgent {
         let session_config_path = config.path().to_path_buf();
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
+        let subagent_registry = Arc::downgrade(&subagents);
         let mut builder = Nanocodex::builder(openai)
             .model(model)
             .workspace(workspace)
             .thinking(thinking.into())
             .reasoning_mode(reasoning_mode.into())
             .fast_mode(agent_config.fast_mode())
-            .tools_factory(move |agent| {
+            .tools_factory(move |_agent| {
                 subagents::install_tools(
                     tools.clone(),
-                    agent,
-                    Arc::clone(&subagents),
+                    subagent_registry.clone(),
+                    model,
                     memory.clone(),
                     subagents_enabled,
                     session_config_path.clone(),
@@ -262,6 +269,19 @@ impl ConfiguredAgent {
             memory_enabled,
         );
         builder = builder.instructions(Arc::clone(&instructions));
+        let subagent_builder = builder.clone();
+        subagents.set_agent_factory(
+            thinking.into(),
+            agent_config.fast_mode(),
+            move |model, thinking, fast_mode| {
+                subagent_builder
+                    .clone()
+                    .model(model)
+                    .thinking(thinking)
+                    .fast_mode(fast_mode)
+                    .build()
+            },
+        )?;
         if let Some(session_id) = session_id {
             let session_id = session_id
                 .parse::<SessionId>()
@@ -551,18 +571,20 @@ fn reconcile_session_reference_instructions(mut instructions: String) -> String 
 }
 
 fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> String {
-    let separator_and_instructions = format!("\n\n{SUBAGENT_INSTRUCTIONS}");
-    if enabled {
-        if instructions.contains(&separator_and_instructions) {
-            return instructions;
-        }
-        instructions.push_str(&separator_and_instructions);
-        return instructions;
-    }
-
-    while let Some(start) = instructions.find(&separator_and_instructions) {
-        let end = start.saturating_add(separator_and_instructions.len());
+    let start_marker = format!("\n\n{SUBAGENT_INSTRUCTIONS_START}");
+    while let Some(start) = instructions.find(&start_marker) {
+        let body_start = start.saturating_add(2);
+        let Some(relative_end) = instructions[body_start..].find(SUBAGENT_INSTRUCTIONS_END) else {
+            break;
+        };
+        let end = body_start
+            .saturating_add(relative_end)
+            .saturating_add(SUBAGENT_INSTRUCTIONS_END.len());
         instructions.replace_range(start..end, "");
+    }
+    if enabled {
+        instructions.push_str("\n\n");
+        instructions.push_str(SUBAGENT_INSTRUCTIONS);
     }
     instructions
 }
@@ -1029,6 +1051,8 @@ mod tests {
         assert!(SUBAGENT_INSTRUCTIONS.contains("wait for delegated work to finish"));
         assert!(SUBAGENT_INSTRUCTIONS.contains("Do not repeat delegated work yourself"));
         assert!(SUBAGENT_INSTRUCTIONS.contains("Double-check their results"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("use `luna` for straightforward tasks"));
+        assert!(SUBAGENT_INSTRUCTIONS.contains("use `selected` otherwise"));
     }
 
     #[test]
@@ -1073,6 +1097,22 @@ mod tests {
         );
         assert!(restored_enabled.text.contains(SUBAGENT_INSTRUCTIONS));
         assert!(restored_enabled.text.ends_with(MEMORY_INSTRUCTIONS));
+
+        let legacy = SUBAGENT_INSTRUCTIONS.replace(
+            "For each `spawn_agent` call, declare `model`: use `luna` for straightforward tasks \
+             that need little reasoning when speed matters more, and use `selected` otherwise. ",
+            "",
+        );
+        let restored_legacy = session_instructions(
+            None,
+            None,
+            &skills,
+            Some((format!("Stored.\n\n{legacy}"), Some(false))),
+            true,
+            false,
+        );
+        assert!(restored_legacy.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(!restored_legacy.text.contains(&legacy));
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -46,6 +46,17 @@ const SUBAGENT_INSTRUCTIONS: &str = concat!(
     "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
     "verification."
 );
+const SUBAGENT_INSTRUCTIONS_SELECTED_ONLY: &str = concat!(
+    "For larger tasks, delegate meaningful, separable work to subagents; handle trivial or tightly ",
+    "coupled work directly. Use code mode to build multi-agent pipelines: map independent subtasks ",
+    "across agents in parallel, await and reduce their results, then dispatch dependent stages. Do ",
+    "not repeat delegated work yourself; wait for delegated work to finish, then use its results for ",
+    "the next step. Double-check their results against the relevant evidence before relying on them. ",
+    "For each `spawn_agent` call, declare `model` as `selected`. ",
+    "Use schemas that expose the fields downstream stages need, and use loops to iterate until the ",
+    "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
+    "verification."
+);
 const SUBAGENT_INSTRUCTIONS_START: &str =
     "For larger tasks, delegate meaningful, separable work to subagents;";
 const SUBAGENT_INSTRUCTIONS_END: &str = "verification.";
@@ -227,6 +238,7 @@ impl ConfiguredAgent {
         let tools = tools.build().map_err(NanocodexError::from)?;
         let memory_enabled = config.memory().enabled();
         let subagents_enabled = config.subagents().enabled();
+        let allow_luna_subagents = config.subagents().allow_luna();
         let memory = memory_enabled.then(|| MemoryStore::new(config.memory_path()));
         let session_config_path = config.path().to_path_buf();
         let (subagents, subagent_control, subagent_updates) =
@@ -243,6 +255,7 @@ impl ConfiguredAgent {
                     tools.clone(),
                     subagent_registry.clone(),
                     model,
+                    allow_luna_subagents,
                     memory.clone(),
                     subagents_enabled,
                     session_config_path.clone(),
@@ -260,12 +273,13 @@ impl ConfiguredAgent {
         let SessionInstructions {
             text: instructions,
             skills,
-        } = session_instructions(
+        } = session_instructions_with_luna(
             agent_config.instructions(),
             agent_config.append_instructions(),
             config.skills(),
             restored_instructions,
             subagents_enabled,
+            allow_luna_subagents,
             memory_enabled,
         );
         builder = builder.instructions(Arc::clone(&instructions));
@@ -420,12 +434,33 @@ impl ConfiguredAgent {
     }
 }
 
+#[cfg(test)]
 fn session_instructions(
     custom: Option<&str>,
     appended: Option<&str>,
     skills: &SkillsConfig,
     restored: Option<(String, Option<bool>)>,
     subagents_enabled: bool,
+    memory_enabled: bool,
+) -> SessionInstructions {
+    session_instructions_with_luna(
+        custom,
+        appended,
+        skills,
+        restored,
+        subagents_enabled,
+        true,
+        memory_enabled,
+    )
+}
+
+fn session_instructions_with_luna(
+    custom: Option<&str>,
+    appended: Option<&str>,
+    skills: &SkillsConfig,
+    restored: Option<(String, Option<bool>)>,
+    subagents_enabled: bool,
+    allow_luna: bool,
     memory_enabled: bool,
 ) -> SessionInstructions {
     restored.map_or_else(
@@ -436,8 +471,13 @@ fn session_instructions(
                 .map(SkillCatalog::available_in)
                 .unwrap_or_default()
                 .into();
-            let mut instructions =
-                fresh_instructions_with_catalog(custom, appended, &catalog, subagents_enabled);
+            let mut instructions = fresh_instructions_with_catalog(
+                custom,
+                appended,
+                &catalog,
+                subagents_enabled,
+                allow_luna,
+            );
             if memory_enabled {
                 instructions.push_str("\n\n");
                 instructions.push_str(MEMORY_INSTRUCTIONS);
@@ -452,7 +492,8 @@ fn session_instructions(
             let instructions = reconcile_tact_instructions(instructions);
             let instructions = reconcile_tool_orchestration_instructions(instructions);
             let instructions = reconcile_session_reference_instructions(instructions);
-            let instructions = reconcile_subagent_instructions(instructions, subagents_enabled);
+            let instructions =
+                reconcile_subagent_instructions(instructions, subagents_enabled, allow_luna);
             let instructions = reconcile_memory_instructions(instructions, memory_enabled);
             let skills = if catalog_present.unwrap_or(true) {
                 SkillCatalog::available_in(&instructions).into()
@@ -495,7 +536,7 @@ fn fresh_instructions(
     skills: &SkillsConfig,
 ) -> String {
     let catalog = SkillCatalog::load(skills);
-    fresh_instructions_with_catalog(custom, appended, &catalog, true)
+    fresh_instructions_with_catalog(custom, appended, &catalog, true, true)
 }
 
 fn fresh_instructions_with_catalog(
@@ -503,6 +544,7 @@ fn fresh_instructions_with_catalog(
     appended: Option<&str>,
     catalog: &SkillCatalog,
     subagents_enabled: bool,
+    allow_luna: bool,
 ) -> String {
     let mut instructions = custom
         .map(str::to_owned)
@@ -512,7 +554,7 @@ fn fresh_instructions_with_catalog(
     instructions = reconcile_session_reference_instructions(instructions);
     if subagents_enabled {
         instructions.push_str("\n\n");
-        instructions.push_str(SUBAGENT_INSTRUCTIONS);
+        instructions.push_str(subagent_instructions(allow_luna));
     }
     if let Some(appended) = appended {
         instructions.push_str("\n\n");
@@ -570,7 +612,19 @@ fn reconcile_session_reference_instructions(mut instructions: String) -> String 
     instructions
 }
 
-fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> String {
+fn subagent_instructions(allow_luna: bool) -> &'static str {
+    if allow_luna {
+        SUBAGENT_INSTRUCTIONS
+    } else {
+        SUBAGENT_INSTRUCTIONS_SELECTED_ONLY
+    }
+}
+
+fn reconcile_subagent_instructions(
+    mut instructions: String,
+    enabled: bool,
+    allow_luna: bool,
+) -> String {
     let start_marker = format!("\n\n{SUBAGENT_INSTRUCTIONS_START}");
     while let Some(start) = instructions.find(&start_marker) {
         let body_start = start.saturating_add(2);
@@ -584,7 +638,7 @@ fn reconcile_subagent_instructions(mut instructions: String, enabled: bool) -> S
     }
     if enabled {
         instructions.push_str("\n\n");
-        instructions.push_str(SUBAGENT_INSTRUCTIONS);
+        instructions.push_str(subagent_instructions(allow_luna));
     }
     instructions
 }
@@ -603,9 +657,9 @@ impl Cancellation {
 mod tests {
     use super::{
         ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT,
-        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, TACT_INSTRUCTIONS,
-        TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions, reconcile_tact_instructions,
-        session_instructions,
+        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS_SELECTED_ONLY,
+        TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS, fresh_instructions,
+        reconcile_tact_instructions, session_instructions, session_instructions_with_luna,
     };
     use crate::{
         app::{
@@ -1113,6 +1167,40 @@ mod tests {
         );
         assert!(restored_legacy.text.contains(SUBAGENT_INSTRUCTIONS));
         assert!(!restored_legacy.text.contains(&legacy));
+    }
+
+    #[test]
+    fn luna_delegation_instructions_follow_the_config() {
+        let skills = SkillsConfig::from_roots(false, Vec::new());
+        let luna_enabled =
+            session_instructions_with_luna(None, None, &skills, None, true, true, false);
+        let luna_disabled =
+            session_instructions_with_luna(None, None, &skills, None, true, false, false);
+
+        assert!(luna_enabled.text.contains(SUBAGENT_INSTRUCTIONS));
+        assert!(
+            !luna_enabled
+                .text
+                .contains(SUBAGENT_INSTRUCTIONS_SELECTED_ONLY)
+        );
+        assert!(
+            luna_disabled
+                .text
+                .contains(SUBAGENT_INSTRUCTIONS_SELECTED_ONLY)
+        );
+        assert!(!luna_disabled.text.contains("use `luna`"));
+
+        let restored = session_instructions_with_luna(
+            None,
+            None,
+            &skills,
+            Some((luna_enabled.text.to_string(), Some(false))),
+            true,
+            false,
+            false,
+        );
+        assert!(restored.text.contains(SUBAGENT_INSTRUCTIONS_SELECTED_ONLY));
+        assert!(!restored.text.contains("use `luna`"));
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -17,8 +17,8 @@ use crate::{
     tui::session::ResumeState,
 };
 use nanocodex::{
-    AgentEvents, Nanocodex, NanocodexError, OpenAi, Tools, TurnControl, agent::session::SessionId,
-    oai::tower::ResponsesServiceConfig,
+    AgentEvents, Model, Nanocodex, NanocodexError, OpenAi, Tools, TurnControl,
+    agent::session::SessionId, oai::tower::ResponsesServiceConfig,
 };
 #[cfg(feature = "harbor-evals")]
 use orchestration::{OrchestrationRecorder, RunOutcome};
@@ -149,10 +149,25 @@ impl ConfiguredAgent {
     }
 
     pub(crate) fn from_config(config: &Config) -> Result<Self> {
-        Self::from_config_with_session(
+        Self::from_config_with_model(
             config,
             config.agent().thinking(),
             config.agent().reasoning_mode(),
+            Model::Sol,
+        )
+    }
+
+    pub(crate) fn from_config_with_model(
+        config: &Config,
+        thinking: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        model: Model,
+    ) -> Result<Self> {
+        Self::from_config_with_session_and_model(
+            config,
+            thinking,
+            reasoning_mode,
+            model,
             None,
             None,
         )
@@ -162,6 +177,24 @@ impl ConfiguredAgent {
         config: &Config,
         thinking: ReasoningEffort,
         reasoning_mode: ReasoningMode,
+        session_id: Option<&str>,
+        resume: Option<ResumeState>,
+    ) -> Result<Self> {
+        Self::from_config_with_session_and_model(
+            config,
+            thinking,
+            reasoning_mode,
+            Model::Sol,
+            session_id,
+            resume,
+        )
+    }
+
+    fn from_config_with_session_and_model(
+        config: &Config,
+        thinking: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        model: Model,
         session_id: Option<&str>,
         resume: Option<ResumeState>,
     ) -> Result<Self> {
@@ -193,6 +226,7 @@ impl ConfiguredAgent {
         let (subagents, subagent_control, subagent_updates) =
             subagents::channel(agent_config.max_subagents());
         let mut builder = Nanocodex::builder(openai)
+            .model(model)
             .workspace(workspace)
             .thinking(thinking.into())
             .reasoning_mode(reasoning_mode.into())

--- a/src/core/orchestration.rs
+++ b/src/core/orchestration.rs
@@ -6,8 +6,11 @@ use crate::{
         AgentDescriptor, AgentId, AgentMessageUpdate, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     },
 };
-use nanocodex::agent::events::{
-    AgentEvent, AgentEventData, AgentEventKind, EventUsage, RunEvent, RunTerminal,
+use nanocodex::{
+    Model,
+    agent::events::{
+        AgentEvent, AgentEventData, AgentEventKind, EventUsage, RunEvent, RunTerminal,
+    },
 };
 use serde::Serialize;
 use std::{
@@ -93,6 +96,7 @@ enum UpdateRecord<'a> {
 struct AgentRecord<'a> {
     id: AgentId,
     session_id: &'a str,
+    model: Model,
     role: &'a str,
     task: &'a str,
     origin: AgentOrigin,
@@ -116,6 +120,7 @@ enum SummaryRecord {
 #[derive(Serialize)]
 struct AgentSummary {
     id: AgentId,
+    model: Model,
     role: String,
     parent_id: Option<AgentId>,
     origin: AgentOrigin,
@@ -283,6 +288,7 @@ impl Recorder {
             .values()
             .map(|agent| AgentSummary {
                 id: agent.descriptor.id,
+                model: agent.descriptor.model,
                 role: agent.descriptor.role.clone(),
                 parent_id: agent.descriptor.parent,
                 origin: AgentOrigin::Spawn,
@@ -384,6 +390,7 @@ impl<'a> From<&'a AgentDescriptor> for AgentRecord<'a> {
         Self {
             id: descriptor.id,
             session_id: &descriptor.session_id,
+            model: descriptor.model,
             role: &descriptor.role,
             task: &descriptor.task,
             origin: AgentOrigin::Spawn,
@@ -398,7 +405,10 @@ mod tests {
     use crate::core::extensions::subagents::{
         AgentDescriptor, AgentId, AgentStatus, AgentUpdate, ScopedAgentUpdate,
     };
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use serde_json::{Value, json, value::to_raw_value};
     use std::{fs, sync::Arc};
     use tempfile::tempdir;
@@ -422,6 +432,7 @@ mod tests {
             "websocket_reconnects": 0,
             "response_attempts": model_calls,
             "response_retries": 0,
+            "billing_uncertain_response_attempts": 0,
             "connection_duration_ns": 100,
             "retry_backoff_duration_ns": 0,
             "model_duration_ns": 900_000,
@@ -463,6 +474,7 @@ mod tests {
                 update: AgentUpdate::Added(AgentDescriptor {
                     id,
                     session_id: "child".to_owned(),
+                    model: Model::Sol,
                     role: "researcher".to_owned(),
                     task: "inspect the task".to_owned(),
                     parent: None,

--- a/src/tui/components/actions.rs
+++ b/src/tui/components/actions.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const ACTIONS: [Action; 14] = [
+const ACTIONS: [Action; 15] = [
     Action::Effort,
     Action::FastMode,
     Action::Theme,
@@ -31,6 +31,7 @@ const ACTIONS: [Action; 14] = [
     Action::DebugContext,
     Action::Handoff,
     Action::Review,
+    Action::Model,
 ];
 const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab open", "esc close"];
 const SEARCH_LABEL: &str = "Search: ";
@@ -45,6 +46,7 @@ pub(super) struct ActionAvailability {
     pub(super) fork: bool,
     pub(super) fast_mode: bool,
     pub(super) memory: bool,
+    pub(super) model: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -53,6 +55,7 @@ pub(super) enum Action {
     Review,
     Subagents,
     Effort,
+    Model,
     FastMode,
     Theme,
     NewSession,
@@ -259,6 +262,7 @@ impl ActionsMenu {
             Action::Handoff | Action::Review => self.availability.new_session,
             Action::Subagents => true,
             Action::Effort => true,
+            Action::Model => self.availability.model,
             Action::FastMode => true,
             Action::Theme => true,
             Action::NewSession => self.availability.new_session,
@@ -288,6 +292,7 @@ impl ActionsMenu {
                 "Prepare handoff · finish active work first"
             }
             Action::FastMode if self.availability.fast_mode => "Disable fast mode",
+            Action::Model if !self.availability.model => "Select model · start a new session first",
             Action::Memory if !self.availability.memory => {
                 "Memory · enable in config: memory.enabled = true"
             }
@@ -303,6 +308,7 @@ impl Action {
             Self::Review => "Review changes",
             Self::Subagents => "Subagents",
             Self::Effort => "Change effort",
+            Self::Model => "Select model",
             Self::FastMode => "Enable fast mode",
             Self::Theme => "Select theme",
             Self::NewSession => "New session",
@@ -322,6 +328,7 @@ impl Action {
             Self::Review => Some("review"),
             Self::Subagents => Some("agents"),
             Self::Effort => Some("thinking"),
+            Self::Model => Some("intelligence"),
             Self::FastMode => Some("priority"),
             Self::Theme => Some("appearance"),
             Self::NewSession => Some("clear"),
@@ -417,6 +424,7 @@ mod tests {
             fork: true,
             fast_mode: false,
             memory: true,
+            model: true,
         }
     }
 
@@ -588,6 +596,30 @@ mod tests {
             enabled.update(key(KeyCode::Enter)).effects,
             [ActionsEffect::Trigger(Action::Effort)]
         );
+    }
+
+    #[test]
+    fn model_action_is_available_only_before_the_first_prompt() {
+        let mut enabled = ActionsMenu::new(available());
+        for character in "intelligence".chars() {
+            enabled.update(key(KeyCode::Char(character)));
+        }
+        assert_eq!(
+            enabled.update(key(KeyCode::Enter)).effects,
+            [ActionsEffect::Trigger(Action::Model)]
+        );
+
+        let mut availability = available();
+        availability.model = false;
+        let mut disabled = ActionsMenu::new(availability);
+        for character in "intelligence".chars() {
+            disabled.update(key(KeyCode::Char(character)));
+        }
+        let terminal = render(&mut disabled);
+        assert!((0..20).any(|row| {
+            row_segment(&terminal, row, 0, 60).contains("Select model · start a new session first")
+        }));
+        assert!(disabled.update(key(KeyCode::Enter)).effects.is_empty());
     }
 
     #[test]

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -3,7 +3,7 @@
 use super::{
     node::{ComponentUpdate, Node, RenderRequest},
     queue::QueueId,
-    root::{RestoredSessionProjection, RootEffect, RootEvent, RootNode},
+    root::{DraftReset, RestoredSessionProjection, RootEffect, RootEvent, RootNode},
 };
 use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -102,6 +103,8 @@ pub(crate) enum AppEvent {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
+        draft_reset: DraftReset,
         skills: Arc<[Skill]>,
     },
     NewSessionFailed {
@@ -149,6 +152,7 @@ pub(crate) enum AppEvent {
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
         skills: Arc<[Skill]>,
     },
     NotifyError {
@@ -267,6 +271,7 @@ impl AppNode {
                         effort,
                         reasoning_mode,
                         reasoning_mode,
+                        DraftReset::Clear,
                     );
                     root.component_mut().set_fast_mode(fast_mode);
                     root.component_mut().set_skills(skills);
@@ -312,6 +317,8 @@ impl AppNode {
                 effort,
                 reasoning_mode,
                 fast_mode,
+                model,
+                draft_reset,
                 skills,
             } => {
                 let workspace = self.workspace.clone();
@@ -323,8 +330,10 @@ impl AppNode {
                     effort,
                     reasoning_mode,
                     reasoning_mode,
+                    draft_reset,
                 );
                 root.component_mut().set_fast_mode(fast_mode);
+                root.component_mut().set_model(model);
                 root.component_mut().set_skills(skills);
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
@@ -372,6 +381,7 @@ impl AppNode {
                 reasoning_mode,
                 preferred_reasoning_mode,
                 fast_mode,
+                model,
                 skills,
             } => self.update_root(
                 pane,
@@ -381,6 +391,7 @@ impl AppNode {
                     reasoning_mode,
                     preferred_reasoning_mode,
                     fast_mode,
+                    model,
                     skills,
                 },
             ),
@@ -756,8 +767,8 @@ fn is_control_c(event: &Event) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::SessionListKind, AppEffect, AppEvent, AppNode, RootEffect, RootEvent, RootNode,
-        SPLIT_HINT,
+        super::SessionListKind, AppEffect, AppEvent, AppNode, DraftReset, RootEffect, RootEvent,
+        RootNode, SPLIT_HINT,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -771,6 +782,7 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
+    use nanocodex::Model;
     use ratatui::{Terminal, backend::TestBackend};
     use semver::Version;
     use std::{path::PathBuf, sync::Arc};
@@ -786,6 +798,29 @@ mod tests {
             KeyCode::Char(character),
             KeyModifiers::CONTROL,
         )))
+    }
+
+    #[test]
+    fn model_session_replacement_preserves_the_draft_in_place() {
+        let mut app = app();
+        app.update(AppEvent::EditorDraft {
+            pane: PaneId::Main,
+            draft: "send with luna".to_owned(),
+        });
+
+        app.update(AppEvent::NewSessionReady {
+            pane: PaneId::Main,
+            effort: ReasoningEffort::Low,
+            reasoning_mode: ReasoningMode::Standard,
+            fast_mode: false,
+            model: Model::Luna,
+            draft_reset: DraftReset::Preserve,
+            skills: Arc::from([]),
+        });
+
+        let root = app.root(PaneId::Main).unwrap();
+        assert_eq!(root.composer().draft(), "send with luna");
+        assert_eq!(root.composer().model(), Model::Luna);
     }
 
     fn memory_record(id: i64, content: &str) -> MemoryRecord {

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -1126,7 +1126,7 @@ impl Composer {
             top,
             &model,
             usize::from(content_end.saturating_sub(model_start)),
-            Style::default().fg(theme.accent()),
+            Style::default().fg(theme.model(self.model)),
         );
         let effort_start = model_start + u16::try_from(model.width()).unwrap_or(u16::MAX);
         if effort_start < content_end {
@@ -1483,14 +1483,27 @@ mod tests {
     }
 
     #[test]
-    fn composer_chrome_uses_the_selected_session_model() {
-        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
-        composer.update(ComposerEvent::SetModel(Model::Luna));
+    fn composer_chrome_uses_the_model_palette() {
+        for (model, color) in [
+            (Model::Luna, Color::White),
+            (Model::Terra, Color::Green),
+            (Model::Sol, Color::Yellow),
+        ] {
+            let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+            composer.update(ComposerEvent::SetModel(model));
+            let terminal = render(&mut composer, 60, 5);
+            let label = model.to_string().chars().collect::<Vec<_>>();
+            let line = rows(&terminal)[0].chars().collect::<Vec<_>>();
+            let start = line
+                .windows(label.len())
+                .position(|window| window == label)
+                .unwrap();
 
-        let terminal = render(&mut composer, 60, 5);
-
-        assert!(rows(&terminal)[0].contains(" gpt-5.6-luna "));
-        assert!(!rows(&terminal)[0].contains(" gpt-5.6-sol "));
+            assert_eq!(
+                terminal.backend().buffer()[(u16::try_from(start).unwrap(), 0)].fg,
+                color
+            );
+        }
     }
 
     #[test]

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -52,6 +52,7 @@ pub(crate) enum ComposerEffect {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ComposerChromeTarget {
     Effort,
+    Model,
     Subagents,
 }
 
@@ -113,6 +114,7 @@ pub(crate) struct Composer {
     subagent_wave: Option<WavedText>,
     turn_timers: VecDeque<TurnTimer>,
     effort_hit_area: Option<Rect>,
+    model_hit_area: Option<Rect>,
     subagent_hit_area: Option<Rect>,
     layout: Option<CachedLayout>,
     history: PromptHistory,
@@ -210,6 +212,7 @@ impl Composer {
             subagent_wave: None,
             turn_timers: VecDeque::new(),
             effort_hit_area: None,
+            model_hit_area: None,
             subagent_hit_area: None,
             layout: None,
             history: PromptHistory::default(),
@@ -374,6 +377,12 @@ impl Composer {
             .is_some_and(|area| area.contains(position))
         {
             return Some(ComposerChromeTarget::Subagents);
+        }
+        if self
+            .model_hit_area
+            .is_some_and(|area| area.contains(position))
+        {
+            return Some(ComposerChromeTarget::Model);
         }
         self.effort_hit_area
             .is_some_and(|area| area.contains(position))
@@ -1001,6 +1010,7 @@ impl Composer {
 
     fn render_chrome(&mut self, buffer: &mut Buffer, area: Rect, theme: &Theme) {
         self.effort_hit_area = None;
+        self.model_hit_area = None;
         self.subagent_hit_area = None;
         let shell_mode = self.draft.starts_with('!');
         let border = self.border_style(theme);
@@ -1121,6 +1131,16 @@ impl Composer {
             Style::default().fg(theme.muted()),
         );
         let model_start = right_start + u16::try_from(timer.width()).unwrap_or(u16::MAX);
+        if model_start < content_end {
+            self.model_hit_area = Some(Rect::new(
+                model_start,
+                top,
+                u16::try_from(model.width())
+                    .unwrap_or(u16::MAX)
+                    .min(content_end.saturating_sub(model_start)),
+                1,
+            ));
+        }
         buffer.set_stringn(
             model_start,
             top,

--- a/src/tui/components/composer.rs
+++ b/src/tui/components/composer.rs
@@ -20,7 +20,7 @@ use crate::{
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use history::PromptHistory;
 use layout::{VisualLayout, byte_at_column, grapheme_at_column};
-use nanocodex::oai::MODEL;
+use nanocodex::Model;
 use ratatui::{
     Frame,
     buffer::Buffer,
@@ -65,6 +65,7 @@ pub(crate) enum ComposerEvent {
     },
     ReplaceDraft(String),
     SetEffort(ReasoningEffort),
+    SetModel(Model),
     SetReasoningMode(ReasoningMode),
     SetFastMode(bool),
     Activity {
@@ -101,6 +102,7 @@ pub(crate) struct Composer {
     context_tokens: u64,
     workspace: String,
     thinking: ReasoningEffort,
+    model: Model,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
     activity_wave: Option<WavedText>,
@@ -197,6 +199,7 @@ impl Composer {
             context_tokens: 0,
             workspace: shorten_home(workspace),
             thinking,
+            model: Model::Sol,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
             activity_wave: None,
@@ -254,6 +257,13 @@ impl Composer {
                     return ComposerUpdate::unchanged();
                 }
                 self.thinking = effort;
+                ComposerUpdate::changed()
+            }
+            ComposerEvent::SetModel(model) => {
+                if self.model == model {
+                    return ComposerUpdate::unchanged();
+                }
+                self.model = model;
                 ComposerUpdate::changed()
             }
             ComposerEvent::SetReasoningMode(mode) => {
@@ -540,6 +550,10 @@ impl Composer {
 
     pub(crate) const fn effort(&self) -> ReasoningEffort {
         self.thinking
+    }
+
+    pub(crate) const fn model(&self) -> Model {
+        self.model
     }
 
     pub(crate) const fn fast_mode(&self) -> bool {
@@ -1031,7 +1045,7 @@ impl Composer {
         } else {
             format!("{usage_before_subagents}{} ", subagent_segment.trim_start())
         };
-        let model = format!(" {MODEL} ");
+        let model = format!(" {} ", self.model);
         let timer = self
             .turn_timers
             .front()
@@ -1387,7 +1401,10 @@ mod tests {
         tui::theme::Theme,
     };
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-    use nanocodex::agent::input::{PromptInput, UserInput};
+    use nanocodex::{
+        Model,
+        agent::input::{PromptInput, UserInput},
+    };
     use ratatui::{
         Terminal,
         backend::TestBackend,
@@ -1463,6 +1480,17 @@ mod tests {
                 footer,
             ]
         );
+    }
+
+    #[test]
+    fn composer_chrome_uses_the_selected_session_model() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::SetModel(Model::Luna));
+
+        let terminal = render(&mut composer, 60, 5);
+
+        assert!(rows(&terminal)[0].contains(" gpt-5.6-luna "));
+        assert!(!rows(&terminal)[0].contains(" gpt-5.6-sol "));
     }
 
     #[test]

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -16,8 +16,9 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 const FOOTER: [&str; 1] = ["esc close"];
-const BINDINGS: [(&str, &str); 21] = [
+const BINDINGS: [(&str, &str); 22] = [
     ("ctrl+s", "change reasoning effort"),
+    ("ctrl+m", "select model · before first prompt"),
     ("ctrl+f", "fork session · when available"),
     ("ctrl+g", "edit prompt in $EDITOR"),
     ("ctrl+r", "recent prompts"),

--- a/src/tui/components/keybindings.rs
+++ b/src/tui/components/keybindings.rs
@@ -18,7 +18,7 @@ use unicode_width::UnicodeWidthStr;
 const FOOTER: [&str; 1] = ["esc close"];
 const BINDINGS: [(&str, &str); 22] = [
     ("ctrl+s", "change reasoning effort"),
-    ("ctrl+m", "select model · before first prompt"),
+    ("ctrl+d", "select model · before first prompt"),
     ("ctrl+f", "fork session · when available"),
     ("ctrl+g", "edit prompt in $EDITOR"),
     ("ctrl+r", "recent prompts"),

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -9,6 +9,7 @@ mod file_finder;
 mod floating;
 mod keybindings;
 mod memory;
+mod model_selector;
 mod node;
 mod queue;
 mod recent_prompt_picker;
@@ -27,5 +28,5 @@ pub(crate) use app::{AppEffect, AppEvent, AppNode};
 pub(crate) use node::{ComponentUpdate, RenderRequest};
 pub(crate) use queue::QueueId;
 pub(crate) use root::{
-    RecentPromptDraft, RestoredSessionProjection, RootEffect, RootNode, SessionListKind,
+    DraftReset, RecentPromptDraft, RestoredSessionProjection, RootEffect, RootNode, SessionListKind,
 };

--- a/src/tui/components/model_selector.rs
+++ b/src/tui/components/model_selector.rs
@@ -131,7 +131,7 @@ impl ModelSelector {
         let indicator_column = left.saturating_add(
             (f64::from(width) * self.displayed_position / (MODELS.len() - 1) as f64).round() as u16,
         );
-        let selected_color = model_color(theme, MODELS[self.selected]);
+        let selected_color = theme.model(MODELS[self.selected]);
         let buffer = frame.buffer_mut();
         for column in left..=right {
             let color = if column <= indicator_column {
@@ -141,16 +141,11 @@ impl ModelSelector {
             };
             buffer.set_string(column, area.y, "━", Style::default().fg(color));
         }
-        for index in 0..MODELS.len() {
+        for (index, model) in MODELS.iter().copied().enumerate() {
             let column = left.saturating_add(
                 (f64::from(width) * index as f64 / (MODELS.len() - 1) as f64).round() as u16,
             );
-            let color = if index <= self.displayed_position.round() as usize {
-                selected_color
-            } else {
-                theme.muted()
-            };
-            buffer.set_string(column, area.y, "●", Style::default().fg(color));
+            buffer.set_string(column, area.y, "●", Style::default().fg(theme.model(model)));
         }
         buffer.set_string(
             indicator_column,
@@ -162,18 +157,18 @@ impl ModelSelector {
         );
 
         let labels = [
-            (left, "Luna"),
-            (left.saturating_add(width / 2), "Terra"),
-            (right, "Sol"),
+            (left, Model::Luna, "Luna"),
+            (left.saturating_add(width / 2), Model::Terra, "Terra"),
+            (right, Model::Sol, "Sol"),
         ];
-        for (column, label) in labels {
+        for (column, model, label) in labels {
             let label_width = u16::try_from(label.len()).unwrap_or(u16::MAX);
             let start = column.saturating_sub(label_width / 2).max(area.x);
             buffer.set_string(
                 start,
                 area.y.saturating_add(1),
                 label,
-                Style::default().fg(theme.text()),
+                Style::default().fg(theme.model(model)),
             );
         }
     }
@@ -211,7 +206,7 @@ impl Component for ModelSelector {
             Span::styled(
                 model_name(model),
                 Style::default()
-                    .fg(model_color(theme, model))
+                    .fg(theme.model(model))
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled("  ·  smarter →", Style::default().fg(Color::Green)),
@@ -251,22 +246,40 @@ fn model_name(model: Model) -> &'static str {
     }
 }
 
-fn model_color(theme: &Theme, model: Model) -> Color {
-    match model {
-        Model::Luna => theme.thinking_low(),
-        Model::Terra => theme.thinking_high(),
-        Model::Sol => theme.thinking_max(),
-        _ => theme.thinking_max(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crossterm::event::{KeyEvent, KeyModifiers};
+    use ratatui::{Terminal, backend::TestBackend};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn render(selector: &mut ModelSelector) -> Terminal<TestBackend> {
+        let mut terminal = Terminal::new(TestBackend::new(60, 9)).unwrap();
+        terminal
+            .draw(|frame| selector.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        terminal
+    }
+
+    fn rendered_label_color(selector: &mut ModelSelector, label: &str) -> Color {
+        let terminal = render(selector);
+        let buffer = terminal.backend().buffer();
+        let label = label.chars().collect::<Vec<_>>();
+        let label_width = u16::try_from(label.len()).unwrap();
+        for y in 0..buffer.area.height {
+            for x in 0..=buffer.area.width.saturating_sub(label_width) {
+                if label.iter().enumerate().all(|(offset, character)| {
+                    buffer[(x + u16::try_from(offset).unwrap(), y)].symbol()
+                        == character.to_string()
+                }) {
+                    return buffer[(x, y)].fg;
+                }
+            }
+        }
+        panic!("label not rendered: {label:?}");
     }
 
     #[test]
@@ -281,6 +294,31 @@ mod tests {
         selector.update_key(key(KeyCode::Left), now);
         selector.update_key(key(KeyCode::Left), now);
         assert_eq!(selector.selected, 0);
+    }
+
+    #[test]
+    fn every_stop_keeps_its_model_color() {
+        let mut selector = ModelSelector::new(Model::Sol);
+
+        assert_eq!(rendered_label_color(&mut selector, "Luna"), Color::White);
+        assert_eq!(rendered_label_color(&mut selector, "Terra"), Color::Green);
+        assert_eq!(rendered_label_color(&mut selector, "Sol"), Color::Yellow);
+    }
+
+    #[test]
+    fn filled_bar_uses_the_selected_model_color() {
+        let mut selector = ModelSelector::new(Model::Sol);
+        let terminal = render(&mut selector);
+        let rail = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .filter(|cell| cell.symbol() == "━")
+            .collect::<Vec<_>>();
+
+        assert!(!rail.is_empty());
+        assert!(rail.iter().all(|cell| cell.fg == Color::Yellow));
     }
 
     #[test]

--- a/src/tui/components/model_selector.rs
+++ b/src/tui/components/model_selector.rs
@@ -1,0 +1,309 @@
+//! Animated linear selector for the model fixed to a new session.
+
+use super::{
+    floating::Floating,
+    node::{Component, ComponentUpdate, RenderRequest},
+};
+use crate::tui::theme::Theme;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use nanocodex::Model;
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+use std::time::{Duration, Instant};
+
+const MODELS: [Model; 3] = [Model::Luna, Model::Terra, Model::Sol];
+const ANIMATION_DURATION: Duration = Duration::from_millis(280);
+const ANIMATION_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+const KEY_BINDINGS: [&str; 3] = ["←/→ model", "enter apply", "esc cancel"];
+
+pub(super) enum ModelSelectorEvent {
+    Terminal { event: Event, now: Instant },
+    AnimationFrame(Instant),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum ModelSelectorEffect {
+    Apply(Model),
+    Dismiss,
+}
+
+pub(super) struct ModelSelector {
+    selected: usize,
+    displayed_position: f64,
+    animation: Option<Animation>,
+}
+
+struct Animation {
+    from: f64,
+    to: f64,
+    started_at: Instant,
+    next_frame: Instant,
+}
+
+impl ModelSelector {
+    pub(super) fn new(initial: Model) -> Self {
+        let selected = model_index(initial);
+        Self {
+            selected,
+            displayed_position: selected as f64,
+            animation: None,
+        }
+    }
+
+    pub(super) fn animation_deadline(&self) -> Option<Instant> {
+        self.animation
+            .as_ref()
+            .map(|animation| animation.next_frame)
+    }
+
+    fn update_key(&mut self, key: KeyEvent, now: Instant) -> ComponentUpdate<ModelSelectorEffect> {
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return ComponentUpdate::none();
+        }
+
+        match key.code {
+            KeyCode::Left | KeyCode::Up => self.select_relative(-1, now),
+            KeyCode::Right | KeyCode::Down => self.select_relative(1, now),
+            KeyCode::Enter => ComponentUpdate {
+                effects: vec![ModelSelectorEffect::Apply(MODELS[self.selected])],
+                render: RenderRequest::Immediate,
+            },
+            KeyCode::Esc | KeyCode::Backspace => ComponentUpdate {
+                effects: vec![ModelSelectorEffect::Dismiss],
+                render: RenderRequest::Immediate,
+            },
+            _ => ComponentUpdate::none(),
+        }
+    }
+
+    fn select_relative(
+        &mut self,
+        direction: isize,
+        now: Instant,
+    ) -> ComponentUpdate<ModelSelectorEffect> {
+        self.advance_animation(now);
+        let next = self
+            .selected
+            .saturating_add_signed(direction)
+            .min(MODELS.len() - 1);
+        if next == self.selected {
+            return ComponentUpdate::none();
+        }
+        self.selected = next;
+        self.animation = Some(Animation {
+            from: self.displayed_position,
+            to: next as f64,
+            started_at: now,
+            next_frame: now + ANIMATION_FRAME_INTERVAL,
+        });
+        ComponentUpdate::render(RenderRequest::Immediate)
+    }
+
+    fn advance_animation(&mut self, now: Instant) -> bool {
+        let Some(animation) = &mut self.animation else {
+            return false;
+        };
+        let elapsed = now.saturating_duration_since(animation.started_at);
+        let progress = (elapsed.as_secs_f64() / ANIMATION_DURATION.as_secs_f64()).min(1.0);
+        let eased = 1.0 - (1.0 - progress).powi(3);
+        self.displayed_position = animation.from + (animation.to - animation.from) * eased;
+        if progress >= 1.0 {
+            self.displayed_position = self.selected as f64;
+            self.animation = None;
+        } else {
+            animation.next_frame = now + ANIMATION_FRAME_INTERVAL;
+        }
+        true
+    }
+
+    fn render_slider(&self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
+        if area.width < 5 || area.height < 2 {
+            return;
+        }
+        let left = area.x.saturating_add(2);
+        let right = area.right().saturating_sub(3).max(left);
+        let width = right.saturating_sub(left);
+        let indicator_column = left.saturating_add(
+            (f64::from(width) * self.displayed_position / (MODELS.len() - 1) as f64).round() as u16,
+        );
+        let selected_color = model_color(theme, MODELS[self.selected]);
+        let buffer = frame.buffer_mut();
+        for column in left..=right {
+            let color = if column <= indicator_column {
+                selected_color
+            } else {
+                theme.muted()
+            };
+            buffer.set_string(column, area.y, "━", Style::default().fg(color));
+        }
+        for index in 0..MODELS.len() {
+            let column = left.saturating_add(
+                (f64::from(width) * index as f64 / (MODELS.len() - 1) as f64).round() as u16,
+            );
+            let color = if index <= self.displayed_position.round() as usize {
+                selected_color
+            } else {
+                theme.muted()
+            };
+            buffer.set_string(column, area.y, "●", Style::default().fg(color));
+        }
+        buffer.set_string(
+            indicator_column,
+            area.y,
+            "◆",
+            Style::default()
+                .fg(selected_color)
+                .add_modifier(Modifier::BOLD),
+        );
+
+        let labels = [
+            (left, "Luna"),
+            (left.saturating_add(width / 2), "Terra"),
+            (right, "Sol"),
+        ];
+        for (column, label) in labels {
+            let label_width = u16::try_from(label.len()).unwrap_or(u16::MAX);
+            let start = column.saturating_sub(label_width / 2).max(area.x);
+            buffer.set_string(
+                start,
+                area.y.saturating_add(1),
+                label,
+                Style::default().fg(theme.text()),
+            );
+        }
+    }
+}
+
+impl Component for ModelSelector {
+    type Event = ModelSelectorEvent;
+    type Effect = ModelSelectorEffect;
+
+    fn update(&mut self, event: Self::Event) -> ComponentUpdate<Self::Effect> {
+        match event {
+            ModelSelectorEvent::Terminal {
+                event: Event::Key(key),
+                now,
+            } => self.update_key(key, now),
+            ModelSelectorEvent::Terminal { .. } => ComponentUpdate::none(),
+            ModelSelectorEvent::AnimationFrame(now) => {
+                if self.advance_animation(now) {
+                    ComponentUpdate::render(RenderRequest::Streaming)
+                } else {
+                    ComponentUpdate::none()
+                }
+            }
+        }
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
+        let layout = Floating::new("Select model", 52, 7, &KEY_BINDINGS).render(frame, area, theme);
+        if layout.body.is_empty() {
+            return;
+        }
+        let model = MODELS[self.selected];
+        let title = Line::from(vec![
+            Span::styled("Selected: ", Style::default().fg(theme.border())),
+            Span::styled(
+                model_name(model),
+                Style::default()
+                    .fg(model_color(theme, model))
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ·  smarter →", Style::default().fg(Color::Green)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(title).alignment(Alignment::Center),
+            Rect {
+                height: 1,
+                ..layout.body
+            },
+        );
+        self.render_slider(
+            frame,
+            Rect {
+                y: layout.body.y.saturating_add(2),
+                height: 2,
+                ..layout.body
+            },
+            theme,
+        );
+    }
+}
+
+fn model_index(model: Model) -> usize {
+    MODELS
+        .iter()
+        .position(|candidate| *candidate == model)
+        .unwrap_or(2)
+}
+
+fn model_name(model: Model) -> &'static str {
+    match model {
+        Model::Luna => "Luna",
+        Model::Terra => "Terra",
+        Model::Sol => "Sol",
+        _ => "Sol",
+    }
+}
+
+fn model_color(theme: &Theme, model: Model) -> Color {
+    match model {
+        Model::Luna => theme.thinking_low(),
+        Model::Terra => theme.thinking_high(),
+        Model::Sol => theme.thinking_max(),
+        _ => theme.thinking_max(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn selection_moves_linearly_and_does_not_wrap() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Sol);
+
+        selector.update_key(key(KeyCode::Right), now);
+        assert_eq!(selector.selected, 2);
+        selector.update_key(key(KeyCode::Left), now);
+        assert_eq!(selector.selected, 1);
+        selector.update_key(key(KeyCode::Left), now);
+        selector.update_key(key(KeyCode::Left), now);
+        assert_eq!(selector.selected, 0);
+    }
+
+    #[test]
+    fn applying_returns_the_selected_model() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Sol);
+        selector.update_key(key(KeyCode::Left), now);
+
+        let update = selector.update_key(key(KeyCode::Enter), now);
+
+        assert_eq!(update.effects, [ModelSelectorEffect::Apply(Model::Terra)]);
+    }
+
+    #[test]
+    fn animation_reaches_the_selected_stop() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Luna);
+        selector.update_key(key(KeyCode::Right), now);
+        assert!(selector.animation_deadline().is_some());
+
+        selector.update(ModelSelectorEvent::AnimationFrame(now + ANIMATION_DURATION));
+
+        assert_eq!(selector.displayed_position, 1.0);
+        assert!(selector.animation_deadline().is_none());
+    }
+}

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -436,6 +436,7 @@ impl RootNode {
     }
 
     pub(crate) fn set_model(&mut self, model: Model) {
+        self.transcript.component_mut().set_model(model);
         let _ = self
             .composer
             .component_mut()
@@ -5036,7 +5037,7 @@ mod tests {
         terminal
             .draw(|frame| root.render(frame, frame.area(), &theme))
             .unwrap();
-        let plasma = terminal
+        let artwork = terminal
             .backend()
             .buffer()
             .content()
@@ -5045,12 +5046,8 @@ mod tests {
             .flatten()
             .filter(|cell| cell.symbol() != " ")
             .collect::<Vec<_>>();
-        assert!(!plasma.is_empty());
-        assert!(
-            plasma
-                .iter()
-                .all(|cell| matches!(cell.fg, Color::Yellow) || cell.fg == theme.code_text())
-        );
+        assert!(!artwork.is_empty());
+        assert!(artwork.iter().all(|cell| cell.fg == Color::Yellow));
     }
 
     #[test]

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -800,7 +800,7 @@ impl RootNode {
         if is_control_key(&event, 's') {
             return self.open_effort();
         }
-        if is_control_key(&event, 'm') {
+        if is_control_key(&event, 'd') {
             return self.open_model();
         }
         if is_control_key(&event, 'r') {
@@ -847,6 +847,7 @@ impl RootNode {
             let position = Position::new(mouse.column, mouse.row);
             match self.composer.component().chrome_target(position) {
                 Some(ComposerChromeTarget::Effort) => return self.open_effort(),
+                Some(ComposerChromeTarget::Model) => return self.open_model(),
                 Some(ComposerChromeTarget::Subagents) => {
                     self.overlay = Some(Overlay::Subagents(SubagentOverlay::Tree));
                     return ComponentUpdate::render(RenderRequest::Immediate);
@@ -3144,14 +3145,21 @@ mod tests {
     }
 
     #[test]
-    fn clicking_composer_chrome_opens_effort_and_subagents() {
+    fn clicking_composer_chrome_opens_model_effort_and_subagents() {
         let mut terminal = Terminal::new(TestBackend::new(100, 16)).unwrap();
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
         terminal
             .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
             .unwrap();
         let top = root.composer_area.y;
+        let model_x = text_column(terminal.backend().buffer(), top, "gpt-5.6-sol");
         let effort_x = text_column(terminal.backend().buffer(), top, "medium");
+        assert_eq!(
+            root.composer
+                .component()
+                .chrome_target(Position::new(model_x, top)),
+            Some(ComposerChromeTarget::Model)
+        );
         assert_eq!(
             root.composer
                 .component()
@@ -3159,6 +3167,10 @@ mod tests {
             Some(ComposerChromeTarget::Effort)
         );
 
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), model_x, top));
+        assert!(matches!(root.overlay, Some(Overlay::Model(_))));
+
+        root.overlay = None;
         root.update(mouse(
             MouseEventKind::Down(MouseButton::Left),
             effort_x,
@@ -5154,10 +5166,10 @@ mod tests {
     }
 
     #[test]
-    fn control_m_selects_a_model_only_before_the_first_prompt() {
+    fn control_d_selects_a_model_only_before_the_first_prompt() {
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
 
-        let opened = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        let opened = root.update(key(KeyCode::Char('d'), KeyModifiers::CONTROL));
         assert!(matches!(&root.overlay, Some(Overlay::Model(_))));
         assert_eq!(opened.render, super::RenderRequest::Immediate);
 
@@ -5167,7 +5179,7 @@ mod tests {
 
         root.interactive = true;
         root.thread = super::ThreadState::Started;
-        let blocked = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        let blocked = root.update(key(KeyCode::Char('d'), KeyModifiers::CONTROL));
         assert!(blocked.effects.is_empty());
         assert!(root.overlay.is_none());
     }
@@ -5180,7 +5192,7 @@ mod tests {
         let mut fork = root.fork(Path::new("/work"), ReasoningEffort::Medium);
 
         assert_eq!(fork.composer().model(), Model::Luna);
-        let update = fork.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        let update = fork.update(key(KeyCode::Char('d'), KeyModifiers::CONTROL));
         assert!(update.effects.is_empty());
         assert!(fork.overlay.is_none());
     }

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -11,6 +11,7 @@ use super::{
     floating::Floating,
     keybindings::{KeybindingsEffect, KeybindingsEvent, KeybindingsHelp},
     memory::{MemoryBrowser, MemoryBrowserEffect, MemoryBrowserEvent},
+    model_selector::{ModelSelector, ModelSelectorEffect, ModelSelectorEvent},
     node::{Component, ComponentUpdate, Node, RenderRequest},
     queue::{MessageQueue, QueueEffect, QueueEvent, QueueId},
     recent_prompt_picker::{RecentPromptPicker, RecentPromptPickerEffect, RecentPromptPickerEvent},
@@ -40,6 +41,7 @@ use crate::{
     },
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -183,6 +185,7 @@ pub(crate) enum RootEvent {
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
         skills: Arc<[Skill]>,
     },
     NotifyError(String),
@@ -248,6 +251,7 @@ pub(crate) enum RootEffect {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
     },
+    SetModel(Model),
     SetFastMode(bool),
     SetMaxSubagents(usize),
     SetTheme(ThemeMode),
@@ -262,6 +266,7 @@ enum Overlay {
     Actions(Node<ActionsMenu>),
     ContextDiagnostics(Node<ContextDiagnosticsPanel>),
     Effort(Node<EffortSelector>),
+    Model(Node<ModelSelector>),
     Theme(Node<ThemeSelector>),
     FileFinder(FileMention),
     Skills(SkillMention),
@@ -293,6 +298,12 @@ struct SkillMention {
 enum ThreadState {
     New,
     Started,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum DraftReset {
+    Clear,
+    Preserve,
 }
 
 /// Owns layout and routing so future screen components do not widen the event loop.
@@ -372,6 +383,7 @@ impl RootNode {
                 self.composer.component().context_tokens(),
             ));
         root.set_fast_mode(self.composer.component().fast_mode());
+        root.set_model(self.composer.component().model());
         root.set_reasoning_modes(
             self.composer.component().reasoning_mode(),
             self.preferred_reasoning_mode,
@@ -423,6 +435,13 @@ impl RootNode {
             .update(ComposerEvent::SetFastMode(enabled));
     }
 
+    pub(crate) fn set_model(&mut self, model: Model) {
+        let _ = self
+            .composer
+            .component_mut()
+            .update(ComposerEvent::SetModel(model));
+    }
+
     pub(crate) fn set_reasoning_modes(&mut self, actual: ReasoningMode, preferred: ReasoningMode) {
         self.preferred_reasoning_mode = preferred;
         let _ = self
@@ -450,10 +469,15 @@ impl RootNode {
         thinking: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
+        draft_reset: DraftReset,
     ) {
         let current_draft = self.composer.component_mut().take_draft();
-        let replaced_draft = current_draft.is_some();
-        let discarded_draft = current_draft.or_else(|| self.discarded_draft.take());
+        let previous_discarded_draft = self.discarded_draft.take();
+        let replaced_draft = current_draft.is_some() && matches!(draft_reset, DraftReset::Clear);
+        let (preserved_draft, discarded_draft) = match draft_reset {
+            DraftReset::Clear => (None, current_draft.or(previous_discarded_draft)),
+            DraftReset::Preserve => (current_draft, previous_discarded_draft),
+        };
         let fork_available = self.fork_available;
         let memory_enabled = self.memory_enabled;
         let theme_mode = self.theme_mode;
@@ -465,6 +489,9 @@ impl RootNode {
         self.memory_enabled = memory_enabled;
         self.theme_mode = theme_mode;
         self.set_max_subagents(max_subagents);
+        if let Some(draft) = preserved_draft {
+            self.composer.component_mut().restore_draft(draft);
+        }
         if replaced_draft {
             self.show_draft_saved();
         }
@@ -532,6 +559,7 @@ impl RootNode {
             thinking,
             reasoning_mode,
             preferred_reasoning_mode,
+            DraftReset::Clear,
         );
         self.set_fast_mode(fast_mode);
         self.transcript = Node::new(projection.transcript);
@@ -561,12 +589,13 @@ impl RootNode {
     }
 
     pub(crate) fn animation_deadline(&self) -> Option<Instant> {
-        let effort = match &self.overlay {
+        let selector = match &self.overlay {
             Some(Overlay::Effort(selector)) => selector.component().animation_deadline(),
+            Some(Overlay::Model(selector)) => selector.component().animation_deadline(),
             _ => None,
         };
         [
-            effort,
+            selector,
             self.transcript.component().animation_deadline(),
             self.composer.component().animation_deadline(),
             self.queue.component().animation_deadline(),
@@ -660,6 +689,7 @@ impl RootNode {
                 Overlay::Actions(actions) => actions.render(frame, area, theme),
                 Overlay::ContextDiagnostics(panel) => panel.render(frame, area, theme),
                 Overlay::Effort(selector) => selector.render(frame, area, theme),
+                Overlay::Model(selector) => selector.render(frame, area, theme),
                 Overlay::Theme(selector) => selector.render(frame, area, theme),
                 Overlay::FileFinder(mention) => mention.finder.render(frame, area, theme),
                 Overlay::Skills(mention) => mention.picker.render(frame, area, theme),
@@ -769,6 +799,9 @@ impl RootNode {
         }
         if is_control_key(&event, 's') {
             return self.open_effort();
+        }
+        if is_control_key(&event, 'm') {
+            return self.open_model();
         }
         if is_control_key(&event, 'r') {
             return self.load_recent_prompts();
@@ -897,6 +930,7 @@ impl RootNode {
                     fork: self.fork_available,
                     fast_mode: self.composer.component().fast_mode(),
                     memory: self.memory_enabled,
+                    model: self.thread == ThreadState::New,
                 },
             ))));
             return ComponentUpdate::render(RenderRequest::Immediate);
@@ -1138,6 +1172,9 @@ impl RootNode {
             Some(Overlay::Actions(_)) => self.update_actions(event),
             Some(Overlay::ContextDiagnostics(_)) => self.update_context_diagnostics(event),
             Some(Overlay::Effort(_)) => self.update_effort(EffortEvent::Terminal { event, now }),
+            Some(Overlay::Model(_)) => {
+                self.update_model(ModelSelectorEvent::Terminal { event, now })
+            }
             Some(Overlay::Theme(_)) => {
                 self.update_theme_selector(ThemeSelectorEvent::Terminal(event))
             }
@@ -1355,6 +1392,9 @@ impl RootNode {
             Some(ActionsEffect::Trigger(Action::Effort)) => {
                 return self.open_effort();
             }
+            Some(ActionsEffect::Trigger(Action::Model)) => {
+                return self.open_model();
+            }
             Some(ActionsEffect::Trigger(Action::FastMode)) => {
                 self.overlay = None;
                 let enabled = !self.composer.component().fast_mode();
@@ -1521,6 +1561,16 @@ impl RootNode {
         self.overlay = Some(Overlay::Effort(Node::new(EffortSelector::new(
             self.composer.component().effort(),
             self.preferred_reasoning_mode == ReasoningMode::Pro,
+        ))));
+        ComponentUpdate::render(RenderRequest::Immediate)
+    }
+
+    fn open_model(&mut self) -> ComponentUpdate<RootEffect> {
+        if self.thread != ThreadState::New {
+            return ComponentUpdate::none();
+        }
+        self.overlay = Some(Overlay::Model(Node::new(ModelSelector::new(
+            self.composer.component().model(),
         ))));
         ComponentUpdate::render(RenderRequest::Immediate)
     }
@@ -1865,6 +1915,42 @@ impl RootNode {
         }
     }
 
+    fn update_model(&mut self, event: ModelSelectorEvent) -> ComponentUpdate<RootEffect> {
+        let Some(Overlay::Model(selector)) = &mut self.overlay else {
+            return ComponentUpdate::none();
+        };
+        let update = selector.update(event);
+        let Some(effect) = update.effects.into_iter().next() else {
+            return ComponentUpdate {
+                effects: Vec::new(),
+                render: update.render,
+            };
+        };
+
+        self.overlay = None;
+        match effect {
+            ModelSelectorEffect::Dismiss => ComponentUpdate::render(RenderRequest::Immediate),
+            ModelSelectorEffect::Apply(model) if model == self.composer.component().model() => {
+                ComponentUpdate::render(RenderRequest::Immediate)
+            }
+            ModelSelectorEffect::Apply(model) => {
+                self.interactive = false;
+                let _ = self
+                    .composer
+                    .component_mut()
+                    .update(ComposerEvent::Activity {
+                        active: true,
+                        status: Some(format!("Starting {} session…", model_name(model))),
+                        now: Instant::now(),
+                    });
+                ComponentUpdate {
+                    effects: vec![RootEffect::SetModel(model)],
+                    render: RenderRequest::Immediate,
+                }
+            }
+        }
+    }
+
     fn update_focus(&mut self) -> ComponentUpdate<RootEffect> {
         let focus_queue = !self.queue.component().focused() && !self.queue.component().is_empty();
         self.queue.component_mut().set_focused(focus_queue);
@@ -2081,6 +2167,7 @@ impl RootNode {
             RenderRequest::None
         };
         let effort = self.update_effort(EffortEvent::AnimationFrame(now));
+        let model = self.update_model(ModelSelectorEvent::AnimationFrame(now));
         let transcript = self.update_transcript(TranscriptEvent::AnimationFrame(now));
         let composer =
             self.update_composer(ComposerEvent::AnimationFrame(now), RenderRequest::Streaming);
@@ -2103,9 +2190,15 @@ impl RootNode {
             RenderRequest::None
         };
         ComponentUpdate {
-            effects: effort.effects.into_iter().chain(composer.effects).collect(),
+            effects: effort
+                .effects
+                .into_iter()
+                .chain(model.effects)
+                .chain(composer.effects)
+                .collect(),
             render: effort
                 .render
+                .max(model.render)
                 .max(transcript.render)
                 .max(composer.render)
                 .max(queue.render)
@@ -2419,6 +2512,7 @@ impl Component for RootNode {
                 reasoning_mode,
                 preferred_reasoning_mode,
                 fast_mode,
+                model,
                 skills,
             } => {
                 let workspace = self.workspace.clone();
@@ -2430,6 +2524,7 @@ impl Component for RootNode {
                     fast_mode,
                     *projection,
                 );
+                self.set_model(model);
                 self.set_skills(skills);
                 ComponentUpdate::render(RenderRequest::Immediate)
             }
@@ -2678,6 +2773,15 @@ fn is_file_query_character(character: char) -> bool {
     character.is_alphanumeric() || matches!(character, '_' | '-' | '.' | '/')
 }
 
+fn model_name(model: Model) -> &'static str {
+    match model {
+        Model::Luna => "Luna",
+        Model::Terra => "Terra",
+        Model::Sol => "Sol",
+        _ => "Sol",
+    }
+}
+
 fn is_skill_query_character(character: char) -> bool {
     character.is_ascii_alphanumeric() || character == '-'
 }
@@ -2764,8 +2868,9 @@ fn is_plain_key(event: &Event, character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        Component, ComposerChromeTarget, ConfirmationAction, Overlay, RenderRequest, RootEffect,
-        RootEvent, RootNode, SessionListKind, SubagentOverlay, ThreadState, TranscriptEvent,
+        Component, ComposerChromeTarget, ConfirmationAction, DraftReset, Overlay, RenderRequest,
+        RootEffect, RootEvent, RootNode, SessionListKind, SubagentOverlay, ThreadState,
+        TranscriptEvent,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -2784,9 +2889,12 @@ mod tests {
         Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
         MouseEventKind,
     };
-    use nanocodex::agent::{
-        events::{AgentEvent, AgentEventKind},
-        input::{PromptInput, UserInput},
+    use nanocodex::{
+        Model,
+        agent::{
+            events::{AgentEvent, AgentEventKind},
+            input::{PromptInput, UserInput},
+        },
     };
     use ratatui::{
         Terminal,
@@ -4000,6 +4108,7 @@ mod tests {
             ReasoningEffort::High,
             ReasoningMode::Standard,
             ReasoningMode::Standard,
+            DraftReset::Clear,
         );
         root.update(key(KeyCode::Char('z'), KeyModifiers::CONTROL));
 
@@ -4966,6 +5075,7 @@ mod tests {
             ReasoningEffort::Medium,
             ReasoningMode::Pro,
             ReasoningMode::Pro,
+            DraftReset::Clear,
         );
         assert_eq!(root.composer().reasoning_mode(), ReasoningMode::Pro);
 
@@ -5041,6 +5151,59 @@ mod tests {
         let reopened = root.update(key(KeyCode::Char('s'), KeyModifiers::CONTROL));
         assert!(matches!(&root.overlay, Some(Overlay::Effort(_))));
         assert_eq!(reopened.render, super::RenderRequest::Immediate);
+    }
+
+    #[test]
+    fn control_m_selects_a_model_only_before_the_first_prompt() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+
+        let opened = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        assert!(matches!(&root.overlay, Some(Overlay::Model(_))));
+        assert_eq!(opened.render, super::RenderRequest::Immediate);
+
+        root.update(key(KeyCode::Left, KeyModifiers::NONE));
+        let selected = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(selected.effects, [RootEffect::SetModel(Model::Terra)]);
+
+        root.interactive = true;
+        root.thread = super::ThreadState::Started;
+        let blocked = root.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        assert!(blocked.effects.is_empty());
+        assert!(root.overlay.is_none());
+    }
+
+    #[test]
+    fn fork_inherits_the_model_and_cannot_change_it() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.set_model(Model::Luna);
+
+        let mut fork = root.fork(Path::new("/work"), ReasoningEffort::Medium);
+
+        assert_eq!(fork.composer().model(), Model::Luna);
+        let update = fork.update(key(KeyCode::Char('m'), KeyModifiers::CONTROL));
+        assert!(update.effects.is_empty());
+        assert!(fork.overlay.is_none());
+    }
+
+    #[test]
+    fn model_action_opens_only_for_a_new_thread() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "intelligence".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(root.overlay, Some(Overlay::Model(_))));
+
+        root.overlay = None;
+        root.thread = ThreadState::Started;
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "intelligence".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        let blocked = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(blocked.effects.is_empty());
+        assert!(matches!(root.overlay, Some(Overlay::Actions(_))));
     }
 
     #[test]
@@ -5291,6 +5454,7 @@ mod tests {
             ReasoningEffort::Low,
             ReasoningMode::Standard,
             ReasoningMode::Standard,
+            DraftReset::Clear,
         );
         let fork = root.fork(Path::new("/work"), ReasoningEffort::Low);
         assert!(root.memory_enabled);
@@ -5332,6 +5496,7 @@ mod tests {
             ReasoningEffort::Medium,
             ReasoningMode::Standard,
             ReasoningMode::Standard,
+            DraftReset::Clear,
         );
 
         assert!(root.interactive);

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -3183,6 +3183,7 @@ mod tests {
             AgentDescriptor {
                 id: AgentId::new(1),
                 session_id: "child".to_owned(),
+                model: Model::Sol,
                 role: "worker".to_owned(),
                 task: "work".to_owned(),
                 parent: None,
@@ -3210,6 +3211,7 @@ mod tests {
         root.update(RootEvent::Subagent(AgentUpdate::Added(AgentDescriptor {
             id: AgentId::new(1),
             session_id: "child".to_owned(),
+            model: Model::Sol,
             role: "worker".to_owned(),
             task: "verify ordering".to_owned(),
             parent: None,
@@ -3296,6 +3298,7 @@ mod tests {
             root.update(RootEvent::Subagent(AgentUpdate::Added(AgentDescriptor {
                 id: AgentId::new(id),
                 session_id: format!("child-{id}"),
+                model: Model::Sol,
                 role: role.to_owned(),
                 task: "coordinate with a peer".to_owned(),
                 parent: None,
@@ -3338,6 +3341,7 @@ mod tests {
             AgentDescriptor {
                 id: AgentId::new(1),
                 session_id: "child".to_owned(),
+                model: Model::Sol,
                 role: "worker".to_owned(),
                 task: "work".to_owned(),
                 parent: None,

--- a/src/tui/components/subagents.rs
+++ b/src/tui/components/subagents.rs
@@ -16,6 +16,7 @@ use crate::{
     tui::{theme::Theme, transcript::TranscriptRecord},
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind};
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::Rect,
@@ -423,14 +424,19 @@ impl SubagentTree {
         let Some(node) = self.node_mut(id) else {
             return;
         };
-        let title = format!("{} · #{}", node.descriptor.role, node.descriptor.id);
+        let title = format!(
+            "{} · {} · #{}",
+            node.descriptor.role,
+            model_name(node.descriptor.model),
+            node.descriptor.id
+        );
         let keys: &[&str] = if node.transcript.component().expandables_focused() {
             &FOCUSED_ENTRY_KEYS
         } else {
             &TRANSCRIPT_KEYS
         };
         let layout = Floating::new(&title, area.width, area.height, keys)
-            .colors(theme.border(), theme.accent())
+            .colors(theme.border(), theme.model(node.descriptor.model))
             .render(frame, area, theme);
         node.transcript.render(frame, layout.body, theme);
     }
@@ -673,6 +679,13 @@ impl SubagentTree {
                     self.nodes.len(),
                     self.filter.label()
                 )),
+                Span::styled("    Model  ", Style::default().fg(theme.muted())),
+                Span::styled(
+                    model_name(node.descriptor.model),
+                    Style::default()
+                        .fg(theme.model(node.descriptor.model))
+                        .add_modifier(Modifier::BOLD),
+                ),
             ]),
             Line::from(vec![
                 Span::styled("Session  ", Style::default().fg(theme.muted())),
@@ -1045,6 +1058,15 @@ fn unix_time_ms() -> u64 {
         })
 }
 
+fn model_name(model: Model) -> &'static str {
+    match model {
+        Model::Luna => "Luna",
+        Model::Terra => "Terra",
+        Model::Sol => "Sol",
+        _ => "Sol",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{SubagentEffect, SubagentTree};
@@ -1058,7 +1080,10 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use ratatui::{Terminal, backend::TestBackend, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{
@@ -1070,6 +1095,7 @@ mod tests {
         AgentDescriptor {
             id: AgentId::new(1),
             session_id: "child-session".to_owned(),
+            model: Model::Luna,
             role: "researcher".to_owned(),
             task: "Trace the event lifecycle".to_owned(),
             parent: None,
@@ -1205,6 +1231,7 @@ mod tests {
         AgentDescriptor {
             id: AgentId::new(2),
             session_id: "second-session".to_owned(),
+            model: Model::Sol,
             role: "reviewer".to_owned(),
             task: "Verify the event ordering".to_owned(),
             parent: None,
@@ -1215,6 +1242,7 @@ mod tests {
         AgentDescriptor {
             id: AgentId::new(id),
             session_id: format!("agent-{id}"),
+            model: Model::Sol,
             role: role.to_owned(),
             task: format!("Task for {role}"),
             parent: parent.map(AgentId::new),
@@ -1419,7 +1447,19 @@ mod tests {
         assert!(rendered.contains("researcher"));
         assert!(rendered.contains("running · 0 children"));
         assert!(rendered.contains("Trace the event lifecycle"));
+        assert!(rendered.contains("Model  Luna"));
         let buffer = terminal.backend().buffer();
+        let luna = buffer
+            .content
+            .windows(4)
+            .find(|cells| {
+                cells
+                    .iter()
+                    .map(|cell| cell.symbol())
+                    .eq(["L", "u", "n", "a"])
+            })
+            .unwrap();
+        assert_eq!(luna[0].fg, Color::White);
         assert_eq!(buffer[(0, 0)].symbol(), "╭");
         assert_eq!(buffer[(89, 39)].symbol(), "╯");
     }

--- a/src/tui/components/transcript/empty.rs
+++ b/src/tui/components/transcript/empty.rs
@@ -1,6 +1,7 @@
 //! Demand-driven empty transcript animation.
 
-use crate::{app::config::ReasoningEffort, tui::theme::Theme};
+use crate::tui::theme::Theme;
+use nanocodex::Model;
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -13,13 +14,21 @@ use std::{
 use unicode_width::UnicodeWidthStr;
 
 const FRAME_INTERVAL: Duration = Duration::from_millis(120);
-const FRAME_COUNT: usize = 48;
-const MAX_WIDTH: u16 = 60;
-const MAX_HEIGHT: u16 = 9;
-const HORIZONTAL_MARGIN: u16 = 4;
-const VERTICAL_MARGIN: u16 = 2;
-const RAMP: [&str; 9] = ["·", ":", "-", "=", "+", "*", "#", "%", "@"];
+const FRAME_COUNT: usize = 120;
+const MAX_WIDTH: u16 = 35;
+const MAX_HEIGHT: u16 = 17;
+const HORIZONTAL_MARGIN: u16 = 2;
+const VERTICAL_MARGIN: u16 = 1;
+const BODY_RADIUS_X: f64 = 13.0;
+const BODY_RADIUS_Y: f64 = 6.0;
+const SHADING_RAMP: [&str; 9] = ["·", ":", "-", "=", "+", "*", "#", "%", "@"];
 const WORDMARK: &str = "𝒕𝒂𝒄𝒕";
+
+#[derive(Clone, Copy)]
+struct CelestialCell {
+    symbol: &'static str,
+    intensity: f64,
+}
 
 pub(super) struct EmptyLogo {
     started_at: Instant,
@@ -56,76 +65,196 @@ impl EmptyLogo {
         true
     }
 
-    pub(super) fn render(
-        &self,
-        frame: &mut Frame<'_>,
-        area: Rect,
-        theme: &Theme,
-        effort: ReasoningEffort,
-    ) {
-        let Some(mask) = mask(area) else {
+    pub(super) fn render(&self, frame: &mut Frame<'_>, area: Rect, theme: &Theme, model: Model) {
+        let Some(canvas) = canvas(area) else {
             return;
         };
         let phase = TAU * self.frame as f64 / FRAME_COUNT as f64;
-        let center_x = f64::from(mask.width.saturating_sub(1)) / 2.0;
-        let center_y = f64::from(mask.height.saturating_sub(1)) / 2.0;
+        let (radius_x, radius_y) = radii(canvas);
+        let center_x = f64::from(canvas.width.saturating_sub(1)) / 2.0;
+        let center_y = f64::from(canvas.height.saturating_sub(1)) / 2.0;
 
-        for row in 0..mask.height {
-            let inset = corner_inset(row, mask.height).min(mask.width.saturating_sub(1) / 2);
-            for column in inset..mask.width.saturating_sub(inset) {
-                let x = f64::from(column) - center_x;
-                let y = (f64::from(row) - center_y) * 2.2;
-                let distance =
-                    ((x - phase.cos() * 8.0).powi(2) + (y - phase.sin() * 3.0).powi(2)).sqrt();
-                let value = (x * 0.23 + phase).sin()
-                    + (x * 0.11 + y * 0.41 - phase * 2.0).sin()
-                    + (distance * 0.31 - phase).sin();
-                let level = (((value + 3.0) / 6.0) * (RAMP.len() - 1) as f64)
-                    .round()
-                    .clamp(0.0, (RAMP.len() - 1) as f64) as usize;
-                let style = plasma_style(level, theme, effort);
-                frame.buffer_mut()[Position::new(mask.x + column, mask.y + row)]
-                    .set_symbol(RAMP[level])
-                    .set_style(style);
+        for row in 0..canvas.height {
+            for column in 0..canvas.width {
+                let x = (f64::from(column) - center_x) / radius_x;
+                let y = (f64::from(row) - center_y) / radius_y;
+                let cell = match model {
+                    Model::Luna => moon(x, y, phase),
+                    Model::Terra => earth(x, y, phase),
+                    Model::Sol => sun(x, y, phase),
+                    _ => sun(x, y, phase),
+                };
+                let Some(cell) = cell else {
+                    continue;
+                };
+                frame.buffer_mut()[Position::new(canvas.x + column, canvas.y + row)]
+                    .set_symbol(cell.symbol)
+                    .set_style(celestial_style(cell.intensity, theme, model));
             }
         }
-        render_wordmark(frame, mask, theme);
+        render_wordmark(frame, canvas, theme, model);
     }
 }
 
-fn render_wordmark(frame: &mut Frame<'_>, mask: Rect, theme: &Theme) {
+fn moon(x: f64, y: f64, phase: f64) -> Option<CelestialCell> {
+    let distance = x.hypot(y);
+    if distance > 1.0 {
+        return orbital_glint(x, y, phase);
+    }
+
+    let craters = [
+        crater(x, y, -0.43, -0.27, 0.18),
+        crater(x, y, 0.38, 0.34, 0.23),
+        crater(x, y, 0.24, -0.42, 0.11),
+        crater(x, y, -0.15, 0.48, 0.13),
+    ]
+    .into_iter()
+    .fold(0.0_f64, f64::max);
+    let terminator = ((x + 0.72) / 1.25).clamp(0.0, 1.0);
+    let shimmer = (x * 8.0 + y * 5.0 + phase * 0.7).sin() * 0.08;
+    let edge = ((1.0 - distance) * 3.5).clamp(0.0, 1.0);
+    let intensity =
+        (0.2 + terminator * 0.65 + edge * 0.15 + shimmer - craters * 0.34).clamp(0.05, 1.0);
+    Some(CelestialCell {
+        symbol: density_symbol(intensity),
+        intensity,
+    })
+}
+
+fn crater(x: f64, y: f64, center_x: f64, center_y: f64, radius: f64) -> f64 {
+    let distance = (x - center_x).hypot(y - center_y) / radius;
+    if distance >= 1.0 {
+        0.0
+    } else {
+        (1.0 - distance).powi(2)
+    }
+}
+
+fn orbital_glint(x: f64, y: f64, phase: f64) -> Option<CelestialCell> {
+    let glint_x = phase.cos() * 1.18;
+    let glint_y = phase.sin() * 1.08;
+    ((x - glint_x).hypot(y - glint_y) < 0.08).then_some(CelestialCell {
+        symbol: "✦",
+        intensity: 1.0,
+    })
+}
+
+fn earth(x: f64, y: f64, phase: f64) -> Option<CelestialCell> {
+    let distance = x.hypot(y);
+    if distance > 1.0 {
+        return (distance < 1.07 && ((x * 13.0 + y * 7.0 + phase).sin() > 0.85)).then_some(
+            CelestialCell {
+                symbol: "·",
+                intensity: 0.45,
+            },
+        );
+    }
+
+    let longitude = x.atan2((1.0 - x * x).max(0.0).sqrt()) + phase * 0.72;
+    let latitude = y.asin();
+    let land = (longitude * 2.1).sin()
+        + (longitude * 3.7 - latitude * 4.2).cos() * 0.72
+        + (longitude * 5.3 + latitude * 2.6).sin() * 0.36
+        + latitude.sin() * 0.28;
+    let edge = ((1.0 - distance) * 4.0).clamp(0.0, 1.0);
+    let light = (0.66 + x * 0.2 - y * 0.08).clamp(0.25, 0.95) * (0.55 + edge * 0.45);
+    let intensity = if land > 0.35 {
+        light.max(0.6)
+    } else {
+        light * 0.48
+    };
+    Some(CelestialCell {
+        symbol: density_symbol(intensity),
+        intensity,
+    })
+}
+
+fn sun(x: f64, y: f64, phase: f64) -> Option<CelestialCell> {
+    let distance = x.hypot(y);
+    if distance > 1.0 {
+        return corona(x, y, distance, phase);
+    }
+
+    let turbulence = (x * 9.0 + phase * 1.4).sin()
+        + (y * 8.0 - phase * 1.9).cos()
+        + ((x - phase.cos() * 0.28).hypot(y - phase.sin() * 0.2) * 13.0 - phase).sin();
+    let edge = ((1.0 - distance) * 4.5).clamp(0.0, 1.0);
+    let intensity = (0.68 + turbulence * 0.09 + edge * 0.2).clamp(0.3, 1.0);
+    Some(CelestialCell {
+        symbol: density_symbol(intensity),
+        intensity,
+    })
+}
+
+fn corona(x: f64, y: f64, distance: f64, phase: f64) -> Option<CelestialCell> {
+    if distance > 1.3 {
+        return None;
+    }
+    let angle = y.atan2(x);
+    let billow = (angle * 3.0 + phase * 0.7).sin() * 0.06
+        + (angle * 7.0 - phase * 1.1).sin() * 0.035
+        + (angle * 11.0 + phase * 0.45).cos() * 0.02;
+    let reach = 1.14 + billow;
+    if distance > reach {
+        return None;
+    }
+    let depth = ((reach - distance) / (reach - 1.0)).clamp(0.0, 1.0);
+    let shimmer = (angle * 13.0 - phase * 1.3 + distance * 9.0).sin() * 0.06;
+    let intensity = (0.16 + depth * 0.48 + shimmer).clamp(0.12, 0.68);
+    Some(CelestialCell {
+        symbol: density_symbol(intensity),
+        intensity,
+    })
+}
+
+fn density_symbol(intensity: f64) -> &'static str {
+    let level = (intensity * (SHADING_RAMP.len() - 1) as f64)
+        .round()
+        .clamp(0.0, (SHADING_RAMP.len() - 1) as f64) as usize;
+    SHADING_RAMP[level]
+}
+
+fn celestial_style(intensity: f64, theme: &Theme, model: Model) -> Style {
+    let style = Style::default().fg(theme.model(model));
+    if intensity < 0.4 {
+        style.add_modifier(Modifier::DIM)
+    } else if intensity > 0.78 {
+        style.add_modifier(Modifier::BOLD)
+    } else {
+        style
+    }
+}
+
+fn render_wordmark(frame: &mut Frame<'_>, canvas: Rect, theme: &Theme, model: Model) {
     let width = u16::try_from(WORDMARK.width()).unwrap_or(u16::MAX);
-    if width > mask.width {
+    if width > canvas.width {
         return;
     }
-    let x = mask.x + mask.width.saturating_sub(width) / 2;
-    let y = mask.y + mask.height / 2;
-    frame
-        .buffer_mut()
-        .set_string(x, y, WORDMARK, Style::reset().fg(theme.code_text()));
+    let x = canvas.x + canvas.width.saturating_sub(width) / 2;
+    let y = canvas.y + canvas.height / 2;
+    frame.buffer_mut().set_string(
+        x,
+        y,
+        WORDMARK,
+        Style::reset()
+            .fg(theme.model(model))
+            .add_modifier(Modifier::BOLD),
+    );
 }
 
-fn corner_inset(row: u16, height: u16) -> u16 {
-    let edge_distance = row.min(height.saturating_sub(1).saturating_sub(row));
-    match edge_distance {
-        0 => 3,
-        1 => 1,
-        _ => 0,
-    }
+fn radii(canvas: Rect) -> (f64, f64) {
+    let available_x = f64::from(canvas.width.saturating_sub(1)) / 2.0;
+    let available_y = f64::from(canvas.height.saturating_sub(1)) / 2.0;
+    let scale = (available_x / (BODY_RADIUS_X * 1.4))
+        .min(available_y / (BODY_RADIUS_Y * 1.4))
+        .min(1.0);
+    (
+        (BODY_RADIUS_X * scale).max(0.5),
+        (BODY_RADIUS_Y * scale).max(0.5),
+    )
 }
 
-fn plasma_style(level: usize, theme: &Theme, effort: ReasoningEffort) -> Style {
-    let style = Style::default().fg(theme.effort(effort));
-    if level < 3 {
-        return style.add_modifier(Modifier::DIM);
-    }
-    if level >= 6 {
-        return style.add_modifier(Modifier::BOLD);
-    }
-    style
-}
-
-fn mask(area: Rect) -> Option<Rect> {
+fn canvas(area: Rect) -> Option<Rect> {
     if area.is_empty() {
         return None;
     }
@@ -143,22 +272,16 @@ fn mask(area: Rect) -> Option<Rect> {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmptyLogo, FRAME_INTERVAL, WORDMARK, corner_inset, mask};
-    use crate::{app::config::ReasoningEffort, tui::theme::Theme};
-    use ratatui::{Terminal, backend::TestBackend, layout::Rect};
-    use std::time::Instant;
+    use super::{EmptyLogo, FRAME_INTERVAL, WORDMARK, canvas};
+    use crate::tui::theme::Theme;
+    use nanocodex::Model;
+    use ratatui::{Terminal, backend::TestBackend, layout::Rect, style::Color};
+    use std::{collections::HashSet, time::Instant};
 
-    fn render(logo: &EmptyLogo, width: u16, height: u16) -> Terminal<TestBackend> {
+    fn render(logo: &EmptyLogo, model: Model, width: u16, height: u16) -> Terminal<TestBackend> {
         let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         terminal
-            .draw(|frame| {
-                logo.render(
-                    frame,
-                    frame.area(),
-                    &Theme::default(),
-                    ReasoningEffort::Xhigh,
-                );
-            })
+            .draw(|frame| logo.render(frame, frame.area(), &Theme::default(), model))
             .unwrap();
         terminal
     }
@@ -174,70 +297,64 @@ mod tests {
     }
 
     #[test]
-    fn plasma_is_centered_in_a_wide_shallow_rounded_rectangle() {
+    fn every_model_renders_distinct_round_artwork_in_its_color() {
         let logo = EmptyLogo::new(Instant::now());
-        let terminal = render(&logo, 80, 20);
-        let mask = mask(Rect::new(0, 0, 80, 20)).unwrap();
+        let expected = [
+            (Model::Luna, Color::White),
+            (Model::Terra, Color::Green),
+            (Model::Sol, Color::Yellow),
+        ];
+        let mut renderings = HashSet::new();
 
-        assert_eq!(mask, Rect::new(10, 5, 60, 9));
-        assert!(mask.width > mask.height * 6);
-        for y in mask.y..mask.bottom() {
-            let inset = corner_inset(y - mask.y, mask.height);
-            for x in mask.x + inset..mask.right() - inset {
-                assert_ne!(terminal.backend().buffer()[(x, y)].symbol(), " ");
-            }
+        for (model, color) in expected {
+            let terminal = render(&logo, model, 80, 24);
+            let buffer = terminal.backend().buffer();
+            let occupied = buffer
+                .content()
+                .iter()
+                .filter(|cell| cell.symbol() != " ")
+                .collect::<Vec<_>>();
+
+            assert!(!occupied.is_empty());
+            assert!(occupied.iter().all(|cell| cell.fg == color));
+            assert!(occupied.iter().all(|cell| !matches!(
+                cell.symbol(),
+                "░" | "▒" | "▓" | "█" | "─" | "╱" | "│" | "╲"
+            )));
+            renderings.insert(symbols(&terminal));
         }
-        assert_eq!(terminal.backend().buffer()[(mask.x, mask.y)].symbol(), " ");
-        assert_ne!(
-            terminal.backend().buffer()[(mask.x + 3, mask.y)].symbol(),
-            " "
-        );
+
+        assert_eq!(renderings.len(), 3);
+    }
+
+    #[test]
+    fn celestial_body_is_centered_and_taller_than_the_old_banner() {
+        let logo = EmptyLogo::new(Instant::now());
+        let terminal = render(&logo, Model::Terra, 80, 24);
+        let canvas = canvas(Rect::new(0, 0, 80, 24)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let occupied_rows = (canvas.y..canvas.bottom())
+            .filter(|&y| (canvas.x..canvas.right()).any(|x| buffer[(x, y)].symbol() != " "))
+            .collect::<Vec<_>>();
+
+        assert_eq!(canvas, Rect::new(22, 3, 35, 17));
+        assert!(occupied_rows.len() >= 11);
         assert_eq!(
-            terminal.backend().buffer()[(mask.x - 1, mask.y)].symbol(),
-            " "
+            occupied_rows.first().unwrap() + occupied_rows.last().unwrap(),
+            2 * (canvas.y + canvas.height / 2)
         );
 
-        let narrow = render(&logo, 1, 1);
+        let narrow = render(&logo, Model::Luna, 1, 1);
         assert_ne!(symbols(&narrow), " ");
     }
 
     #[test]
-    fn plasma_uses_the_effort_color_with_multiple_character_densities() {
+    fn wordmark_is_centered_in_the_model_color() {
         let logo = EmptyLogo::new(Instant::now());
-        let terminal = render(&logo, 80, 20);
-        let buffer = terminal.backend().buffer();
-        let colors = buffer
-            .content()
-            .iter()
-            .filter(|cell| cell.symbol() != " ")
-            .map(|cell| cell.fg)
-            .collect::<std::collections::HashSet<_>>();
-        let glyphs = buffer
-            .content()
-            .iter()
-            .filter(|cell| cell.symbol() != " ")
-            .map(|cell| cell.symbol())
-            .collect::<std::collections::HashSet<_>>();
-
-        assert_eq!(
-            colors,
-            [
-                ratatui::style::Color::Red,
-                ratatui::style::Color::Rgb(0xD7, 0xD7, 0xD7),
-            ]
-            .into_iter()
-            .collect()
-        );
-        assert!(glyphs.len() >= 5);
-    }
-
-    #[test]
-    fn literal_script_wordmark_is_centered_and_contrasting() {
-        let logo = EmptyLogo::new(Instant::now());
-        let terminal = render(&logo, 80, 20);
-        let mask = mask(Rect::new(0, 0, 80, 20)).unwrap();
-        let x = mask.x + (mask.width - 4) / 2;
-        let y = mask.y + mask.height / 2;
+        let terminal = render(&logo, Model::Terra, 80, 24);
+        let canvas = canvas(Rect::new(0, 0, 80, 24)).unwrap();
+        let x = canvas.x + (canvas.width - 4) / 2;
+        let y = canvas.y + canvas.height / 2;
         let buffer = terminal.backend().buffer();
         let rendered = (x..x + 4)
             .map(|column| buffer[(column, y)].symbol())
@@ -245,7 +362,7 @@ mod tests {
 
         assert_eq!(rendered, WORDMARK);
         for column in x..x + 4 {
-            assert_eq!(buffer[(column, y)].fg, Theme::default().code_text());
+            assert_eq!(buffer[(column, y)].fg, Color::Green);
         }
     }
 
@@ -253,11 +370,11 @@ mod tests {
     fn animation_advances_only_after_its_deadline() {
         let start = Instant::now();
         let mut logo = EmptyLogo::new(start);
-        let first = symbols(&render(&logo, 60, 12));
+        let first = symbols(&render(&logo, Model::Sol, 60, 18));
 
         assert!(!logo.advance(start + FRAME_INTERVAL / 2));
         assert!(logo.advance(start + FRAME_INTERVAL));
-        assert_ne!(symbols(&render(&logo, 60, 12)), first);
+        assert_ne!(symbols(&render(&logo, Model::Sol, 60, 18)), first);
         assert!(logo.deadline() > start + FRAME_INTERVAL);
     }
 }

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
 use empty::EmptyLogo;
+use nanocodex::Model;
 use ratatui::{
     Frame,
     buffer::Buffer,
@@ -89,6 +90,7 @@ pub(crate) struct Transcript {
     pending_expandable_anchor: Option<PendingExpandableAnchor>,
     empty_logo: EmptyLogo,
     effort: ReasoningEffort,
+    home_model: Model,
     pinned_prompt: Option<PinnedPrompt>,
     updates_banner_area: Option<Rect>,
 }
@@ -253,6 +255,7 @@ impl Transcript {
             pending_expandable_anchor: None,
             empty_logo: EmptyLogo::new(Instant::now()),
             effort,
+            home_model: Model::Sol,
             pinned_prompt: None,
             updates_banner_area: None,
         }
@@ -261,11 +264,16 @@ impl Transcript {
     pub(crate) fn fork_snapshot(&self) -> Self {
         let mut snapshot = Self::with_effort(self.effort);
         snapshot.model = self.model.fork_snapshot();
+        snapshot.home_model = self.home_model;
         snapshot
     }
 
     pub(crate) const fn set_effort(&mut self, effort: ReasoningEffort) {
         self.effort = effort;
+    }
+
+    pub(crate) const fn set_model(&mut self, model: Model) {
+        self.home_model = model;
     }
 
     pub(super) fn render_chrome(&mut self, frame: &mut Frame<'_>, area: Rect, theme: &Theme) {
@@ -1459,7 +1467,7 @@ impl Component for Transcript {
         self.selection_rows.clear();
         Clear.render(area, frame.buffer_mut());
         if self.is_empty() {
-            self.empty_logo.render(frame, area, theme, self.effort);
+            self.empty_logo.render(frame, area, theme, self.home_model);
             return;
         }
         let mut plan = self.render_plan(area.width, area.height, theme);
@@ -1830,7 +1838,10 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use ratatui::{Terminal, backend::TestBackend, layout::Position, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{sync::Arc, time::Duration};
@@ -2548,7 +2559,7 @@ mod tests {
         let mut transcript = Transcript::new();
 
         let empty = render(&mut transcript, 41, 14);
-        assert_ne!(empty.buffer()[(5, 2)].symbol(), " ");
+        assert_ne!(empty.buffer()[(20, 6)].symbol(), " ");
         let deadline = transcript
             .animation_deadline()
             .expect("empty transcript should schedule the logo");
@@ -2561,8 +2572,24 @@ mod tests {
 
         transcript.update(TranscriptEvent::Record(user(1, "hello")));
         let populated = render(&mut transcript, 41, 14);
-        assert_eq!(populated.buffer()[(5, 2)].symbol(), " ");
+        assert_eq!(populated.buffer()[(20, 6)].symbol(), " ");
         assert!(transcript.animation_deadline().is_none());
+    }
+
+    #[test]
+    fn empty_logo_tracks_the_selected_model() {
+        let mut transcript = Transcript::new();
+
+        for (model, color) in [
+            (Model::Luna, Color::White),
+            (Model::Terra, Color::Green),
+            (Model::Sol, Color::Yellow),
+        ] {
+            transcript.set_model(model);
+            let rendered = render(&mut transcript, 41, 14);
+
+            assert_eq!(rendered.buffer()[(20, 6)].fg, color);
+        }
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -464,6 +464,7 @@ pub(crate) async fn run(
                     &restored_config,
                     initial_effort,
                     reasoning_mode,
+                    model,
                     Some(&session_id),
                     Some(snapshot),
                 )?;
@@ -1017,6 +1018,7 @@ pub(crate) async fn run(
                             schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                         }
                         runtime.current_effort = effort;
+                        runtime.subagent_control.set_thinking(effort.into());
                         if pane == PaneId::Main {
                             config.set_thinking(effort);
                         }
@@ -1038,6 +1040,7 @@ pub(crate) async fn run(
                             schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                         }
                         runtime.current_fast_mode = enabled;
+                        runtime.subagent_control.set_fast_mode(enabled);
                         if pane == PaneId::Main {
                             config.set_fast_mode(enabled);
                         }
@@ -2087,6 +2090,7 @@ fn apply_pane_effect(
                     &config,
                     effort,
                     reasoning_mode,
+                    Model::Sol,
                     None,
                     None,
                 );
@@ -2240,6 +2244,7 @@ fn apply_pane_effect(
                         &config,
                         effort,
                         reasoning_mode,
+                        model,
                         Some(&session_id),
                         Some(snapshot),
                     )?;
@@ -2434,7 +2439,14 @@ async fn prepare_handoff(
     let reasoning_mode = config.agent().reasoning_mode();
     let fast_mode = config.agent().fast_mode();
     let task = tokio::task::spawn_blocking(move || {
-        ConfiguredAgent::from_config_with_session(&config, effort, reasoning_mode, None, None)
+        ConfiguredAgent::from_config_with_session(
+            &config,
+            effort,
+            reasoning_mode,
+            Model::Sol,
+            None,
+            None,
+        )
     });
     let configured = tokio::select! {
         result = task => result

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -59,6 +59,7 @@ use crate::{
 };
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
 use futures_util::StreamExt;
+use nanocodex::Model;
 use std::{
     collections::HashMap,
     io::{self, IsTerminal},
@@ -94,6 +95,8 @@ type NewSessionTask = JoinHandle<(
     ReasoningEffort,
     ReasoningMode,
     bool,
+    Model,
+    components::DraftReset,
     Result<ConfiguredAgent>,
 )>;
 
@@ -145,6 +148,7 @@ struct RestoredSession {
     configured: ConfiguredAgent,
     projection: RestoredSessionProjection,
     reasoning_mode: ReasoningMode,
+    model: Model,
 }
 
 enum EditorTarget {
@@ -210,14 +214,21 @@ struct PaneSettings {
     effort: ReasoningEffort,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
+    model: Model,
 }
 
 impl PaneSettings {
-    const fn new(effort: ReasoningEffort, reasoning_mode: ReasoningMode, fast_mode: bool) -> Self {
+    const fn new(
+        effort: ReasoningEffort,
+        reasoning_mode: ReasoningMode,
+        fast_mode: bool,
+        model: Model,
+    ) -> Self {
         Self {
             effort,
             reasoning_mode,
             fast_mode,
+            model,
         }
     }
 }
@@ -258,6 +269,7 @@ struct PaneRuntime {
     current_effort: ReasoningEffort,
     reasoning_mode: ReasoningMode,
     current_fast_mode: bool,
+    current_model: Model,
     active_shells: usize,
     generation: u64,
     subagent_control: SubagentControl,
@@ -429,7 +441,7 @@ pub(crate) async fn run(
         StartupMode::NewSession | StartupMode::ResumeSelector => None,
     };
     let resuming = resume_session_id.is_some();
-    let (configured, restored_projection, reasoning_mode) =
+    let (configured, restored_projection, reasoning_mode, model) =
         if let Some(session_id) = resume_session_id {
             let restored_config = config.clone();
             let config_path = restored_config.path().to_path_buf();
@@ -446,6 +458,7 @@ pub(crate) async fn run(
             let records = records?;
             tokio::task::spawn_blocking(move || -> Result<_> {
                 let reasoning_mode = session::reasoning_mode(&records);
+                let model = session::model(&records);
                 let projection = RootNode::project_session(initial_effort, records);
                 let configured = ConfiguredAgent::from_config_with_session(
                     &restored_config,
@@ -454,7 +467,7 @@ pub(crate) async fn run(
                     Some(&session_id),
                     Some(snapshot),
                 )?;
-                Ok((configured, Some(projection), reasoning_mode))
+                Ok((configured, Some(projection), reasoning_mode, model))
             })
             .await
             .map_err(RuntimeError::SessionTask)??
@@ -463,6 +476,7 @@ pub(crate) async fn run(
                 ConfiguredAgent::from_config(&config)?,
                 None,
                 preferred_reasoning_mode,
+                Model::Sol,
             )
         };
     let mut terminal = TerminalSession::enter().map_err(RuntimeError::Terminal)?;
@@ -491,7 +505,7 @@ pub(crate) async fn run(
                 PaneSession::new(&main_session_id, None, !skills.is_empty())
             },
             &config,
-            PaneSettings::new(initial_effort, reasoning_mode, initial_fast_mode),
+            PaneSettings::new(initial_effort, reasoning_mode, initial_fast_mode, model),
             instructions,
             subagent_control.clone(),
             &writer_sender,
@@ -528,6 +542,7 @@ pub(crate) async fn run(
             projection,
         );
     }
+    root.set_model(model);
     root.set_skills(skills);
     let mut theme = config.theme().clone();
     if let Some(scheme) = theme::detect_system_scheme() {
@@ -938,6 +953,10 @@ pub(crate) async fn run(
                             .get(&PaneId::Main)
                             .expect("main pane must exist")
                             .reasoning_mode;
+                        let model = panes
+                            .get(&PaneId::Main)
+                            .expect("main pane must exist")
+                            .current_model;
                         let subagent_control = panes
                             .get(&PaneId::Main)
                             .expect("main pane must exist")
@@ -966,7 +985,7 @@ pub(crate) async fn run(
                                     skills_catalog_present,
                                 ),
                                 &config,
-                                PaneSettings::new(effort, reasoning_mode, fast_mode),
+                                PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                                 instructions,
                                 subagent_control.clone(),
                                 &writer_sender,
@@ -1171,7 +1190,7 @@ pub(crate) async fn run(
                         let skills = install_configured_agent(
                             pane,
                             configured,
-                            PaneSettings::new(effort, reasoning_mode, fast_mode),
+                            PaneSettings::new(effort, reasoning_mode, fast_mode, Model::Sol),
                             &config,
                             &mut panes,
                             &commands,
@@ -1211,14 +1230,14 @@ pub(crate) async fn run(
             }, if new_session_task.is_some() && !stopping => {
                 new_session_task = None;
                 input = Some(EventStream::new());
-                let (pane, effort, reasoning_mode, fast_mode, configured) =
+                let (pane, effort, reasoning_mode, fast_mode, model, draft_reset, configured) =
                     result.map_err(RuntimeError::NewSessionTask)?;
                 match configured {
                     Ok(configured) => {
                         let skills = install_configured_agent(
                             pane,
                             configured,
-                            PaneSettings::new(effort, reasoning_mode, fast_mode),
+                            PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                             &config,
                             &mut panes,
                             &commands,
@@ -1235,6 +1254,8 @@ pub(crate) async fn run(
                                 effort,
                                 reasoning_mode,
                                 fast_mode,
+                                model,
+                                draft_reset,
                                 skills,
                             }),
                             &mut scheduler,
@@ -1357,6 +1378,7 @@ pub(crate) async fn run(
                         configured,
                         projection,
                         reasoning_mode,
+                        model,
                     }) => {
                         let ConfiguredAgent {
                             agent,
@@ -1388,7 +1410,7 @@ pub(crate) async fn run(
                                 PaneGeneration { pane, generation },
                                 PaneSession::persisted(&session_id, !skills.is_empty()),
                                 &config,
-                                PaneSettings::new(effort, reasoning_mode, fast_mode),
+                                PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                                 instructions,
                                 subagent_control.clone(),
                                 &writer_sender,
@@ -1421,6 +1443,7 @@ pub(crate) async fn run(
                                 reasoning_mode,
                                 preferred_reasoning_mode,
                                 fast_mode,
+                                model,
                                 skills,
                             }),
                             &mut scheduler,
@@ -1568,6 +1591,7 @@ fn open_pane(
         effort,
         reasoning_mode,
         fast_mode,
+        model,
     } = settings;
     let PaneSession {
         id: session_id,
@@ -1581,7 +1605,7 @@ fn open_pane(
     journal.defer_start(SessionStarted {
         session_id: session_id.to_owned(),
         parent_session_id: parent_session_id.map(str::to_owned),
-        model: nanocodex::oai::MODEL.to_owned(),
+        model: model.to_string(),
         effort,
         reasoning_mode,
         fast_mode,
@@ -1621,6 +1645,7 @@ fn open_pane(
         current_effort: effort,
         reasoning_mode,
         current_fast_mode: fast_mode,
+        current_model: model,
         active_shells: 0,
         generation,
         subagent_control,
@@ -1923,6 +1948,43 @@ fn apply_pane_effect(
                 })
             }));
         }
+        components::RootEffect::SetModel(model) => {
+            *context.input = None;
+            let effort = context
+                .app
+                .root(pane)
+                .expect("model pane must exist")
+                .composer()
+                .effort();
+            let reasoning_mode = context
+                .panes
+                .get(&pane)
+                .expect("model pane must have a runtime")
+                .reasoning_mode;
+            let fast_mode = context
+                .panes
+                .get(&pane)
+                .expect("model pane must have a runtime")
+                .current_fast_mode;
+            let config = context.config.clone();
+            *context.new_session_task = Some(tokio::task::spawn_blocking(move || {
+                let configured = ConfiguredAgent::from_config_with_model(
+                    &config,
+                    effort,
+                    reasoning_mode,
+                    model,
+                );
+                (
+                    pane,
+                    effort,
+                    reasoning_mode,
+                    fast_mode,
+                    model,
+                    components::DraftReset::Preserve,
+                    configured,
+                )
+            }));
+        }
         components::RootEffect::SetFastMode(enabled) => {
             *context.input = None;
             let config = (pane == PaneId::Main).then(|| context.config.clone());
@@ -2028,7 +2090,15 @@ fn apply_pane_effect(
                     None,
                     None,
                 );
-                (pane, effort, reasoning_mode, fast_mode, configured)
+                (
+                    pane,
+                    effort,
+                    reasoning_mode,
+                    fast_mode,
+                    Model::Sol,
+                    components::DraftReset::Clear,
+                    configured,
+                )
             }));
         }
         components::RootEffect::LoadSessions(kind) => {
@@ -2164,6 +2234,7 @@ fn apply_pane_effect(
                     let records = records?;
                     tokio::task::spawn_blocking(move || -> Result<_> {
                     let reasoning_mode = session::reasoning_mode(&records);
+                    let model = session::model(&records);
                     let projection = RootNode::project_session(effort, records);
                     let configured = ConfiguredAgent::from_config_with_session(
                         &config,
@@ -2176,6 +2247,7 @@ fn apply_pane_effect(
                         configured,
                         projection,
                         reasoning_mode,
+                        model,
                     })
                     })
                     .await
@@ -2567,6 +2639,7 @@ mod tests {
             worker::WorkerCommand,
         },
     };
+    use nanocodex::Model;
     use std::{collections::HashMap, fs, path::Path, sync::Arc};
     use tempfile::tempdir;
 
@@ -2794,7 +2867,12 @@ mod tests {
             },
             PaneSession::new("main-session", None, false),
             &config,
-            PaneSettings::new(ReasoningEffort::Low, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Low,
+                ReasoningMode::Standard,
+                false,
+                Model::Luna,
+            ),
             Arc::from("instructions"),
             subagent_control.clone(),
             &sender,
@@ -2807,7 +2885,12 @@ mod tests {
             },
             PaneSession::new("fork-session", Some("main-session"), false),
             &config,
-            PaneSettings::new(ReasoningEffort::Low, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Low,
+                ReasoningMode::Standard,
+                false,
+                Model::Luna,
+            ),
             Arc::from("instructions"),
             subagent_control.clone(),
             &sender,
@@ -2867,6 +2950,7 @@ mod tests {
             .decode_payload::<crate::tui::transcript::SessionStarted>()
             .unwrap();
         assert_eq!(started.parent_session_id.as_deref(), Some("main-session"));
+        assert_eq!(started.model, Model::Luna.to_string());
         assert_eq!(records[1].kind(), "user.submitted");
     }
 
@@ -2891,7 +2975,12 @@ mod tests {
             },
             PaneSession::new("old-session", None, false),
             &config,
-            PaneSettings::new(ReasoningEffort::Medium, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Medium,
+                ReasoningMode::Standard,
+                false,
+                Model::Sol,
+            ),
             Arc::from("instructions"),
             subagent_control.clone(),
             &sender,
@@ -2913,7 +3002,12 @@ mod tests {
             },
             PaneSession::new("new-session", None, false),
             &config,
-            PaneSettings::new(ReasoningEffort::Medium, ReasoningMode::Standard, false),
+            PaneSettings::new(
+                ReasoningEffort::Medium,
+                ReasoningMode::Standard,
+                false,
+                Model::Sol,
+            ),
             Arc::from("instructions"),
             subagent_control,
             &sender,

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -7,7 +7,7 @@ use crate::{
         transcript::{SessionStarted, TranscriptRecord},
     },
 };
-use nanocodex::agent::session::SessionSnapshot;
+use nanocodex::{Model, agent::session::SessionSnapshot};
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
@@ -227,6 +227,15 @@ pub(crate) fn reasoning_mode(records: &[Arc<TranscriptRecord>]) -> ReasoningMode
         .map_or(ReasoningMode::Standard, |started| started.reasoning_mode)
 }
 
+pub(crate) fn model(records: &[Arc<TranscriptRecord>]) -> Model {
+    records
+        .iter()
+        .find(|record| record.source() == "tact" && record.kind() == "session.started")
+        .and_then(|record| record.decode_payload::<SessionStarted>().ok())
+        .and_then(|started| started.model.parse().ok())
+        .unwrap_or(Model::Sol)
+}
+
 pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -244,7 +253,7 @@ pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{encode_checkpoint, load_checkpoint, load_transcript, save_checkpoint};
+    use super::{encode_checkpoint, load_checkpoint, load_transcript, model, save_checkpoint};
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::{
@@ -252,7 +261,7 @@ mod tests {
             transcript::{LocalEvent, SessionStarted, TranscriptJournal, TranscriptRecord, TurnId},
         },
     };
-    use nanocodex::agent::session::SessionSnapshot;
+    use nanocodex::{Model, agent::session::SessionSnapshot};
     use rusqlite::Connection;
     use serde_json::{Value, json};
     use std::sync::Arc;
@@ -288,6 +297,28 @@ mod tests {
 
         assert!(load_transcript(&config, "missing").unwrap().is_empty());
         assert!(!database_path(&config).exists());
+    }
+
+    #[test]
+    fn restored_model_comes_from_the_session_start_record() {
+        let record = TranscriptRecord::from_local(
+            1,
+            1,
+            LocalEvent::SessionStarted(SessionStarted {
+                session_id: "session".to_owned(),
+                parent_session_id: None,
+                model: Model::Luna.to_string(),
+                effort: ReasoningEffort::Medium,
+                reasoning_mode: ReasoningMode::Standard,
+                fast_mode: false,
+                workspace: "/work".into(),
+                application_version: "test".to_owned(),
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(model(&[Arc::new(record)]), Model::Luna);
+        assert_eq!(model(&[]), Model::Sol);
     }
 
     #[test]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,6 +1,7 @@
 //! Configurable terminal colors and light/dark mode selection.
 
 use crate::app::config::ReasoningEffort;
+use nanocodex::Model;
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::{fmt, str::FromStr};
@@ -166,6 +167,15 @@ impl Theme {
             ReasoningEffort::High => self.thinking_high(),
             ReasoningEffort::Xhigh => self.thinking_xhigh(),
             ReasoningEffort::Max => self.thinking_max(),
+        }
+    }
+
+    pub(crate) const fn model(&self, model: Model) -> Color {
+        match model {
+            Model::Luna => Color::White,
+            Model::Terra => Color::Green,
+            Model::Sol => Color::Yellow,
+            _ => Color::Yellow,
         }
     }
 
@@ -357,6 +367,7 @@ impl fmt::Display for ColorName {
 #[cfg(test)]
 mod tests {
     use super::{ColorScheme, SYSTEM_SCHEME_POLL_INTERVAL, Theme, ThemeMode};
+    use nanocodex::Model;
     use ratatui::style::Color;
 
     #[test]
@@ -373,6 +384,15 @@ mod tests {
     #[test]
     fn system_theme_polling_is_perceptually_immediate() {
         assert!(SYSTEM_SCHEME_POLL_INTERVAL <= std::time::Duration::from_millis(100));
+    }
+
+    #[test]
+    fn models_have_a_shared_semantic_palette() {
+        let theme = Theme::default();
+
+        assert_eq!(theme.model(Model::Luna), Color::White);
+        assert_eq!(theme.model(Model::Terra), Color::Green);
+        assert_eq!(theme.model(Model::Sol), Color::Yellow);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the empty-transcript banner with animated Luna, Terra, and Sol artwork
- use each model's semantic color and the original typographic shading ramp
- render Sol with a soft billowing corona instead of radial spokes

## Stack

- Depends on: #105
- Top of stack

## Testing

- focused empty-transcript artwork tests
- cargo nextest run --no-fail-fast (763 passed)
- just check-fmt
- just clippy
