### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary

- bump the Tact package version from 0.4.0 to 0.5.0
- update the matching root package entry in Cargo.lock
- leave dependency versions unchanged

## Stack

- Depends on: #105
- Top of stack

## Testing

- just check-fmt
- just clippy
- cargo nextest run --no-fail-fast (763 passed)
- cargo package --locked --allow-dirty
