### PR TITLE
fix(tui): preserve and promote fork sessions

### DIFF
--- a/src/core/extensions/sessions.rs
+++ b/src/core/extensions/sessions.rs
@@ -431,6 +431,7 @@ mod tests {
                     LocalEvent::SessionStarted(SessionStarted {
                         session_id: "referenced".to_owned(),
                         parent_session_id: None,
+                        parent_sequence: None,
                         model: "model".to_owned(),
                         effort: ReasoningEffort::Medium,
                         reasoning_mode: ReasoningMode::Standard,

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -410,6 +410,7 @@ fn write_session(config_path: &Path, session_id: &str, workspace: &Path, event_c
         LocalEvent::SessionStarted(SessionStarted {
             session_id: session_id.to_owned(),
             parent_session_id: None,
+            parent_sequence: None,
             model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
@@ -447,6 +448,7 @@ fn write_mixed_session_segment(config_path: &Path, session_id: &str, workspace: 
         LocalEvent::SessionStarted(SessionStarted {
             session_id: session_id.to_owned(),
             parent_session_id: None,
+            parent_sequence: None,
             model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -193,7 +193,7 @@ pub(crate) enum AppEffect {
 pub(crate) struct AppNode {
     theme: Theme,
     workspace: PathBuf,
-    main: Option<Node<RootNode>>,
+    main: Option<(PaneId, Node<RootNode>)>,
     fork: Option<(PaneId, Node<RootNode>)>,
     focus: PaneId,
     main_area: Rect,
@@ -207,7 +207,7 @@ impl AppNode {
         Self {
             theme,
             workspace,
-            main: Some(Node::new(root)),
+            main: Some((PaneId::Main, Node::new(root))),
             fork: None,
             focus: PaneId::Main,
             main_area: Rect::default(),
@@ -217,11 +217,12 @@ impl AppNode {
     }
 
     pub(crate) fn open_resume_selector(&mut self) -> ComponentUpdate<AppEffect> {
-        let Some(root) = self.main.as_mut() else {
+        let Some((pane, root)) = self.main.as_mut() else {
             return ComponentUpdate::none();
         };
+        let pane = *pane;
         let update = root.component_mut().load_sessions();
-        self.map_root_update(PaneId::Main, update)
+        self.map_root_update(pane, update)
     }
 
     pub(crate) fn update(&mut self, event: AppEvent) -> ComponentUpdate<AppEffect> {
@@ -302,10 +303,11 @@ impl AppNode {
             AppEvent::ForkReady(pane) => self.update_root(pane, RootEvent::ForkReady),
             AppEvent::ForkFailed { pane, error } => {
                 self.remove_pane(pane);
-                let target = if self.main.is_some() {
-                    PaneId::Main
-                } else {
-                    self.focus
+                let Some(target) = self.main_pane() else {
+                    return ComponentUpdate {
+                        effects: vec![AppEffect::Shutdown],
+                        render: RenderRequest::Immediate,
+                    };
                 };
                 self.update_root(
                     target,
@@ -405,11 +407,7 @@ impl AppNode {
                 self.update_root(pane, RootEvent::ConfirmReviewDownload)
             }
             AppEvent::UpdateAvailable(version) => {
-                let pane = if self.main.is_some() {
-                    PaneId::Main
-                } else {
-                    self.focus
-                };
+                let pane = self.main_pane().unwrap_or(self.focus);
                 self.update_root(pane, RootEvent::UpdateAvailable(version))
             }
             AppEvent::ConfigReloaded {
@@ -421,7 +419,7 @@ impl AppNode {
             } => {
                 self.theme.replace_from_config(theme);
                 let mode = self.theme.mode();
-                if let Some(main) = &mut self.main {
+                if let Some((_, main)) = &mut self.main {
                     main.component_mut().set_theme_mode(mode);
                 }
                 if let Some((_, fork)) = &mut self.fork {
@@ -455,12 +453,12 @@ impl AppNode {
         let Some((fork_pane, fork)) = &mut self.fork else {
             self.main_area = area;
             self.fork_area = Rect::default();
-            if let Some(main) = &mut self.main {
+            if let Some((main_pane, main)) = &mut self.main {
                 main.component_mut().render_focused(
                     frame,
                     area,
                     &self.theme,
-                    self.focus == PaneId::Main,
+                    self.focus == *main_pane,
                 );
             }
             return;
@@ -490,12 +488,12 @@ impl AppNode {
             height: self.fork_area.height.saturating_sub(hint_height),
             ..self.fork_area
         };
-        if let Some(main) = &mut self.main {
+        if let Some((main_pane, main)) = &mut self.main {
             main.component_mut().render_focused(
                 frame,
                 main_content,
                 &self.theme,
-                self.focus == PaneId::Main,
+                self.focus == *main_pane,
             );
         }
         fork.component_mut().render_focused(
@@ -521,7 +519,7 @@ impl AppNode {
         [
             self.main
                 .as_ref()
-                .and_then(|root| root.component().animation_deadline()),
+                .and_then(|(_, root)| root.component().animation_deadline()),
             self.fork
                 .as_ref()
                 .and_then(|(_, root)| root.component().animation_deadline()),
@@ -555,8 +553,10 @@ impl AppNode {
             let position = Position::new(mouse.column, mouse.row);
             if self.fork_area.contains(position) {
                 self.focus = self.fork.as_ref().map_or(PaneId::Main, |(pane, _)| *pane);
-            } else if self.main_area.contains(position) {
-                self.focus = PaneId::Main;
+            } else if self.main_area.contains(position)
+                && let Some(main_pane) = self.main_pane()
+            {
+                self.focus = main_pane;
             }
         }
         self.update_root(self.focus, RootEvent::Terminal(event))
@@ -586,10 +586,10 @@ impl AppNode {
     }
 
     fn update_all(&mut self, event: RootEvent) -> ComponentUpdate<AppEffect> {
-        let main = self.main.take().map(|mut root| {
+        let main = self.main.take().map(|(pane, mut root)| {
             let update = root.update(event_for_other_pane(&event));
-            self.main = Some(root);
-            self.map_root_update(PaneId::Main, update)
+            self.main = Some((pane, root));
+            self.map_root_update(pane, update)
         });
         let fork = self.fork.take().map(|(pane, mut root)| {
             let update = root.update(event);
@@ -638,7 +638,7 @@ impl AppNode {
 
     fn set_theme_mode(&mut self, mode: ThemeMode) {
         self.theme.set_mode(mode);
-        if let Some(main) = &mut self.main {
+        if let Some((_, main)) = &mut self.main {
             main.component_mut().set_theme_mode(mode);
         }
         if let Some((_, fork)) = &mut self.fork {
@@ -647,7 +647,7 @@ impl AppNode {
     }
 
     pub(crate) fn set_max_subagents(&mut self, limit: usize) {
-        if let Some(main) = &mut self.main {
+        if let Some((_, main)) = &mut self.main {
             main.component_mut().set_max_subagents(limit);
         }
         if let Some((_, fork)) = &mut self.fork {
@@ -656,7 +656,7 @@ impl AppNode {
     }
 
     pub(crate) fn set_preferred_reasoning_mode(&mut self, mode: ReasoningMode) {
-        if let Some(main) = &mut self.main {
+        if let Some((_, main)) = &mut self.main {
             main.component_mut().set_preferred_reasoning_mode(mode);
         }
         if let Some((_, fork)) = &mut self.fork {
@@ -665,7 +665,7 @@ impl AppNode {
     }
 
     pub(crate) fn set_memory_enabled(&mut self, enabled: bool) {
-        if let Some(main) = &mut self.main {
+        if let Some((_, main)) = &mut self.main {
             main.component_mut().set_memory_enabled(enabled);
         }
         if let Some((_, fork)) = &mut self.fork {
@@ -674,10 +674,10 @@ impl AppNode {
     }
 
     fn begin_fork(&mut self) -> PaneId {
-        if let Some(main) = &mut self.main {
+        if let Some((_, main)) = &mut self.main {
             main.component_mut().set_fork_available(false);
         }
-        let main = self
+        let (_, main) = self
             .main
             .as_ref()
             .expect("forking requires the primary pane");
@@ -691,45 +691,49 @@ impl AppNode {
     }
 
     fn remove_pane(&mut self, pane: PaneId) {
-        match pane {
-            PaneId::Main => self.main = None,
-            PaneId::Fork(_) if self.fork.as_ref().is_some_and(|(id, _)| *id == pane) => {
-                self.fork = None;
-            }
-            PaneId::Fork(_) => return,
+        if self.main.as_ref().is_some_and(|(id, _)| *id == pane) {
+            self.main = self.fork.take();
+        } else if self.fork.as_ref().is_some_and(|(id, _)| *id == pane) {
+            self.fork = None;
+        } else {
+            return;
         }
-        if self.main.is_some() {
-            self.focus = PaneId::Main;
-            if self.fork.is_none()
-                && let Some(main) = &mut self.main
-            {
+        if let Some((main_pane, main)) = &mut self.main {
+            self.focus = *main_pane;
+            if self.fork.is_none() {
                 main.component_mut().set_fork_available(true);
             }
-        } else if self.fork.is_some() {
-            self.focus = self.fork.as_ref().map_or(PaneId::Main, |(pane, _)| *pane);
         }
+    }
+
+    pub(crate) fn main_pane(&self) -> Option<PaneId> {
+        self.main.as_ref().map(|(pane, _)| *pane)
     }
 
     fn pane(&self, pane: PaneId) -> Option<&Node<RootNode>> {
-        match pane {
-            PaneId::Main => self.main.as_ref(),
-            PaneId::Fork(_) => self
-                .fork
-                .as_ref()
-                .filter(|(fork_pane, _)| *fork_pane == pane)
-                .map(|(_, root)| root),
-        }
+        self.main
+            .as_ref()
+            .filter(|(main_pane, _)| *main_pane == pane)
+            .or_else(|| {
+                self.fork
+                    .as_ref()
+                    .filter(|(fork_pane, _)| *fork_pane == pane)
+            })
+            .map(|(_, root)| root)
     }
 
     fn pane_mut(&mut self, pane: PaneId) -> Option<&mut Node<RootNode>> {
-        match pane {
-            PaneId::Main => self.main.as_mut(),
-            PaneId::Fork(_) => self
-                .fork
-                .as_mut()
-                .filter(|(fork_pane, _)| *fork_pane == pane)
-                .map(|(_, root)| root),
+        if self
+            .main
+            .as_ref()
+            .is_some_and(|(main_pane, _)| *main_pane == pane)
+        {
+            return self.main.as_mut().map(|(_, root)| root);
         }
+        self.fork
+            .as_mut()
+            .filter(|(fork_pane, _)| *fork_pane == pane)
+            .map(|(_, root)| root)
     }
 }
 
@@ -1142,6 +1146,84 @@ mod tests {
         ));
         assert!(app.root(PaneId::Main).is_none());
         assert!(app.root(PaneId::Fork(1)).is_some());
+    }
+
+    #[test]
+    fn closing_the_primary_promotes_the_fork() {
+        let mut app = app();
+        app.update(control('f'));
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        })));
+        app.update(control('c'));
+
+        let close = app.update(control('c'));
+
+        assert!(matches!(
+            close.effects.as_slice(),
+            [AppEffect::ClosePane(PaneId::Main)]
+        ));
+        assert_eq!(app.main_pane(), Some(PaneId::Fork(1)));
+        assert!(!rendered(&mut app, 100, 20).contains(SPLIT_HINT.trim()));
+
+        app.update(control('c'));
+        let shutdown = app.update(control('c'));
+
+        assert!(matches!(shutdown.effects.as_slice(), [AppEffect::Shutdown]));
+    }
+
+    #[test]
+    fn promoted_fork_can_open_another_fork() {
+        let mut app = app();
+        app.update(control('f'));
+        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        })));
+        app.update(control('c'));
+        app.update(control('c'));
+
+        let fork = app.update(control('f'));
+
+        assert!(matches!(
+            fork.effects.as_slice(),
+            [AppEffect::OpenFork(PaneId::Fork(2))]
+        ));
+        assert_eq!(app.main_pane(), Some(PaneId::Fork(1)));
+        assert!(app.root(PaneId::Fork(2)).is_some());
+    }
+
+    #[test]
+    fn failed_pending_fork_shuts_down_after_its_parent_closes() {
+        let mut app = app();
+        app.update(control('f'));
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        })));
+        app.update(control('c'));
+        app.update(control('c'));
+
+        let update = app.update(AppEvent::ForkFailed {
+            pane: PaneId::Fork(1),
+            error: "fork failed".to_owned(),
+        });
+
+        assert!(matches!(update.effects.as_slice(), [AppEffect::Shutdown]));
     }
 
     #[test]

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -78,7 +78,10 @@ pub(crate) enum AppEvent {
         index: usize,
         text: String,
     },
-    WorkerTurnFinished(PaneId),
+    WorkerTurnFinished {
+        pane: PaneId,
+        terminal_expected: bool,
+    },
     ShellFinished(PaneId),
     TurnsCancelled(PaneId),
     SteerAdmitted {
@@ -93,7 +96,9 @@ pub(crate) enum AppEvent {
         pane: PaneId,
         id: QueueId,
     },
-    ForkReady(PaneId),
+    ForkReady {
+        pane: PaneId,
+    },
     ForkFailed {
         pane: PaneId,
         error: String,
@@ -184,7 +189,7 @@ pub(crate) enum AppEvent {
 
 pub(crate) enum AppEffect {
     Pane { pane: PaneId, effect: RootEffect },
-    OpenFork(PaneId),
+    OpenFork { pane: PaneId, parent: PaneId },
     ClosePane(PaneId),
     SetTheme(ThemeMode),
     Shutdown,
@@ -286,9 +291,10 @@ impl AppNode {
             AppEvent::QueueEditorFinished { pane, index, text } => {
                 self.update_root(pane, RootEvent::RestoreQueued { index, text })
             }
-            AppEvent::WorkerTurnFinished(pane) => {
-                self.update_root(pane, RootEvent::WorkerTurnFinished)
-            }
+            AppEvent::WorkerTurnFinished {
+                pane,
+                terminal_expected,
+            } => self.update_root(pane, RootEvent::WorkerTurnFinished { terminal_expected }),
             AppEvent::ShellFinished(pane) => self.update_root(pane, RootEvent::ShellFinished),
             AppEvent::TurnsCancelled(pane) => self.update_root(pane, RootEvent::TurnsCancelled),
             AppEvent::SteerAdmitted { pane, id } => {
@@ -300,7 +306,7 @@ impl AppNode {
             AppEvent::SteerFailed { pane, id } => {
                 self.update_root(pane, RootEvent::SteerFailed { id })
             }
-            AppEvent::ForkReady(pane) => self.update_root(pane, RootEvent::ForkReady),
+            AppEvent::ForkReady { pane } => self.update_root(pane, RootEvent::ForkReady),
             AppEvent::ForkFailed { pane, error } => {
                 self.remove_pane(pane);
                 let Some(target) = self.main_pane() else {
@@ -617,7 +623,8 @@ impl AppNode {
             match effect {
                 RootEffect::Fork => {
                     if self.fork.is_none() && self.main.is_some() {
-                        effects.push(AppEffect::OpenFork(self.begin_fork()));
+                        let (pane, parent) = self.begin_fork();
+                        effects.push(AppEffect::OpenFork { pane, parent });
                     }
                 }
                 RootEffect::Shutdown => {
@@ -673,11 +680,11 @@ impl AppNode {
         }
     }
 
-    fn begin_fork(&mut self) -> PaneId {
+    fn begin_fork(&mut self) -> (PaneId, PaneId) {
         if let Some((_, main)) = &mut self.main {
             main.component_mut().set_fork_available(false);
         }
-        let (_, main) = self
+        let (parent, main) = self
             .main
             .as_ref()
             .expect("forking requires the primary pane");
@@ -687,7 +694,7 @@ impl AppNode {
         self.next_fork = self.next_fork.saturating_add(1);
         self.fork = Some((pane, Node::new(fork)));
         self.focus = pane;
-        pane
+        (pane, *parent)
     }
 
     fn remove_pane(&mut self, pane: PaneId) {
@@ -941,7 +948,10 @@ mod tests {
 
         assert!(matches!(
             update.effects.as_slice(),
-            [AppEffect::OpenFork(PaneId::Fork(1))]
+            [AppEffect::OpenFork {
+                pane: PaneId::Fork(1),
+                parent: PaneId::Main,
+            }]
         ));
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
         terminal.draw(|frame| app.render(frame)).unwrap();
@@ -997,7 +1007,9 @@ mod tests {
     fn fork_effort_changes_do_not_change_the_primary_composer() {
         let mut app = app();
         app.update(control('f'));
-        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
         app.update(control('s'));
         app.update(AppEvent::Terminal(Event::Key(KeyEvent::new(
             KeyCode::Right,
@@ -1033,7 +1045,9 @@ mod tests {
     fn preferred_reasoning_mode_is_shared_without_changing_running_sessions() {
         let mut app = app();
         app.update(control('f'));
-        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
 
         app.set_preferred_reasoning_mode(ReasoningMode::Pro);
 
@@ -1089,7 +1103,9 @@ mod tests {
     fn control_c_clears_the_focused_fork_composer_before_closing_it() {
         let mut app = app();
         app.update(control('f'));
-        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
         app.update(AppEvent::Terminal(Event::Key(KeyEvent::new(
             KeyCode::Char('h'),
             KeyModifiers::NONE,
@@ -1181,7 +1197,9 @@ mod tests {
     fn promoted_fork_can_open_another_fork() {
         let mut app = app();
         app.update(control('f'));
-        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
         let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
         terminal.draw(|frame| app.render(frame)).unwrap();
         app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
@@ -1197,7 +1215,10 @@ mod tests {
 
         assert!(matches!(
             fork.effects.as_slice(),
-            [AppEffect::OpenFork(PaneId::Fork(2))]
+            [AppEffect::OpenFork {
+                pane: PaneId::Fork(2),
+                parent: PaneId::Fork(1),
+            }]
         ));
         assert_eq!(app.main_pane(), Some(PaneId::Fork(1)));
         assert!(app.root(PaneId::Fork(2)).is_some());
@@ -1274,7 +1295,9 @@ mod tests {
         let mut app = app();
         app.set_memory_enabled(true);
         app.update(control('f'));
-        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
 
         for pane in [PaneId::Main, PaneId::Fork(1)] {
             let update = open_memory(&mut app, pane);
@@ -1305,7 +1328,9 @@ mod tests {
     fn config_reload_updates_memory_action_availability_for_every_root() {
         let mut app = app();
         app.update(control('f'));
-        app.update(AppEvent::ForkReady(PaneId::Fork(1)));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
 
         app.update(AppEvent::ConfigReloaded {
             pane: PaneId::Main,

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -158,7 +158,9 @@ pub(crate) enum RootEvent {
         index: usize,
         text: String,
     },
-    WorkerTurnFinished,
+    WorkerTurnFinished {
+        terminal_expected: bool,
+    },
     ShellFinished,
     TurnsCancelled,
     ForkReady,
@@ -324,6 +326,8 @@ pub(crate) struct RootNode {
     composer_content_area: Rect,
     queue_area: Rect,
     in_flight_turns: usize,
+    unmatched_worker_turns: usize,
+    unmatched_agent_turns: usize,
     in_flight_shells: usize,
     blocking_task: Option<BlockingTask>,
     review_url: Option<String>,
@@ -358,6 +362,8 @@ impl RootNode {
             composer_content_area: Rect::default(),
             queue_area: Rect::default(),
             in_flight_turns: 0,
+            unmatched_worker_turns: 0,
+            unmatched_agent_turns: 0,
             in_flight_shells: 0,
             blocking_task: None,
             review_url: None,
@@ -928,7 +934,7 @@ impl RootNode {
             self.overlay = Some(Overlay::Actions(Node::new(ActionsMenu::new(
                 ActionAvailability {
                     new_session: new_session_enabled,
-                    fork: self.fork_available,
+                    fork: self.can_fork(),
                     fast_mode: self.composer.component().fast_mode(),
                     memory: self.memory_enabled,
                     model: self.thread == ThreadState::New,
@@ -1598,7 +1604,7 @@ impl RootNode {
     }
 
     fn open_fork(&mut self) -> ComponentUpdate<RootEffect> {
-        if !self.fork_available {
+        if !self.can_fork() {
             return ComponentUpdate::none();
         }
         self.overlay = None;
@@ -1606,6 +1612,10 @@ impl RootNode {
             effects: vec![RootEffect::Fork],
             render: RenderRequest::Immediate,
         }
+    }
+
+    fn can_fork(&self) -> bool {
+        self.fork_available && self.in_flight_turns == 0 && !self.transcript.component().is_active()
     }
 
     fn open_new_session(&mut self) -> ComponentUpdate<RootEffect> {
@@ -2067,6 +2077,27 @@ impl RootNode {
         self.submit_next_queued()
     }
 
+    fn worker_turn_finished(&mut self, terminal_expected: bool) -> ComponentUpdate<RootEffect> {
+        if !terminal_expected {
+            return self.turn_finished();
+        }
+        if self.unmatched_agent_turns > 0 {
+            self.unmatched_agent_turns -= 1;
+            return self.turn_finished();
+        }
+        self.unmatched_worker_turns = self.unmatched_worker_turns.saturating_add(1);
+        ComponentUpdate::none()
+    }
+
+    fn agent_turn_finished(&mut self) -> ComponentUpdate<RootEffect> {
+        if self.unmatched_worker_turns > 0 {
+            self.unmatched_worker_turns -= 1;
+            return self.turn_finished();
+        }
+        self.unmatched_agent_turns = self.unmatched_agent_turns.saturating_add(1);
+        ComponentUpdate::none()
+    }
+
     fn turns_cancelled(&mut self) -> ComponentUpdate<RootEffect> {
         self.queue.component_mut().cancel_steers();
         ComponentUpdate::render(RenderRequest::Immediate)
@@ -2308,6 +2339,7 @@ impl Component for RootNode {
                     self.recent_prompts.push(prompt);
                 }
                 let steer_applied = record.kind() == "run.steered";
+                let turn_finished = matches!(record.kind(), "run.completed" | "run.failed");
                 let turn_timer = turn_timer_event(&record);
                 let observation = self.context_diagnostics.observe(&record);
                 if let Some(Overlay::ContextDiagnostics(panel)) = &mut self.overlay {
@@ -2333,6 +2365,11 @@ impl Component for RootNode {
                     let applied = self.steer_applied();
                     update.effects.extend(applied.effects);
                     update.render = update.render.max(applied.render);
+                }
+                if turn_finished {
+                    let finished = self.agent_turn_finished();
+                    update.effects.extend(finished.effects);
+                    update.render = update.render.max(finished.render);
                 }
                 update
             }
@@ -2480,7 +2517,9 @@ impl Component for RootNode {
                 )
             }
             RootEvent::RestoreQueued { index, text } => self.restore_queued(index, text),
-            RootEvent::WorkerTurnFinished => self.turn_finished(),
+            RootEvent::WorkerTurnFinished { terminal_expected } => {
+                self.worker_turn_finished(terminal_expected)
+            }
             RootEvent::ShellFinished => {
                 self.in_flight_shells = self.in_flight_shells.saturating_sub(1);
                 ComponentUpdate::none()
@@ -4317,7 +4356,9 @@ mod tests {
         root.queue.component_mut().push("first".to_owned());
         root.queue.component_mut().push("second".to_owned());
 
-        let update = root.update(super::RootEvent::WorkerTurnFinished);
+        let update = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
         assert_eq!(
             update.effects,
             [RootEffect::Submit("first\n\nsecond".to_owned().into())]
@@ -4363,12 +4404,16 @@ mod tests {
             panic!("enter should issue a steer");
         };
         let id = *id;
-        let finished = root.update(super::RootEvent::WorkerTurnFinished);
+        let finished = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
         assert!(finished.effects.is_empty());
         assert_eq!(root.queue.component().len(), 2);
 
         root.update(super::RootEvent::SteerPromoted(id));
-        let promoted_finished = root.update(super::RootEvent::WorkerTurnFinished);
+        let promoted_finished = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
         assert_eq!(
             promoted_finished.effects,
             [RootEffect::Submit("later".to_owned().into())]
@@ -4390,7 +4435,9 @@ mod tests {
         assert_eq!(interrupt.effects, [RootEffect::CancelTurns]);
 
         root.update(super::RootEvent::TurnsCancelled);
-        let finished = root.update(super::RootEvent::WorkerTurnFinished);
+        let finished = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
         assert_eq!(
             finished.effects,
             [RootEffect::Submit(
@@ -4415,7 +4462,9 @@ mod tests {
 
         root.update(super::RootEvent::TurnsCancelled);
         let applied = root.update(run_steered());
-        let finished = root.update(super::RootEvent::WorkerTurnFinished);
+        let finished = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
 
         assert_eq!(
             applied.effects,
@@ -5495,7 +5544,9 @@ mod tests {
             root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
         }
         root.update(key(KeyCode::Enter, KeyModifiers::NONE));
-        root.update(super::RootEvent::WorkerTurnFinished);
+        root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
         root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
         for character in "clear".chars() {
             root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
@@ -5747,6 +5798,108 @@ mod tests {
         let update = root.update(key(KeyCode::Char('f'), KeyModifiers::CONTROL));
 
         assert_eq!(update.effects, [RootEffect::Fork]);
+    }
+
+    #[test]
+    fn fork_waits_for_worker_and_agent_turn_state_to_agree() {
+        let mut worker_before_started = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        worker_before_started.in_flight_turns = 1;
+        worker_before_started.update(RootEvent::WorkerTurnFinished {
+            terminal_expected: true,
+        });
+        assert!(
+            worker_before_started
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects
+                .is_empty()
+        );
+        worker_before_started.update(RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::RunStarted,
+            json!({}),
+        )));
+        worker_before_started.update(RootEvent::Transcript(agent_record(
+            2,
+            AgentEventKind::RunCompleted,
+            json!({}),
+        )));
+        assert_eq!(
+            worker_before_started
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects,
+            [RootEffect::Fork]
+        );
+
+        let mut before_started = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        before_started.in_flight_turns = 1;
+
+        assert!(
+            before_started
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects
+                .is_empty()
+        );
+
+        before_started.update(RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::RunStarted,
+            json!({}),
+        )));
+        assert!(
+            before_started
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects
+                .is_empty()
+        );
+        before_started.update(RootEvent::Transcript(agent_record(
+            2,
+            AgentEventKind::RunCompleted,
+            json!({}),
+        )));
+        assert!(
+            before_started
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects
+                .is_empty()
+        );
+        before_started.update(RootEvent::WorkerTurnFinished {
+            terminal_expected: true,
+        });
+        assert_eq!(
+            before_started
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects,
+            [RootEffect::Fork]
+        );
+
+        let mut before_terminal = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        before_terminal.in_flight_turns = 1;
+        before_terminal.update(RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::RunStarted,
+            json!({}),
+        )));
+        before_terminal.update(RootEvent::WorkerTurnFinished {
+            terminal_expected: true,
+        });
+
+        assert!(
+            before_terminal
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects
+                .is_empty()
+        );
+        before_terminal.update(RootEvent::Transcript(agent_record(
+            2,
+            AgentEventKind::RunCompleted,
+            json!({}),
+        )));
+        assert_eq!(
+            before_terminal
+                .update(key(KeyCode::Char('f'), KeyModifiers::CONTROL))
+                .effects,
+            [RootEffect::Fork]
+        );
     }
 
     #[test]

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -264,6 +264,10 @@ impl Transcript {
         snapshot
     }
 
+    pub(crate) const fn is_active(&self) -> bool {
+        self.model.is_active()
+    }
+
     pub(crate) const fn set_effort(&mut self, effort: ReasoningEffort) {
         self.effort = effort;
     }
@@ -1610,6 +1614,12 @@ fn render_entry(
         EntryKind::DirectedMessage(thread) => {
             layout_without_links(message::render(thread, width, theme, expanded))
         }
+        EntryKind::ForkedFrom { session_id } => {
+            layout_without_links(vec![Line::from(Span::styled(
+                format!("◇ Forked from @@{session_id}"),
+                Style::default().fg(theme.muted()),
+            ))])
+        }
         EntryKind::EffortChanged { to } => layout_without_links(vec![Line::from(vec![
             Span::styled("◇ Effort changed to ", Style::default().fg(theme.muted())),
             Span::styled(
@@ -1820,17 +1830,20 @@ mod tests {
         Transcript, TranscriptEvent, unix_milliseconds,
     };
     use crate::{
-        app::config::ReasoningEffort,
+        app::config::{ReasoningEffort, ReasoningMode},
         core::extensions::subagents::{AgentMessageUpdate, MessageSender},
         tui::{
             theme::Theme,
-            transcript::{EntryKind, LocalEvent, TranscriptRecord, TurnId},
+            transcript::{EntryKind, LocalEvent, SessionStarted, TranscriptRecord, TurnId},
         },
     };
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use ratatui::{Terminal, backend::TestBackend, layout::Position, style::Color};
     use serde_json::{json, value::to_raw_value};
     use std::{sync::Arc, time::Duration};
@@ -1968,6 +1981,39 @@ mod tests {
                 .selection_span_nearest(Position::new(0, 0))
                 .is_some()
         );
+    }
+
+    #[test]
+    fn fork_start_renders_its_parent_session_boundary() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(Arc::new(
+            TranscriptRecord::from_local(
+                1,
+                1,
+                LocalEvent::SessionStarted(SessionStarted {
+                    session_id: "fork".to_owned(),
+                    parent_session_id: Some("parent".to_owned()),
+                    parent_sequence: Some(0),
+                    model: Model::Luna.to_string(),
+                    effort: ReasoningEffort::Medium,
+                    reasoning_mode: ReasoningMode::Standard,
+                    fast_mode: false,
+                    workspace: "/work".into(),
+                    application_version: "test".to_owned(),
+                }),
+            )
+            .unwrap(),
+        )));
+
+        let backend = render(&mut transcript, 40, 3);
+        let output = backend
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(output.contains("Forked from @@parent"));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -937,40 +937,44 @@ pub(crate) async fn run(
                         }
                         schedule(app.update(AppEvent::TurnsCancelled(pane)), &mut scheduler);
                     }
-                    WorkerEvent::ForkOpened { pane, events } => {
+                    WorkerEvent::ForkOpened {
+                        pane,
+                        parent: main_pane,
+                        events,
+                    } => {
                         let session_id = events.request_id().to_owned();
                         let parent_session_id = panes
-                            .get(&PaneId::Main)
+                            .get(&main_pane)
                             .map(|runtime| runtime.session_id.clone());
                         let effort = app
                             .root(pane)
                             .map(|root| root.composer().effort())
                             .unwrap_or_else(|| config.agent().thinking());
                         let fast_mode = panes
-                            .get(&PaneId::Main)
+                            .get(&main_pane)
                             .expect("main pane must exist")
                             .current_fast_mode;
                         let reasoning_mode = panes
-                            .get(&PaneId::Main)
+                            .get(&main_pane)
                             .expect("main pane must exist")
                             .reasoning_mode;
                         let model = panes
-                            .get(&PaneId::Main)
+                            .get(&main_pane)
                             .expect("main pane must exist")
                             .current_model;
                         let subagent_control = panes
-                            .get(&PaneId::Main)
+                            .get(&main_pane)
                             .expect("main pane must exist")
                             .subagent_control
                             .clone();
                         let instructions = Arc::clone(
                             &panes
-                                .get(&PaneId::Main)
+                                .get(&main_pane)
                                 .expect("main pane must exist")
                                 .instructions,
                         );
                         let skills_catalog_present = panes
-                            .get(&PaneId::Main)
+                            .get(&main_pane)
                             .expect("main pane must exist")
                             .skills_catalog_present;
                         panes.insert(
@@ -1019,7 +1023,7 @@ pub(crate) async fn run(
                         }
                         runtime.current_effort = effort;
                         runtime.subagent_control.set_thinking(effort.into());
-                        if pane == PaneId::Main {
+                        if app.main_pane() == Some(pane) {
                             config.set_thinking(effort);
                         }
                         input = Some(EventStream::new());
@@ -1041,7 +1045,7 @@ pub(crate) async fn run(
                         }
                         runtime.current_fast_mode = enabled;
                         runtime.subagent_control.set_fast_mode(enabled);
-                        if pane == PaneId::Main {
+                        if app.main_pane() == Some(pane) {
                             config.set_fast_mode(enabled);
                         }
                         input = Some(EventStream::new());
@@ -1492,8 +1496,9 @@ pub(crate) async fn run(
         }
     }
 
-    let session_id = panes
-        .get(&PaneId::Main)
+    let session_id = app
+        .main_pane()
+        .and_then(|pane| panes.get(&pane))
         .and_then(PaneRuntime::exit_session_id);
     drop(terminal);
     if let Some(error) = writer_error {
@@ -1939,8 +1944,9 @@ fn apply_pane_effect(
         } => {
             *context.input = None;
             let config = context.config.clone();
+            let is_main = context.app.main_pane() == Some(pane);
             *context.effort_task = Some(tokio::task::spawn_blocking(move || {
-                if pane == PaneId::Main {
+                if is_main {
                     config.persist_thinking(effort)?;
                 }
                 config.persist_reasoning_mode(reasoning_mode)?;
@@ -1990,7 +1996,7 @@ fn apply_pane_effect(
         }
         components::RootEffect::SetFastMode(enabled) => {
             *context.input = None;
-            let config = (pane == PaneId::Main).then(|| context.config.clone());
+            let config = (context.app.main_pane() == Some(pane)).then(|| context.config.clone());
             *context.fast_mode_task = Some(tokio::task::spawn_blocking(move || {
                 if let Some(config) = config {
                     config.persist_fast_mode(enabled)?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -149,6 +149,7 @@ struct RestoredSession {
     projection: RestoredSessionProjection,
     reasoning_mode: ReasoningMode,
     model: Model,
+    next_sequence: u64,
 }
 
 enum EditorTarget {
@@ -205,6 +206,8 @@ struct PaneGeneration {
 struct PaneSession<'a> {
     id: &'a str,
     parent_id: Option<&'a str>,
+    parent_sequence: Option<u64>,
+    next_sequence: u64,
     previously_persisted: bool,
     skills_catalog_present: bool,
 }
@@ -234,19 +237,29 @@ impl PaneSettings {
 }
 
 impl<'a> PaneSession<'a> {
-    const fn new(id: &'a str, parent_id: Option<&'a str>, skills_catalog_present: bool) -> Self {
+    const fn new(
+        id: &'a str,
+        parent_id: Option<&'a str>,
+        parent_sequence: Option<u64>,
+        next_sequence: u64,
+        skills_catalog_present: bool,
+    ) -> Self {
         Self {
             id,
             parent_id,
+            parent_sequence,
+            next_sequence,
             previously_persisted: false,
             skills_catalog_present,
         }
     }
 
-    const fn persisted(id: &'a str, skills_catalog_present: bool) -> Self {
+    const fn persisted(id: &'a str, next_sequence: u64, skills_catalog_present: bool) -> Self {
         Self {
             id,
             parent_id: None,
+            parent_sequence: None,
+            next_sequence,
             previously_persisted: true,
             skills_catalog_present,
         }
@@ -441,7 +454,7 @@ pub(crate) async fn run(
         StartupMode::NewSession | StartupMode::ResumeSelector => None,
     };
     let resuming = resume_session_id.is_some();
-    let (configured, restored_projection, reasoning_mode, model) =
+    let (configured, restored_projection, reasoning_mode, model, next_sequence) =
         if let Some(session_id) = resume_session_id {
             let restored_config = config.clone();
             let config_path = restored_config.path().to_path_buf();
@@ -459,6 +472,7 @@ pub(crate) async fn run(
             tokio::task::spawn_blocking(move || -> Result<_> {
                 let reasoning_mode = session::reasoning_mode(&records);
                 let model = session::model(&records);
+                let next_sequence = session::next_sequence(&records);
                 let projection = RootNode::project_session(initial_effort, records);
                 let configured = ConfiguredAgent::from_config_with_session(
                     &restored_config,
@@ -468,7 +482,13 @@ pub(crate) async fn run(
                     Some(&session_id),
                     Some(snapshot),
                 )?;
-                Ok((configured, Some(projection), reasoning_mode, model))
+                Ok((
+                    configured,
+                    Some(projection),
+                    reasoning_mode,
+                    model,
+                    next_sequence,
+                ))
             })
             .await
             .map_err(RuntimeError::SessionTask)??
@@ -478,6 +498,7 @@ pub(crate) async fn run(
                 None,
                 preferred_reasoning_mode,
                 Model::Sol,
+                1,
             )
         };
     let mut terminal = TerminalSession::enter().map_err(RuntimeError::Terminal)?;
@@ -501,9 +522,9 @@ pub(crate) async fn run(
                 generation: 0,
             },
             if resuming {
-                PaneSession::persisted(&main_session_id, !skills.is_empty())
+                PaneSession::persisted(&main_session_id, next_sequence, !skills.is_empty())
             } else {
-                PaneSession::new(&main_session_id, None, !skills.is_empty())
+                PaneSession::new(&main_session_id, None, None, 1, !skills.is_empty())
             },
             &config,
             PaneSettings::new(initial_effort, reasoning_mode, initial_fast_mode, model),
@@ -617,7 +638,8 @@ pub(crate) async fn run(
                     memory_generations: &mut memory_generations,
                     subagent_shutdowns: &mut subagent_shutdowns,
                 },
-            )?;
+            )
+            .await?;
         };
     }
 
@@ -870,7 +892,13 @@ pub(crate) async fn run(
                             .journal_mut()?.append_local(LocalEvent::WorkerTurnAccepted { id })?;
                         schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                     }
-                    WorkerEvent::TurnFinished { pane, id, error, snapshot } => {
+                    WorkerEvent::TurnFinished {
+                        pane,
+                        id,
+                        error,
+                        snapshot,
+                        terminal_expected,
+                    } => {
                         let Some(runtime) = panes.get_mut(&pane) else {
                             continue;
                         };
@@ -892,7 +920,10 @@ pub(crate) async fn run(
                             None => runtime.journal_mut()?.append_local(event)?,
                         };
                         schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
-                        apply_app_update!(app.update(AppEvent::WorkerTurnFinished(pane)));
+                        apply_app_update!(app.update(AppEvent::WorkerTurnFinished {
+                            pane,
+                            terminal_expected,
+                        }));
                     }
                     WorkerEvent::SteerAdmitted { pane, queue_id } => {
                         apply_app_update!(app.update(AppEvent::SteerAdmitted { pane, id: queue_id }));
@@ -940,6 +971,7 @@ pub(crate) async fn run(
                     WorkerEvent::ForkOpened {
                         pane,
                         parent: main_pane,
+                        parent_sequence,
                         events,
                     } => {
                         let session_id = events.request_id().to_owned();
@@ -977,9 +1009,7 @@ pub(crate) async fn run(
                             .get(&main_pane)
                             .expect("main pane must exist")
                             .skills_catalog_present;
-                        panes.insert(
-                            pane,
-                            open_pane(
+                        let mut runtime = open_pane(
                                 PaneGeneration {
                                     pane,
                                     generation: 0,
@@ -987,6 +1017,8 @@ pub(crate) async fn run(
                                 PaneSession::new(
                                     &session_id,
                                     parent_session_id.as_deref(),
+                                    Some(parent_sequence),
+                                    1,
                                     skills_catalog_present,
                                 ),
                                 &config,
@@ -994,11 +1026,20 @@ pub(crate) async fn run(
                                 instructions,
                                 subagent_control.clone(),
                                 &writer_sender,
-                            )?,
-                        );
+                            )?;
+                        let started = runtime
+                            .journal_mut()?
+                            .persist_start()
+                            .await?
+                            .expect("a new fork must have a deferred session start");
+                        panes.insert(pane, runtime);
                         writers_open = writers_open.saturating_add(1);
                         agent_events::forward(pane, 0, events, agent_event_sender.clone());
-                        apply_app_update!(app.update(AppEvent::ForkReady(pane)));
+                        apply_app_update!(app.update(AppEvent::Transcript {
+                            pane,
+                            record: started,
+                        }));
+                        apply_app_update!(app.update(AppEvent::ForkReady { pane }));
                     }
                     WorkerEvent::ForkFailed { pane, error } => {
                         apply_app_update!(app.update(AppEvent::ForkFailed { pane, error }));
@@ -1386,6 +1427,7 @@ pub(crate) async fn run(
                         projection,
                         reasoning_mode,
                         model,
+                        next_sequence,
                     }) => {
                         let ConfiguredAgent {
                             agent,
@@ -1415,7 +1457,11 @@ pub(crate) async fn run(
                             pane,
                             open_pane(
                                 PaneGeneration { pane, generation },
-                                PaneSession::persisted(&session_id, !skills.is_empty()),
+                                PaneSession::persisted(
+                                    &session_id,
+                                    next_sequence,
+                                    !skills.is_empty(),
+                                ),
                                 &config,
                                 PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                                 instructions,
@@ -1553,7 +1599,7 @@ fn install_configured_agent(
         pane,
         open_pane(
             PaneGeneration { pane, generation },
-            PaneSession::new(&session_id, None, !skills.is_empty()),
+            PaneSession::new(&session_id, None, None, 1, !skills.is_empty()),
             config,
             settings,
             instructions,
@@ -1604,15 +1650,19 @@ fn open_pane(
     let PaneSession {
         id: session_id,
         parent_id: parent_session_id,
+        parent_sequence,
+        next_sequence,
         previously_persisted,
         skills_catalog_present,
     } = session;
-    let (mut journal, writer) = TranscriptJournal::open(config.path(), session_id)?;
+    let (mut journal, writer) =
+        TranscriptJournal::open_at(config.path(), session_id, next_sequence)?;
     let writer_path = journal.path().to_path_buf();
     let persisted_transcript = journal.persistence_flag();
     journal.defer_start(SessionStarted {
         session_id: session_id.to_owned(),
         parent_session_id: parent_session_id.map(str::to_owned),
+        parent_sequence,
         model: model.to_string(),
         effort,
         reasoning_mode,
@@ -1778,13 +1828,30 @@ struct EffectContext<'a> {
     subagent_shutdowns: &'a mut JoinSet<()>,
 }
 
-fn apply_update(update: ComponentUpdate<AppEffect>, mut context: EffectContext<'_>) -> Result<()> {
+async fn apply_update(
+    update: ComponentUpdate<AppEffect>,
+    mut context: EffectContext<'_>,
+) -> Result<()> {
     for effect in update.effects {
         match effect {
-            AppEffect::OpenFork(pane) => context
-                .commands
-                .send(WorkerCommand::OpenFork(pane))
-                .map_err(|_| RuntimeError::AgentWorkerStopped)?,
+            AppEffect::OpenFork { pane, parent } => {
+                let parent_sequence = {
+                    let journal = context
+                        .panes
+                        .get_mut(&parent)
+                        .expect("fork parent pane must have a runtime")
+                        .journal_mut()?;
+                    journal.flush().await?;
+                    journal.last_sequence()
+                };
+                context
+                    .commands
+                    .send(WorkerCommand::OpenFork {
+                        pane,
+                        parent_sequence,
+                    })
+                    .map_err(|_| RuntimeError::AgentWorkerStopped)?;
+            }
             AppEffect::ClosePane(pane) => {
                 if let Some(runtime) = context.panes.get(&pane) {
                     schedule_subagent_shutdown(runtime, context.subagent_shutdowns);
@@ -2245,6 +2312,7 @@ fn apply_pane_effect(
                     tokio::task::spawn_blocking(move || -> Result<_> {
                     let reasoning_mode = session::reasoning_mode(&records);
                     let model = session::model(&records);
+                    let next_sequence = session::next_sequence(&records);
                     let projection = RootNode::project_session(effort, records);
                     let configured = ConfiguredAgent::from_config_with_session(
                         &config,
@@ -2259,6 +2327,7 @@ fn apply_pane_effect(
                         projection,
                         reasoning_mode,
                         model,
+                        next_sequence,
                     })
                     })
                     .await
@@ -2883,7 +2952,7 @@ mod tests {
                 pane: PaneId::Main,
                 generation: 0,
             },
-            PaneSession::new("main-session", None, false),
+            PaneSession::new("main-session", None, None, 1, false),
             &config,
             PaneSettings::new(
                 ReasoningEffort::Low,
@@ -2901,7 +2970,7 @@ mod tests {
                 pane: PaneId::Fork(1),
                 generation: 0,
             },
-            PaneSession::new("fork-session", Some("main-session"), false),
+            PaneSession::new("fork-session", Some("main-session"), Some(0), 1, false),
             &config,
             PaneSettings::new(
                 ReasoningEffort::Low,
@@ -2991,7 +3060,7 @@ mod tests {
                 pane: PaneId::Main,
                 generation: 0,
             },
-            PaneSession::new("old-session", None, false),
+            PaneSession::new("old-session", None, None, 1, false),
             &config,
             PaneSettings::new(
                 ReasoningEffort::Medium,
@@ -3018,7 +3087,7 @@ mod tests {
                 pane: PaneId::Main,
                 generation: 1,
             },
-            PaneSession::new("new-session", None, false),
+            PaneSession::new("new-session", None, None, 1, false),
             &config,
             PaneSettings::new(
                 ReasoningEffort::Medium,

--- a/src/tui/pane.rs
+++ b/src/tui/pane.rs
@@ -1,4 +1,4 @@
-//! Stable identities for the primary and optional forked sessions.
+//! Stable identities for sessions that can move between primary and fork roles.
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum PaneId {

--- a/src/tui/session.rs
+++ b/src/tui/session.rs
@@ -10,6 +10,7 @@ use crate::{
 use nanocodex::{Model, agent::session::SessionSnapshot};
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -80,6 +81,14 @@ pub(crate) enum SessionError {
         "session {session_id} uses resume-state format {found}; expected {RESUME_STATE_FORMAT_VERSION}"
     )]
     IncompatibleCheckpoint { session_id: String, found: u32 },
+    #[error("session lineage contains a cycle at {session_id}")]
+    LineageCycle { session_id: String },
+    #[error("session lineage references missing ancestor {session_id}")]
+    MissingAncestor { session_id: String },
+    #[error("stored transcript for {session_id} has no matching session start")]
+    InvalidLineageStart { session_id: String },
+    #[error("session {session_id} does not contain lineage boundary {sequence}")]
+    InvalidLineageBoundary { session_id: String, sequence: u64 },
     #[error("the session storage task stopped unexpectedly: {0}")]
     StorageTask(#[source] tokio::task::JoinError),
 }
@@ -207,7 +216,87 @@ pub(crate) fn load_transcript(
     let Some(storage) = SessionStorage::open_read_only(config_path)? else {
         return Ok(Vec::new());
     };
-    storage.load_records(session_id).map_err(Into::into)
+    let mut records = Vec::new();
+    load_lineage(
+        &storage,
+        session_id,
+        None,
+        &mut HashSet::new(),
+        &mut records,
+    )?;
+    Ok(records)
+}
+
+fn load_lineage(
+    storage: &SessionStorage,
+    session_id: &str,
+    through_sequence: Option<u64>,
+    loading: &mut HashSet<String>,
+    records: &mut Vec<Arc<TranscriptRecord>>,
+) -> Result<(), SessionError> {
+    if through_sequence == Some(0) {
+        return Ok(());
+    }
+    if !loading.insert(session_id.to_owned()) {
+        return Err(SessionError::LineageCycle {
+            session_id: session_id.to_owned(),
+        });
+    }
+    let (local, boundary_found, session_found) = match through_sequence {
+        Some(sequence) => {
+            let prefix = storage.load_records_through(session_id, sequence)?;
+            (prefix.records, prefix.boundary_found, prefix.session_found)
+        }
+        None => (storage.load_records(session_id)?, true, true),
+    };
+    if local.is_empty() {
+        loading.remove(session_id);
+        if through_sequence.is_some() && !session_found {
+            return Err(SessionError::MissingAncestor {
+                session_id: session_id.to_owned(),
+            });
+        }
+        if let Some(sequence) = through_sequence
+            && !boundary_found
+        {
+            return Err(SessionError::InvalidLineageBoundary {
+                session_id: session_id.to_owned(),
+                sequence,
+            });
+        }
+        return Ok(());
+    }
+    if let Some(sequence) = through_sequence
+        && !boundary_found
+    {
+        loading.remove(session_id);
+        return Err(SessionError::InvalidLineageBoundary {
+            session_id: session_id.to_owned(),
+            sequence,
+        });
+    }
+    let started = local
+        .iter()
+        .find(|record| record.source() == "tact" && record.kind() == "session.started")
+        .and_then(|record| record.decode_payload::<SessionStarted>().ok());
+    if through_sequence.is_some()
+        && !started
+            .as_ref()
+            .is_some_and(|started| started.session_id == session_id)
+    {
+        return Err(SessionError::InvalidLineageStart {
+            session_id: session_id.to_owned(),
+        });
+    }
+    if let Some(started) = started
+        && let (Some(parent), Some(parent_sequence)) =
+            (started.parent_session_id, started.parent_sequence)
+    {
+        load_lineage(storage, &parent, Some(parent_sequence), loading, records)?;
+    }
+    records.extend(local);
+    loading.remove(session_id);
+    Ok(())
 }
 
 pub(crate) async fn load_transcript_async(
@@ -222,6 +311,7 @@ pub(crate) async fn load_transcript_async(
 pub(crate) fn reasoning_mode(records: &[Arc<TranscriptRecord>]) -> ReasoningMode {
     records
         .iter()
+        .rev()
         .find(|record| record.source() == "tact" && record.kind() == "session.started")
         .and_then(|record| record.decode_payload::<SessionStarted>().ok())
         .map_or(ReasoningMode::Standard, |started| started.reasoning_mode)
@@ -230,10 +320,37 @@ pub(crate) fn reasoning_mode(records: &[Arc<TranscriptRecord>]) -> ReasoningMode
 pub(crate) fn model(records: &[Arc<TranscriptRecord>]) -> Model {
     records
         .iter()
+        .rev()
         .find(|record| record.source() == "tact" && record.kind() == "session.started")
         .and_then(|record| record.decode_payload::<SessionStarted>().ok())
         .and_then(|started| started.model.parse().ok())
         .unwrap_or(Model::Sol)
+}
+
+pub(crate) fn next_sequence(records: &[Arc<TranscriptRecord>]) -> u64 {
+    let current_session_id = records.iter().rev().find_map(|record| {
+        (record.source() == "tact" && record.kind() == "session.started")
+            .then(|| record.decode_payload::<SessionStarted>().ok())
+            .flatten()
+            .map(|started| started.session_id)
+    });
+    let Some(current_session_id) = current_session_id else {
+        return 1;
+    };
+    let mut segment = None::<String>;
+    let mut maximum = 0;
+    for record in records {
+        if record.source() == "tact" && record.kind() == "session.started" {
+            segment = record
+                .decode_payload::<SessionStarted>()
+                .ok()
+                .map(|started| started.session_id);
+        }
+        if segment.as_deref() == Some(&current_session_id) {
+            maximum = maximum.max(record.sequence());
+        }
+    }
+    maximum.saturating_add(1).max(1)
 }
 
 pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
@@ -290,6 +407,46 @@ mod tests {
         .unwrap()
     }
 
+    fn started(
+        sequence: u64,
+        session_id: &str,
+        parent_session_id: Option<&str>,
+        parent_sequence: Option<u64>,
+    ) -> Arc<TranscriptRecord> {
+        Arc::new(
+            TranscriptRecord::from_local(
+                sequence,
+                sequence,
+                LocalEvent::SessionStarted(SessionStarted {
+                    session_id: session_id.to_owned(),
+                    parent_session_id: parent_session_id.map(str::to_owned),
+                    parent_sequence,
+                    model: Model::Luna.to_string(),
+                    effort: ReasoningEffort::Medium,
+                    reasoning_mode: ReasoningMode::Standard,
+                    fast_mode: false,
+                    workspace: "/work".into(),
+                    application_version: "test".to_owned(),
+                }),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn prompt(sequence: u64, text: &str) -> Arc<TranscriptRecord> {
+        Arc::new(
+            TranscriptRecord::from_local(
+                sequence,
+                sequence,
+                LocalEvent::UserSubmitted {
+                    id: TurnId::new(sequence),
+                    text: text.to_owned(),
+                },
+            )
+            .unwrap(),
+        )
+    }
+
     #[test]
     fn loading_a_missing_session_does_not_create_storage() {
         let directory = tempdir().unwrap();
@@ -307,6 +464,7 @@ mod tests {
             LocalEvent::SessionStarted(SessionStarted {
                 session_id: "session".to_owned(),
                 parent_session_id: None,
+                parent_sequence: None,
                 model: Model::Luna.to_string(),
                 effort: ReasoningEffort::Medium,
                 reasoning_mode: ReasoningMode::Standard,
@@ -333,6 +491,7 @@ mod tests {
                     LocalEvent::SessionStarted(SessionStarted {
                         session_id: "session".to_owned(),
                         parent_session_id: None,
+                        parent_sequence: None,
                         model: "model".to_owned(),
                         effort: ReasoningEffort::Medium,
                         reasoning_mode: ReasoningMode::Standard,
@@ -367,6 +526,157 @@ mod tests {
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0].kind(), "session.started");
         assert_eq!(loaded[1].kind(), "user.submitted");
+    }
+
+    #[test]
+    fn fork_resume_loads_its_parent_only_through_the_fork_boundary() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        storage
+            .append_records(
+                "parent",
+                &[
+                    started(1, "parent", None, None),
+                    prompt(2, "before the fork"),
+                    prompt(3, "later in the parent"),
+                ],
+            )
+            .unwrap();
+        storage
+            .append_records(
+                "fork",
+                &[
+                    started(1, "fork", Some("parent"), Some(2)),
+                    prompt(2, "inside the fork"),
+                    prompt(3, "later in the fork"),
+                ],
+            )
+            .unwrap();
+        storage
+            .append_records(
+                "grandchild",
+                &[
+                    started(1, "grandchild", Some("fork"), Some(2)),
+                    prompt(2, "inside the grandchild"),
+                ],
+            )
+            .unwrap();
+
+        let loaded = load_transcript(&config, "grandchild").unwrap();
+        let prompts = loaded
+            .iter()
+            .filter(|record| record.kind() == "user.submitted")
+            .map(|record| record.payload_json().to_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            prompts,
+            [
+                r#"{"id":2,"text":"before the fork"}"#,
+                r#"{"id":2,"text":"inside the fork"}"#,
+                r#"{"id":2,"text":"inside the grandchild"}"#,
+            ]
+        );
+        assert_eq!(
+            loaded
+                .iter()
+                .filter(|record| record.kind() == "session.started")
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn resumed_session_sequences_continue_after_every_existing_segment() {
+        let records = [
+            started(1, "parent", None, None),
+            prompt(8, "parent prompt"),
+            started(1, "fork", None, None),
+            prompt(2, "first fork segment"),
+            started(3, "fork", None, None),
+            prompt(4, "second fork segment"),
+        ];
+
+        assert_eq!(super::next_sequence(&records), 5);
+    }
+
+    #[test]
+    fn fork_resume_rejects_a_missing_nonempty_ancestor() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let started = started(1, "fork", Some("missing"), Some(1));
+        SessionStorage::open(&config)
+            .unwrap()
+            .append_records("fork", &[started])
+            .unwrap();
+
+        let error = load_transcript(&config, "fork").unwrap_err();
+
+        assert!(matches!(
+            error,
+            super::SessionError::MissingAncestor { session_id } if session_id == "missing"
+        ));
+    }
+
+    #[test]
+    fn fork_resume_rejects_a_lineage_cycle() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        storage
+            .append_records("one", &[started(1, "one", Some("two"), Some(1))])
+            .unwrap();
+        storage
+            .append_records("two", &[started(1, "two", Some("one"), Some(1))])
+            .unwrap();
+
+        let error = load_transcript(&config, "one").unwrap_err();
+
+        assert!(matches!(
+            error,
+            super::SessionError::LineageCycle { session_id } if session_id == "one"
+        ));
+    }
+
+    #[test]
+    fn fork_resume_stops_decoding_at_the_parent_boundary() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        storage
+            .append_records(
+                "parent",
+                &[started(1, "parent", None, None), prompt(2, "inherited")],
+            )
+            .unwrap();
+        storage.append_raw_record("parent", b"not-json").unwrap();
+        storage
+            .append_records("fork", &[started(1, "fork", Some("parent"), Some(2))])
+            .unwrap();
+
+        let loaded = load_transcript(&config, "fork").unwrap();
+
+        assert_eq!(loaded.len(), 3);
+        assert_eq!(loaded[1].payload_json(), r#"{"id":2,"text":"inherited"}"#);
+    }
+
+    #[test]
+    fn fork_resume_rejects_a_boundary_that_is_not_persisted() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        storage
+            .append_records(
+                "parent",
+                &[started(1, "parent", None, None), prompt(3, "after gap")],
+            )
+            .unwrap();
+        storage
+            .append_records("fork", &[started(1, "fork", Some("parent"), Some(2))])
+            .unwrap();
+
+        assert!(load_transcript(&config, "fork").is_err());
     }
 
     #[test]
@@ -416,6 +726,7 @@ mod tests {
         journal.defer_start(SessionStarted {
             session_id: "session".to_owned(),
             parent_session_id: None,
+            parent_sequence: None,
             model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
@@ -452,6 +763,7 @@ mod tests {
         journal.defer_start(SessionStarted {
             session_id: "session".to_owned(),
             parent_session_id: None,
+            parent_sequence: None,
             model: nanocodex::oai::MODEL.to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,

--- a/src/tui/storage.rs
+++ b/src/tui/storage.rs
@@ -108,6 +108,12 @@ pub(crate) struct SessionStorage {
     active_turns: HashMap<String, u64>,
 }
 
+pub(crate) struct RecordPrefix {
+    pub(crate) records: Vec<Arc<TranscriptRecord>>,
+    pub(crate) boundary_found: bool,
+    pub(crate) session_found: bool,
+}
+
 impl SessionStorage {
     pub(crate) fn open(config_path: &Path) -> Result<Self, StorageError> {
         let path = database_path(config_path);
@@ -228,6 +234,29 @@ impl SessionStorage {
         &self,
         session_id: &str,
     ) -> Result<Vec<Arc<TranscriptRecord>>, StorageError> {
+        Ok(self.load_record_prefix(session_id, None)?.records)
+    }
+
+    pub(crate) fn load_records_through(
+        &self,
+        session_id: &str,
+        through_sequence: u64,
+    ) -> Result<RecordPrefix, StorageError> {
+        if through_sequence == 0 {
+            return Ok(RecordPrefix {
+                records: Vec::new(),
+                boundary_found: true,
+                session_found: false,
+            });
+        }
+        self.load_record_prefix(session_id, Some(through_sequence))
+    }
+
+    fn load_record_prefix(
+        &self,
+        session_id: &str,
+        through_sequence: Option<u64>,
+    ) -> Result<RecordPrefix, StorageError> {
         let mut statement = self
             .connection
             .prepare("SELECT record_json FROM events WHERE session_id = ?1 ORDER BY event_id")
@@ -236,7 +265,9 @@ impl SessionStorage {
             .query([session_id])
             .map_err(|source| query(&self.path, source))?;
         let mut records = Vec::new();
+        let mut session_found = false;
         while let Some(row) = rows.next().map_err(|source| query(&self.path, source))? {
+            session_found = true;
             let encoded = row
                 .get_ref(0)
                 .map_err(|source| query(&self.path, source))?
@@ -251,9 +282,25 @@ impl SessionStorage {
                         ),
                     )
                 })?;
-            records.push(Arc::new(decode_record(encoded)?));
+            let record = Arc::new(decode_record(encoded)?);
+            if through_sequence.is_some_and(|end| record.sequence() > end) {
+                break;
+            }
+            let boundary_found = through_sequence == Some(record.sequence());
+            records.push(record);
+            if boundary_found {
+                return Ok(RecordPrefix {
+                    records,
+                    boundary_found: true,
+                    session_found,
+                });
+            }
         }
-        Ok(records)
+        Ok(RecordPrefix {
+            records,
+            boundary_found: through_sequence.is_none(),
+            session_found,
+        })
     }
 
     pub(crate) fn load_record_page(
@@ -904,6 +951,7 @@ mod tests {
                     LocalEvent::SessionStarted(SessionStarted {
                         session_id: session_id.to_owned(),
                         parent_session_id: None,
+                        parent_sequence: None,
                         model: "model".to_owned(),
                         effort: ReasoningEffort::Medium,
                         reasoning_mode: ReasoningMode::Standard,

--- a/src/tui/transcript/entry.rs
+++ b/src/tui/transcript/entry.rs
@@ -48,6 +48,7 @@ pub(crate) enum EntryKind {
     Reasoning { text: String },
     Tool(ToolEntry),
     DirectedMessage(DirectedMessageEntry),
+    ForkedFrom { session_id: String },
     EffortChanged { to: ReasoningEffort },
     FastModeChanged { enabled: bool },
     Interrupted { count: usize },

--- a/src/tui/transcript/journal.rs
+++ b/src/tui/transcript/journal.rs
@@ -13,14 +13,19 @@ use std::{
     },
     time::{SystemTime, UNIX_EPOCH},
 };
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
 
 pub(crate) struct TranscriptJournal {
     path: PathBuf,
-    sender: mpsc::UnboundedSender<PendingWrite>,
+    sender: mpsc::UnboundedSender<JournalCommand>,
     persisted: Arc<AtomicBool>,
     pending_start: Option<SessionStarted>,
     next_sequence: u64,
+    last_sequence: u64,
+    empty: bool,
 }
 
 pub(crate) struct TranscriptWriter {
@@ -32,10 +37,27 @@ struct PendingWrite {
     resume_state: Option<Vec<u8>>,
 }
 
+enum JournalCommand {
+    Write(PendingWrite),
+    Flush(oneshot::Sender<()>),
+}
+
 impl TranscriptJournal {
+    #[cfg_attr(
+        not(test),
+        allow(dead_code, reason = "used by focused persistence tests")
+    )]
     pub(crate) fn open(
         config_path: &Path,
         session_id: &str,
+    ) -> Result<(Self, TranscriptWriter), TranscriptError> {
+        Self::open_at(config_path, session_id, 1)
+    }
+
+    pub(crate) fn open_at(
+        config_path: &Path,
+        session_id: &str,
+        next_sequence: u64,
     ) -> Result<(Self, TranscriptWriter), TranscriptError> {
         let path = database_path(config_path);
         let (sender, receiver) = mpsc::unbounded_channel();
@@ -52,7 +74,9 @@ impl TranscriptJournal {
                 sender,
                 persisted,
                 pending_start: None,
-                next_sequence: 1,
+                next_sequence,
+                last_sequence: next_sequence.saturating_sub(1),
+                empty: true,
             },
             TranscriptWriter { task },
         ))
@@ -71,7 +95,29 @@ impl TranscriptJournal {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.next_sequence == 1
+        self.empty
+    }
+
+    pub(crate) const fn last_sequence(&self) -> u64 {
+        self.last_sequence
+    }
+
+    pub(crate) async fn flush(&self) -> Result<(), TranscriptError> {
+        let (completion, completed) = oneshot::channel();
+        self.sender
+            .send(JournalCommand::Flush(completion))
+            .map_err(|_| TranscriptError::WriterStopped(self.path.clone()))?;
+        completed
+            .await
+            .map_err(|_| TranscriptError::WriterStopped(self.path.clone()))
+    }
+
+    pub(crate) async fn persist_start(
+        &mut self,
+    ) -> Result<Option<Arc<TranscriptRecord>>, TranscriptError> {
+        let record = self.start_if_needed()?;
+        self.flush().await?;
+        Ok(record)
     }
 
     pub(crate) fn set_initial_effort(&mut self, effort: crate::app::config::ReasoningEffort) {
@@ -95,7 +141,7 @@ impl TranscriptJournal {
         &mut self,
         event: AgentEvent,
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
-        self.start_if_needed()?;
+        drop(self.start_if_needed()?);
         let record = TranscriptRecord::from_agent(self.next_sequence, unix_milliseconds(), event);
         self.next_sequence = self.next_sequence.saturating_add(1);
         if record.kind() == "api.event" {
@@ -114,7 +160,7 @@ impl TranscriptJournal {
         &mut self,
         event: LocalEvent,
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
-        self.start_if_needed()?;
+        drop(self.start_if_needed()?);
         self.append_local_record(event)
     }
 
@@ -123,17 +169,17 @@ impl TranscriptJournal {
         event: LocalEvent,
         resume_state: Vec<u8>,
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
-        self.start_if_needed()?;
+        drop(self.start_if_needed()?);
         let record = self.local_record(event)?;
         self.send(record, Some(resume_state))
     }
 
-    fn start_if_needed(&mut self) -> Result<(), TranscriptError> {
+    fn start_if_needed(&mut self) -> Result<Option<Arc<TranscriptRecord>>, TranscriptError> {
         let Some(started) = self.pending_start.take() else {
-            return Ok(());
+            return Ok(None);
         };
-        self.append_local_record(LocalEvent::SessionStarted(started))?;
-        Ok(())
+        self.append_local_record(LocalEvent::SessionStarted(started))
+            .map(Some)
     }
 
     fn append_local_record(
@@ -145,6 +191,7 @@ impl TranscriptJournal {
     }
 
     fn local_record(&mut self, event: LocalEvent) -> Result<TranscriptRecord, TranscriptError> {
+        self.empty = false;
         let sequence = self.next_sequence;
         self.next_sequence = self.next_sequence.saturating_add(1);
         TranscriptRecord::from_local(sequence, unix_milliseconds(), event).map_err(|source| {
@@ -156,17 +203,18 @@ impl TranscriptJournal {
     }
 
     fn send(
-        &self,
+        &mut self,
         record: TranscriptRecord,
         resume_state: Option<Vec<u8>>,
     ) -> Result<Arc<TranscriptRecord>, TranscriptError> {
         let record = Arc::new(record);
         self.sender
-            .send(PendingWrite {
+            .send(JournalCommand::Write(PendingWrite {
                 record: Arc::clone(&record),
                 resume_state,
-            })
+            }))
             .map_err(|_| TranscriptError::WriterStopped(self.path.clone()))?;
+        self.last_sequence = record.sequence();
         Ok(record)
     }
 }
@@ -178,40 +226,62 @@ impl TranscriptWriter {
 }
 
 fn write_journal(
-    mut receiver: mpsc::UnboundedReceiver<PendingWrite>,
+    mut receiver: mpsc::UnboundedReceiver<JournalCommand>,
     config_path: &Path,
     session_id: &str,
     persisted: &AtomicBool,
 ) -> Result<(), TranscriptError> {
-    let Some(first) = receiver.blocking_recv() else {
-        return Ok(());
-    };
-    let mut storage = SessionStorage::open(config_path)?;
-    let mut batch = vec![first];
-    loop {
-        while let Ok(record) = receiver.try_recv() {
-            batch.push(record);
+    let mut storage = None;
+    let mut batch = Vec::new();
+    while let Some(command) = receiver.blocking_recv() {
+        let mut commands = vec![command];
+        while let Ok(command) = receiver.try_recv() {
+            commands.push(command);
         }
-        let records = batch
-            .iter()
-            .map(|pending| Arc::clone(&pending.record))
-            .collect::<Vec<_>>();
-        let resume_state = batch
-            .iter()
-            .rev()
-            .find_map(|pending| pending.resume_state.as_deref());
-        if let Some(resume_state) = resume_state {
-            storage.append_records_and_resume_state(session_id, &records, Some(resume_state))?;
-        } else {
-            storage.append_records(session_id, &records)?;
+        for command in commands {
+            match command {
+                JournalCommand::Write(record) => batch.push(record),
+                JournalCommand::Flush(completion) => {
+                    write_batch(&mut storage, &mut batch, config_path, session_id, persisted)?;
+                    let _ = completion.send(());
+                }
+            }
         }
-        persisted.store(true, Ordering::Release);
-        batch.clear();
-        let Some(record) = receiver.blocking_recv() else {
-            return Ok(());
-        };
-        batch.push(record);
+        write_batch(&mut storage, &mut batch, config_path, session_id, persisted)?;
     }
+    Ok(())
+}
+
+fn write_batch(
+    storage: &mut Option<SessionStorage>,
+    batch: &mut Vec<PendingWrite>,
+    config_path: &Path,
+    session_id: &str,
+    persisted: &AtomicBool,
+) -> Result<(), TranscriptError> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+    let storage = match storage {
+        Some(storage) => storage,
+        None => storage.insert(SessionStorage::open(config_path)?),
+    };
+    let records = batch
+        .iter()
+        .map(|pending| Arc::clone(&pending.record))
+        .collect::<Vec<_>>();
+    let resume_state = batch
+        .iter()
+        .rev()
+        .find_map(|pending| pending.resume_state.as_deref());
+    if let Some(resume_state) = resume_state {
+        storage.append_records_and_resume_state(session_id, &records, Some(resume_state))?;
+    } else {
+        storage.append_records(session_id, &records)?;
+    }
+    persisted.store(true, Ordering::Release);
+    batch.clear();
+    Ok(())
 }
 
 fn unix_milliseconds() -> u64 {
@@ -241,6 +311,7 @@ mod tests {
         SessionStarted {
             session_id: session_id.to_owned(),
             parent_session_id: None,
+            parent_sequence: None,
             model: "model".to_owned(),
             effort: ReasoningEffort::Medium,
             reasoning_mode: ReasoningMode::Standard,
@@ -269,6 +340,89 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].kind(), "session.started");
         assert_eq!(records[1].kind(), "user.submitted");
+    }
+
+    #[tokio::test]
+    async fn persist_start_makes_an_untouched_fork_available_to_descendants() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut journal, writer) = TranscriptJournal::open(&config, "fork").unwrap();
+        let mut fork = started("fork");
+        fork.parent_session_id = Some("parent".to_owned());
+        fork.parent_sequence = Some(0);
+        journal.defer_start(fork);
+
+        let record = journal.persist_start().await.unwrap().unwrap();
+
+        assert_eq!(record.sequence(), 1);
+        assert_eq!(journal.last_sequence(), 1);
+        let records = SessionStorage::open(&config)
+            .unwrap()
+            .load_records("fork")
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind(), "session.started");
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn untouched_nested_forks_restore_every_lineage_edge() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut parent, parent_writer) = TranscriptJournal::open(&config, "parent").unwrap();
+        parent.defer_start(started("parent"));
+        parent
+            .append_local(LocalEvent::UserSubmitted {
+                id: TurnId::new(1),
+                text: "parent prompt".to_owned(),
+            })
+            .unwrap();
+        parent.flush().await.unwrap();
+
+        let (mut fork, fork_writer) = TranscriptJournal::open(&config, "fork").unwrap();
+        let mut fork_start = started("fork");
+        fork_start.parent_session_id = Some("parent".to_owned());
+        fork_start.parent_sequence = Some(parent.last_sequence());
+        fork.defer_start(fork_start);
+        fork.persist_start().await.unwrap();
+
+        let (mut grandchild, grandchild_writer) =
+            TranscriptJournal::open(&config, "grandchild").unwrap();
+        let mut grandchild_start = started("grandchild");
+        grandchild_start.parent_session_id = Some("fork".to_owned());
+        grandchild_start.parent_sequence = Some(fork.last_sequence());
+        grandchild.defer_start(grandchild_start);
+        grandchild
+            .append_local(LocalEvent::UserSubmitted {
+                id: TurnId::new(1),
+                text: "grandchild prompt".to_owned(),
+            })
+            .unwrap();
+        grandchild.flush().await.unwrap();
+
+        let records = session::load_transcript(&config, "grandchild").unwrap();
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind() == "session.started")
+                .count(),
+            3
+        );
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind() == "user.submitted")
+                .count(),
+            2
+        );
+
+        drop(parent);
+        drop(fork);
+        drop(grandchild);
+        parent_writer.into_task().await.unwrap().unwrap();
+        fork_writer.into_task().await.unwrap().unwrap();
+        grandchild_writer.into_task().await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -1,6 +1,6 @@
 use super::{
-    DirectedMessageEntry, EntryId, EntryKind, MessageDelivery, MessagePhase, ShellId, ToolEntry,
-    ToolState, TranscriptEntry, TranscriptRecord, TransientStatus,
+    DirectedMessageEntry, EntryId, EntryKind, MessageDelivery, MessagePhase, SessionStarted,
+    ShellId, ToolEntry, ToolState, TranscriptEntry, TranscriptRecord, TransientStatus,
 };
 use crate::{
     app::config::ReasoningEffort,
@@ -230,6 +230,11 @@ impl TranscriptModel {
 
     fn apply_local(&mut self, record: &TranscriptRecord) -> ModelChange {
         let changed = match record.kind() {
+            "session.started" => self.decode_local::<SessionStarted>(record).map(|payload| {
+                if let Some(session_id) = payload.parent_session_id {
+                    self.push(EntryKind::ForkedFrom { session_id });
+                }
+            }),
             "user.submitted" => self.decode_local::<UserSubmitted>(record).map(|payload| {
                 self.push(EntryKind::User { text: payload.text });
             }),

--- a/src/tui/transcript/record.rs
+++ b/src/tui/transcript/record.rs
@@ -33,6 +33,8 @@ pub(crate) struct SessionStarted {
     pub(crate) session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) parent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) parent_sequence: Option<u64>,
     pub(crate) model: String,
     pub(crate) effort: ReasoningEffort,
     pub(crate) reasoning_mode: ReasoningMode,
@@ -245,6 +247,10 @@ impl TranscriptRecord {
 
     pub(crate) const fn recorded_at_unix_ms(&self) -> u64 {
         self.recorded_at_unix_ms
+    }
+
+    pub(crate) const fn sequence(&self) -> u64 {
+        self.sequence
     }
 
     pub(crate) fn kind(&self) -> &str {

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -53,7 +53,10 @@ pub(crate) enum WorkerCommand {
         enabled: bool,
     },
     CancelAll(PaneId),
-    OpenFork(PaneId),
+    OpenFork {
+        pane: PaneId,
+        parent_sequence: u64,
+    },
     ClosePane(PaneId),
 }
 
@@ -79,6 +82,7 @@ pub(crate) enum WorkerEvent {
         id: TurnId,
         error: Option<String>,
         snapshot: Option<Box<SessionSnapshot>>,
+        terminal_expected: bool,
     },
     SteerAdmitted {
         pane: PaneId,
@@ -103,6 +107,7 @@ pub(crate) enum WorkerEvent {
     ForkOpened {
         pane: PaneId,
         parent: PaneId,
+        parent_sequence: u64,
         events: AgentEvents,
     },
     ForkFailed {
@@ -381,7 +386,10 @@ async fn run(
                         cancel_pane(pane, &controls, &mut cancelled, &updates).await;
                         continue;
                     }
-                    WorkerCommand::OpenFork(pane) => {
+                    WorkerCommand::OpenFork {
+                        pane,
+                        parent_sequence,
+                    } => {
                         if fork.is_some() {
                             drop(updates.send(WorkerEvent::ForkFailed {
                                 pane,
@@ -407,6 +415,7 @@ async fn run(
                                 drop(updates.send(WorkerEvent::ForkOpened {
                                     pane,
                                     parent: *main_pane,
+                                    parent_sequence,
                                     events,
                                 }));
                             }
@@ -624,6 +633,7 @@ fn reject_turn(request: TurnRequest, error: String, updates: &mpsc::UnboundedSen
             id: request.id,
             error: Some(error),
             snapshot: None,
+            terminal_expected: false,
         })),
         TurnPurpose::Auxiliary(completion) => {
             drop(completion.send(Err(AuxiliaryError::Failed(error))));
@@ -752,6 +762,7 @@ fn finish_turn(
                 id: TurnId::new(0),
                 error: Some(format!("turn task stopped unexpectedly: {error}")),
                 snapshot: None,
+                terminal_expected: false,
             }));
             return;
         }
@@ -774,6 +785,7 @@ fn finish_turn(
                 id: key.id,
                 error,
                 snapshot,
+                terminal_expected: true,
             }));
         }
         TurnPurpose::Auxiliary(completion) => {

--- a/src/tui/worker.rs
+++ b/src/tui/worker.rs
@@ -102,6 +102,7 @@ pub(crate) enum WorkerEvent {
     },
     ForkOpened {
         pane: PaneId,
+        parent: PaneId,
         events: AgentEvents,
     },
     ForkFailed {
@@ -246,7 +247,7 @@ async fn run(
     updates: mpsc::UnboundedSender<WorkerEvent>,
     shutdown: CancellationToken,
 ) {
-    let mut main = Some(agent);
+    let mut main = Some((PaneId::Main, agent));
     let mut fork = None::<(PaneId, Nanocodex)>;
     let mut controls = HashMap::<TurnKey, TurnControl>::new();
     let mut memory_reviews = HashMap::from([(PaneId::Main, memory_review)]);
@@ -334,22 +335,18 @@ async fn run(
                         memory_review,
                     } => {
                         debug_assert!(!controls.keys().any(|key| key.pane == pane));
-                        let retired = match pane {
-                            PaneId::Main => {
-                                memory_reviews.insert(pane, memory_review);
-                                main.replace(agent)
-                            }
-                            PaneId::Fork(_) if fork.as_ref().is_some_and(|(id, _)| *id == pane) => {
-                                memory_reviews.insert(pane, memory_review);
-                                fork.replace((pane, agent)).map(|(_, agent)| agent)
-                            }
-                            PaneId::Fork(_) => {
-                                drop(updates.send(WorkerEvent::ForkFailed {
-                                    pane,
-                                    error: "session pane is no longer available".to_owned(),
-                                }));
-                                Some(agent)
-                            }
+                        let retired = if main.as_ref().is_some_and(|(id, _)| *id == pane) {
+                            memory_reviews.insert(pane, memory_review);
+                            main.replace((pane, agent)).map(|(_, agent)| agent)
+                        } else if fork.as_ref().is_some_and(|(id, _)| *id == pane) {
+                            memory_reviews.insert(pane, memory_review);
+                            fork.replace((pane, agent)).map(|(_, agent)| agent)
+                        } else {
+                            drop(updates.send(WorkerEvent::ForkFailed {
+                                pane,
+                                error: "session pane is no longer available".to_owned(),
+                            }));
+                            Some(agent)
                         };
                         if let Some(retired) = retired {
                             drop(retired.shutdown().await);
@@ -392,7 +389,7 @@ async fn run(
                             }));
                             continue;
                         }
-                        let Some(agent) = main.as_ref() else {
+                        let Some((main_pane, agent)) = main.as_ref() else {
                             drop(updates.send(WorkerEvent::ForkFailed {
                                 pane,
                                 error: "the primary session is no longer available".to_owned(),
@@ -402,12 +399,16 @@ async fn run(
                         match agent.fork().await {
                             Ok((agent, events)) => {
                                 let memory_review = *memory_reviews
-                                    .get(&PaneId::Main)
+                                    .get(main_pane)
                                     .expect("the primary pane must have memory-review state");
                                 let memory_review = memory_review.forked();
                                 memory_reviews.insert(pane, memory_review);
                                 fork = Some((pane, agent));
-                                drop(updates.send(WorkerEvent::ForkOpened { pane, events }));
+                                drop(updates.send(WorkerEvent::ForkOpened {
+                                    pane,
+                                    parent: *main_pane,
+                                    events,
+                                }));
                             }
                             Err(error) => drop(updates.send(WorkerEvent::ForkFailed {
                                 pane,
@@ -417,12 +418,14 @@ async fn run(
                         continue;
                     }
                     WorkerCommand::ClosePane(pane) => {
-                        let agent = match pane {
-                            PaneId::Main => main.take(),
-                            PaneId::Fork(_) if fork.as_ref().is_some_and(|(id, _)| *id == pane) => {
-                                fork.take().map(|(_, agent)| agent)
-                            }
-                            PaneId::Fork(_) => None,
+                        let agent = if main.as_ref().is_some_and(|(id, _)| *id == pane) {
+                            let agent = main.take().map(|(_, agent)| agent);
+                            main = fork.take();
+                            agent
+                        } else if fork.as_ref().is_some_and(|(id, _)| *id == pane) {
+                            fork.take().map(|(_, agent)| agent)
+                        } else {
+                            None
                         };
                         memory_reviews.remove(&pane);
                         close_pane(pane, agent, &controls, &mut cancelled, &updates).await;
@@ -461,7 +464,7 @@ async fn run(
 
     drop(cancel_turns(&controls, None).await);
     let (main_shutdown, fork_shutdown) = tokio::join!(
-        shutdown_agent(main.take()),
+        shutdown_agent(main.take().map(|(_, agent)| agent)),
         shutdown_agent(fork.take().map(|(_, agent)| agent)),
     );
     let shutdown_error = main_shutdown.err().or_else(|| fork_shutdown.err());
@@ -790,15 +793,12 @@ fn finish_turn(
 
 fn agent_for<'a>(
     pane: PaneId,
-    main: Option<&'a Nanocodex>,
+    main: Option<&'a (PaneId, Nanocodex)>,
     fork: Option<&'a (PaneId, Nanocodex)>,
 ) -> Option<&'a Nanocodex> {
-    match pane {
-        PaneId::Main => main,
-        PaneId::Fork(_) => fork
-            .filter(|(fork_pane, _)| *fork_pane == pane)
-            .map(|(_, agent)| agent),
-    }
+    main.filter(|(main_pane, _)| *main_pane == pane)
+        .or_else(|| fork.filter(|(fork_pane, _)| *fork_pane == pane))
+        .map(|(_, agent)| agent)
 }
 
 async fn cancel_pane(


### PR DESCRIPTION
## Summary

- promote an open fork when its main session closes, preserving the fork session ID and keeping the TUI usable
- persist exact fork lineage boundaries and reconstruct ancestor transcript history when resuming a fork
- render `Forked from @@<session-id>` boundaries for live and resumed forks
- gate fork creation on joined worker/agent turn completion, flush the parent boundary before forking, and persist child lineage before enabling nested forks
- bound ancestor reads at the persisted fork sequence and reject missing, cyclic, or invalid lineage

## Validation

- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test` (779 passed)