### PR TITLE
fix(tui): adopt universal structured tool results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,8 +2439,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6910a6f7aceeaa50264c66cc53c207291dfc9829ec9a050818137814a1d30f90"
+source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-oai-api",
@@ -2450,8 +2449,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-agent"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791f01cdbd33729f7fb5ad84e92b27d3b3eccae20fdd18da9bdb5ff33f95ed2d"
+source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
 dependencies = [
  "chrono",
  "futures-util",
@@ -2473,8 +2471,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-oai-api"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23e2fbd39b8ecb34efe21a2eb362a0de14f86c436df99f21ed6e904d15ba774"
+source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
 dependencies = [
  "async-trait",
  "base64",
@@ -2500,8 +2497,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc20017ac00d3eeef1a6a2bc5ad63f8b72734e9cbc5a48032fe2b916c8a6b98c"
+source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
 dependencies = [
  "async-trait",
  "base64",
@@ -2531,8 +2527,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools-macros"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94504a431686ef9eab7210a2f9ea4d3f2489a3fbe2fc343239be535e3061045"
+source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,8 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "nanocodex"
-version = "0.4.0"
-source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223def7aa7a85ccdb7bc0ecfef6a9f36ee332db6730c10a757cfd382e08487d4"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-oai-api",
@@ -2448,8 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-agent"
-version = "0.4.0"
-source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bf178f13a34a0e77a4039644d48e823b613c7ebbcfcc6fbf88f7442cb924f8"
 dependencies = [
  "chrono",
  "futures-util",
@@ -2470,8 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-oai-api"
-version = "0.4.0"
-source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb1a99937e9af21fb452d6ebfde1151d2cfaa763c98e22540593a5e22525478"
 dependencies = [
  "async-trait",
  "base64",
@@ -2496,8 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools"
-version = "0.4.0"
-source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2749e5464e7251c1f67e8f1ab6c608c175f66a1c5c64e0fbd8b27b7928cc343"
 dependencies = [
  "async-trait",
  "base64",
@@ -2526,8 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools-macros"
-version = "0.4.0"
-source = "git+https://github.com/clabby/nanocodex?branch=cl%2Fstructured-events#1b7743130d318f3889e4eccad9e821812f29c860"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e27623b5720bc25e4d52e10eba53c0fac0a68213b55b9f1fd91021165429930"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ futures-util = "0.3.33"
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = "0.4.0"
+nanocodex = { git = "https://github.com/clabby/nanocodex", branch = "cl/structured-events" }
 pulldown-cmark = { version = "0.13.4", default-features = false }
 png = "0.18.1"
 ratatui = "0.30.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ futures-util = "0.3.33"
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = { git = "https://github.com/clabby/nanocodex", branch = "cl/structured-events" }
+nanocodex = "0.5.0"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 png = "0.18.1"
 ratatui = "0.30.2"

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -233,6 +233,7 @@ fn mixed_projection_records(turns: u64) -> Vec<Arc<TranscriptRecord>> {
 
         if turn % 4 == 0 {
             let call_id = format!("tool-{turn}");
+            let output = format!("test output for package {turn}\n").repeat(16);
             records.push(agent_record(
                 sequence,
                 AgentEventKind::ToolCall,
@@ -252,7 +253,11 @@ fn mixed_projection_records(turns: u64) -> Vec<Arc<TranscriptRecord>> {
                     "status": "completed",
                     "duration_ns": 1_000_000_u64,
                     "result": {
-                        "output": format!("test output for package {turn}\n").repeat(16),
+                        "output": output.as_str(),
+                        "exit_code": 0,
+                    },
+                    "structured_result": {
+                        "output": output.as_str(),
                         "exit_code": 0,
                     },
                     "metadata": null,
@@ -331,6 +336,7 @@ impl Harness {
                     "status": "completed",
                     "duration_ns": 1_000_000_u64,
                     "result": {"output": output.as_str(), "exit_code": 0},
+                    "structured_result": {"output": output.as_str(), "exit_code": 0},
                     "metadata": null,
                 }),
             ));
@@ -366,6 +372,7 @@ impl Harness {
                 "status": "completed",
                 "duration_ns": 1_000_000_u64,
                 "result": "Done!",
+                "structured_result": {},
                 "metadata": null,
             }),
         ));

--- a/src/tui/bench.rs
+++ b/src/tui/bench.rs
@@ -252,13 +252,13 @@ fn mixed_projection_records(turns: u64) -> Vec<Arc<TranscriptRecord>> {
                     "tool": "exec_command",
                     "status": "completed",
                     "duration_ns": 1_000_000_u64,
-                    "result": {
-                        "output": output.as_str(),
-                        "exit_code": 0,
-                    },
+                    "result": format!(
+                        "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n{output}"
+                    ),
                     "structured_result": {
                         "output": output.as_str(),
                         "exit_code": 0,
+                        "wall_time_seconds": 0.0,
                     },
                     "metadata": null,
                 }),
@@ -335,8 +335,14 @@ impl Harness {
                     "tool": "exec_command",
                     "status": "completed",
                     "duration_ns": 1_000_000_u64,
-                    "result": {"output": output.as_str(), "exit_code": 0},
-                    "structured_result": {"output": output.as_str(), "exit_code": 0},
+                    "result": format!(
+                        "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n{output}"
+                    ),
+                    "structured_result": {
+                        "output": output.as_str(),
+                        "exit_code": 0,
+                        "wall_time_seconds": 0.0,
+                    },
                     "metadata": null,
                 }),
             ));

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -1912,6 +1912,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 1_200_000_000_u64,
                 "result": {"output": output, "exit_code": 0},
+                "structured_result": {"output": output, "exit_code": 0},
                 "metadata": null,
             }),
         )));
@@ -3134,6 +3135,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 2_500_000_000_u64,
                 "result": {"output": "done", "exit_code": 0},
+                "structured_result": {"output": "done", "exit_code": 0},
                 "metadata": null,
             }),
         )));
@@ -3191,6 +3193,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 10_u64,
                 "result": {"output": "ok", "exit_code": 0},
+                "structured_result": {"output": "ok", "exit_code": 0},
                 "metadata": null,
             }),
         )));
@@ -3317,6 +3320,10 @@ mod tests {
                     "output": "error[E0277]: the size for values of type `Self` cannot be known at compilation time",
                     "exit_code": 101
                 },
+                "structured_result": {
+                    "output": "error[E0277]: the size for values of type `Self` cannot be known at compilation time",
+                    "exit_code": 101
+                },
                 "metadata": null,
             }),
         )));
@@ -3403,6 +3410,10 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 1_u64,
                 "result": {
+                    "output": "first output line\nsecond output line",
+                    "session_id": 7
+                },
+                "structured_result": {
                     "output": "first output line\nsecond output line",
                     "session_id": 7
                 },

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -1911,8 +1911,14 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 1_200_000_000_u64,
-                "result": {"output": output, "exit_code": 0},
-                "structured_result": {"output": output, "exit_code": 0},
+                "result": format!(
+                    "Wall time: 1.2000 seconds\nProcess exited with code 0\nOutput:\n{output}"
+                ),
+                "structured_result": {
+                    "output": output,
+                    "exit_code": 0,
+                    "wall_time_seconds": 1.2,
+                },
                 "metadata": null,
             }),
         )));
@@ -3134,8 +3140,12 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 2_500_000_000_u64,
-                "result": {"output": "done", "exit_code": 0},
-                "structured_result": {"output": "done", "exit_code": 0},
+                "result": "Wall time: 2.5000 seconds\nProcess exited with code 0\nOutput:\ndone",
+                "structured_result": {
+                    "output": "done",
+                    "exit_code": 0,
+                    "wall_time_seconds": 2.5,
+                },
                 "metadata": null,
             }),
         )));
@@ -3192,8 +3202,12 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 10_u64,
-                "result": {"output": "ok", "exit_code": 0},
-                "structured_result": {"output": "ok", "exit_code": 0},
+                "result": "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nok",
+                "structured_result": {
+                    "output": "ok",
+                    "exit_code": 0,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         )));
@@ -3316,14 +3330,8 @@ mod tests {
                 "tool": "custom_operation",
                 "status": "failed",
                 "duration_ns": 1_200_000_000_u64,
-                "result": {
-                    "output": "error[E0277]: the size for values of type `Self` cannot be known at compilation time",
-                    "exit_code": 101
-                },
-                "structured_result": {
-                    "output": "error[E0277]: the size for values of type `Self` cannot be known at compilation time",
-                    "exit_code": 101
-                },
+                "result": "error[E0277]: the size for values of type `Self` cannot be known at compilation time",
+                "structured_result": "error[E0277]: the size for values of type `Self` cannot be known at compilation time",
                 "metadata": null,
             }),
         )));
@@ -3409,13 +3417,11 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 1_u64,
-                "result": {
-                    "output": "first output line\nsecond output line",
-                    "session_id": 7
-                },
+                "result": "Wall time: 0.0000 seconds\nProcess running with session ID 7\nOutput:\nfirst output line\nsecond output line",
                 "structured_result": {
                     "output": "first output line\nsecond output line",
-                    "session_id": 7
+                    "session_id": 7,
+                    "wall_time_seconds": 0.0,
                 },
                 "metadata": null,
             }),

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -599,7 +599,11 @@ impl TranscriptModel {
         let payload = record.decode_payload::<ToolResultPayload>()?;
         let resumed_shell = self.shell_followups.remove(&payload.call_id);
         let shell_followup = payload.tool == "write_stdin";
-        let result = normalize_result(payload.result);
+        let result = if matches!(payload.tool.as_str(), "exec_command" | "write_stdin") {
+            normalize_result(payload.structured_result)
+        } else {
+            normalize_result(payload.result)
+        };
         let resumed_result = resumed_shell.map(|_| result.clone());
         let state = tool_result_state(&payload.tool, &payload.status, &result);
         let entry_state = if resumed_shell.is_some() && state == ToolState::Running {
@@ -1217,6 +1221,7 @@ struct ToolResultPayload {
     status: String,
     duration_ns: u64,
     result: Value,
+    structured_result: Value,
     metadata: Option<Value>,
 }
 
@@ -1889,7 +1894,8 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 1_u64,
-                "result": {"output": "running", "session_id": 7},
+                "result": "Process running with session ID 7",
+                "structured_result": {"output": "running", "session_id": 7},
                 "metadata": null,
             }),
         ));
@@ -1917,6 +1923,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 2_u64,
                 "result": {"output": " done", "exit_code": 0},
+                "structured_result": {"output": " done", "exit_code": 0},
                 "metadata": null,
             }),
         ));
@@ -1961,6 +1968,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 1_u64,
                 "result": {"output": "running", "session_id": 7},
+                "structured_result": {"output": "running", "session_id": 7},
                 "metadata": null,
             }),
         ));
@@ -1991,7 +1999,8 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 2_u64,
-                "result": {"output": " still", "session_id": 7},
+                "result": "Process running with session ID 7",
+                "structured_result": {"output": " still", "session_id": 7},
                 "metadata": null,
             }),
         ));
@@ -2022,7 +2031,8 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 2_u64,
-                "result": {"output": " done", "exit_code": 0},
+                "result": "Process exited with code 0",
+                "structured_result": {"output": " done", "exit_code": 0},
                 "metadata": null,
             }),
         ));
@@ -2062,6 +2072,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 1_u64,
                 "result": {"output": "", "exit_code": null},
+                "structured_result": {"output": "", "exit_code": null},
                 "metadata": null,
             }),
         ));
@@ -2144,6 +2155,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 10,
                 "result": {"output": "ok", "exit_code": 0},
+                "structured_result": {"output": "ok", "exit_code": 0},
                 "metadata": null,
             }),
         ));
@@ -2239,6 +2251,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 10,
                 "result": [{"text": "Script running"}],
+                "structured_result": [{"text": "Script running"}],
                 "metadata": null,
             }),
         ));

--- a/src/tui/transcript/model.rs
+++ b/src/tui/transcript/model.rs
@@ -1894,8 +1894,12 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 1_u64,
-                "result": "Process running with session ID 7",
-                "structured_result": {"output": "running", "session_id": 7},
+                "result": "Wall time: 0.0000 seconds\nProcess running with session ID 7\nOutput:\nrunning",
+                "structured_result": {
+                    "output": "running",
+                    "session_id": 7,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         ));
@@ -1922,8 +1926,12 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 2_u64,
-                "result": {"output": " done", "exit_code": 0},
-                "structured_result": {"output": " done", "exit_code": 0},
+                "result": "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n done",
+                "structured_result": {
+                    "output": " done",
+                    "exit_code": 0,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         ));
@@ -1967,8 +1975,12 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 1_u64,
-                "result": {"output": "running", "session_id": 7},
-                "structured_result": {"output": "running", "session_id": 7},
+                "result": "Wall time: 0.0000 seconds\nProcess running with session ID 7\nOutput:\nrunning",
+                "structured_result": {
+                    "output": "running",
+                    "session_id": 7,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         ));
@@ -1999,8 +2011,12 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 2_u64,
-                "result": "Process running with session ID 7",
-                "structured_result": {"output": " still", "session_id": 7},
+                "result": "Wall time: 0.0000 seconds\nProcess running with session ID 7\nOutput:\n still",
+                "structured_result": {
+                    "output": " still",
+                    "session_id": 7,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         ));
@@ -2031,8 +2047,12 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 2_u64,
-                "result": "Process exited with code 0",
-                "structured_result": {"output": " done", "exit_code": 0},
+                "result": "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n done",
+                "structured_result": {
+                    "output": " done",
+                    "exit_code": 0,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         ));
@@ -2071,8 +2091,8 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 1_u64,
-                "result": {"output": "", "exit_code": null},
-                "structured_result": {"output": "", "exit_code": null},
+                "result": "Wall time: 0.0000 seconds\nOutput:\n",
+                "structured_result": {"output": "", "wall_time_seconds": 0.0},
                 "metadata": null,
             }),
         ));
@@ -2154,8 +2174,12 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 10,
-                "result": {"output": "ok", "exit_code": 0},
-                "structured_result": {"output": "ok", "exit_code": 0},
+                "result": "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\nok",
+                "structured_result": {
+                    "output": "ok",
+                    "exit_code": 0,
+                    "wall_time_seconds": 0.0,
+                },
                 "metadata": null,
             }),
         ));


### PR DESCRIPTION
## Summary

- consume Nanocodex structured shell results for reliable process lifecycle projection
- update transcript fixtures to model the separate display and structured result payloads
- replace the temporary Nanocodex Git dependency with the crates.io 0.5.0 release
- inherit Nanocodex's compaction guard for orphaned custom-tool notifications

## Validation

- `just check-fmt`
- `cargo check --all-features`
- `just clippy`
- `just test` (779 passed)

Closes #110.
Closes #111.