### PR TITLE
chore(release): prepare 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Summary

- bump the Tact package version to 0.5.2
- refresh the root package entry in Cargo.lock

## Validation

- `cargo check --all-features --locked`
- `just check-fmt`
- `just clippy`
- `just test` (788 passed)
- `cargo package --allow-dirty --locked`