### PR TITLE
fix(tui): refresh fork action after promotion

### DIFF
--- a/src/tui/components/actions.rs
+++ b/src/tui/components/actions.rs
@@ -91,6 +91,10 @@ impl ActionsMenu {
         }
     }
 
+    pub(super) fn set_fork_available(&mut self, available: bool) {
+        self.availability.fork = available;
+    }
+
     fn update_key(&mut self, key: KeyEvent) -> ComponentUpdate<ActionsEffect> {
         if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
             return ComponentUpdate::none();

--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -1225,6 +1225,48 @@ mod tests {
     }
 
     #[test]
+    fn promoted_fork_refreshes_an_open_actions_menu() {
+        let mut app = app();
+        app.update(control('f'));
+        app.update(AppEvent::ForkReady {
+            pane: PaneId::Fork(1),
+        });
+        let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+        terminal.draw(|frame| app.render(frame)).unwrap();
+        app.update(AppEvent::Terminal(Event::Key(KeyEvent::new(
+            KeyCode::Char('/'),
+            KeyModifiers::NONE,
+        ))));
+        app.update(AppEvent::Terminal(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 10,
+            row: 5,
+            modifiers: KeyModifiers::NONE,
+        })));
+        app.update(control('c'));
+        app.update(control('c'));
+        for character in "btw".chars() {
+            app.update(AppEvent::Terminal(Event::Key(KeyEvent::new(
+                KeyCode::Char(character),
+                KeyModifiers::NONE,
+            ))));
+        }
+
+        let fork = app.update(AppEvent::Terminal(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))));
+
+        assert!(matches!(
+            fork.effects.as_slice(),
+            [AppEffect::OpenFork {
+                pane: PaneId::Fork(2),
+                parent: PaneId::Fork(1),
+            }]
+        ));
+    }
+
+    #[test]
     fn failed_pending_fork_shuts_down_after_its_parent_closes() {
         let mut app = app();
         app.update(control('f'));

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -414,6 +414,10 @@ impl RootNode {
 
     pub(crate) fn set_fork_available(&mut self, available: bool) {
         self.fork_available = available;
+        let can_fork = self.can_fork();
+        if let Some(Overlay::Actions(actions)) = &mut self.overlay {
+            actions.component_mut().set_fork_available(can_fork);
+        }
     }
 
     pub(crate) fn set_skills(&mut self, skills: Arc<[Skill]>) {


### PR DESCRIPTION
## Summary

- refresh an already-open Actions menu when a fork is promoted to the primary pane
- preserve the complete live safe-checkpoint predicate while updating fork availability
- verify the promoted fork recursively creates a child linked to its own pane

## Validation

- `just check-fmt`
- `cargo check --all-features --locked`
- `just clippy`
- `just test` (780 passed)