### PR TITLE
fix(tui): preserve queued edits during dequeue

### DIFF
--- a/src/tui/components/app.rs
+++ b/src/tui/components/app.rs
@@ -75,7 +75,7 @@ pub(crate) enum AppEvent {
     },
     QueueEditorFinished {
         pane: PaneId,
-        index: usize,
+        id: QueueId,
         text: String,
     },
     WorkerTurnFinished {
@@ -288,8 +288,8 @@ impl AppNode {
             AppEvent::HandoffFailed { pane, error } => {
                 self.update_root(pane, RootEvent::HandoffFailed(error))
             }
-            AppEvent::QueueEditorFinished { pane, index, text } => {
-                self.update_root(pane, RootEvent::RestoreQueued { index, text })
+            AppEvent::QueueEditorFinished { pane, id, text } => {
+                self.update_root(pane, RootEvent::FinishQueuedEdit { id, text })
             }
             AppEvent::WorkerTurnFinished {
                 pane,

--- a/src/tui/components/queue.rs
+++ b/src/tui/components/queue.rs
@@ -32,7 +32,7 @@ impl QueueId {
 #[derive(Debug, Eq, PartialEq)]
 pub(super) enum QueueEffect {
     Blur,
-    Edit { index: usize, text: String },
+    Edit { id: QueueId, text: String },
     Steer { id: QueueId, prompt: Submission },
 }
 
@@ -50,6 +50,7 @@ struct QueueItem {
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum QueueItemState {
     Queued,
+    Editing,
     SubmittingSteer,
     AdmittedSteer,
     CancelledSteer,
@@ -88,18 +89,19 @@ impl MessageQueue {
         self.selected = self.items.len() - 1;
     }
 
-    pub(super) fn restore(&mut self, index: usize, text: String) {
-        let index = index.min(self.items.len());
-        self.items.insert(
-            index,
-            QueueItem {
-                id: QueueId(self.next_id),
-                prompt: text.into(),
-                state: QueueItemState::Queued,
-            },
-        );
-        self.next_id = self.next_id.saturating_add(1);
+    pub(super) fn finish_edit(&mut self, id: QueueId, text: String) -> bool {
+        let Some(index) = self.items.iter().position(|item| item.id == id) else {
+            return false;
+        };
+        if text.trim().is_empty() {
+            self.items.remove(index);
+            self.repair_selection();
+            return true;
+        }
+        self.items[index].prompt = text.into();
+        self.items[index].state = QueueItemState::Queued;
         self.selected = index;
+        true
     }
 
     pub(super) fn drain_ready(&mut self) -> Vec<Submission> {
@@ -194,10 +196,14 @@ impl MessageQueue {
     }
 
     pub(super) fn cancel_steers(&mut self) {
-        self.items
-            .sort_by_key(|item| item.state == QueueItemState::Queued);
+        self.items.sort_by_key(|item| {
+            matches!(item.state, QueueItemState::Queued | QueueItemState::Editing)
+        });
         for item in &mut self.items {
-            if item.state != QueueItemState::Queued {
+            if matches!(
+                item.state,
+                QueueItemState::SubmittingSteer | QueueItemState::AdmittedSteer
+            ) {
                 item.state = QueueItemState::CancelledSteer;
             }
         }
@@ -313,12 +319,16 @@ impl MessageQueue {
                 self.remove_selected().is_some()
             }
             KeyCode::Char('e') => {
-                let Some((index, item)) = self.remove_selected() else {
+                let Some(item) = self.items.get_mut(self.selected) else {
                     return ComponentUpdate::none();
                 };
+                if item.state != QueueItemState::Queued {
+                    return ComponentUpdate::none();
+                }
+                item.state = QueueItemState::Editing;
                 return ComponentUpdate {
                     effects: vec![QueueEffect::Edit {
-                        index,
+                        id: item.id,
                         text: item.prompt.display_text().to_owned(),
                     }],
                     render: RenderRequest::Immediate,
@@ -507,7 +517,8 @@ fn truncate(text: &str, width: usize) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Component, MessageQueue, QueueEffect, QueueEvent, STEERING_TEXT, Submission, truncate,
+        Component, MessageQueue, QueueEffect, QueueEvent, QueueId, STEERING_TEXT, Submission,
+        truncate,
     };
     use crate::tui::theme::Theme;
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
@@ -579,20 +590,41 @@ mod tests {
     }
 
     #[test]
-    fn edit_removes_the_item_before_emitting_the_effect() {
+    fn edit_blocks_the_item_before_emitting_the_effect() {
         let mut queue = MessageQueue::default();
         queue.push("edit me".to_owned());
 
         let update = queue.update(key(KeyCode::Char('e'), KeyModifiers::NONE));
 
-        assert!(queue.is_empty());
+        assert_eq!(queue.len(), 1);
+        assert!(queue.drain_ready().is_empty());
         assert_eq!(
             update.effects,
             [QueueEffect::Edit {
-                index: 0,
+                id: QueueId::new(0),
                 text: "edit me".to_owned(),
             }]
         );
+    }
+
+    #[test]
+    fn cancelling_turns_does_not_reorder_an_item_being_edited() {
+        let mut queue = MessageQueue::default();
+        queue.push("first".to_owned());
+        queue.push("edit me".to_owned());
+        queue.push("last".to_owned());
+        queue.update(key(KeyCode::Up, KeyModifiers::NONE));
+
+        queue.update(key(KeyCode::Char('e'), KeyModifiers::NONE));
+        queue.cancel_steers();
+        assert!(queue.finish_edit(QueueId::new(1), "edited".to_owned()));
+
+        let prompts = queue
+            .drain_ready()
+            .into_iter()
+            .map(|prompt| prompt.display_text().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(prompts, ["first", "edited", "last"]);
     }
 
     #[test]

--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -154,8 +154,8 @@ pub(crate) enum RootEvent {
     ReviewCancelled,
     ReviewFinished(String),
     ReviewFailed(String),
-    RestoreQueued {
-        index: usize,
+    FinishQueuedEdit {
+        id: QueueId,
         text: String,
     },
     WorkerTurnFinished {
@@ -227,7 +227,7 @@ pub(crate) enum RootEffect {
     RunShell(String),
     OpenDraftEditor,
     OpenQueueEditor {
-        index: usize,
+        id: QueueId,
         text: String,
     },
     OpenConfigEditor,
@@ -1991,8 +1991,8 @@ impl RootNode {
         for effect in update.effects {
             match effect {
                 QueueEffect::Blur => {}
-                QueueEffect::Edit { index, text } => {
-                    effects.push(RootEffect::OpenQueueEditor { index, text });
+                QueueEffect::Edit { id, text } => {
+                    effects.push(RootEffect::OpenQueueEditor { id, text });
                 }
                 QueueEffect::Steer { id, prompt } => {
                     effects.push(RootEffect::Steer { id, prompt });
@@ -2139,19 +2139,11 @@ impl RootNode {
         update
     }
 
-    fn restore_queued(&mut self, index: usize, text: String) -> ComponentUpdate<RootEffect> {
-        if text.trim().is_empty() {
+    fn finish_queued_edit(&mut self, id: QueueId, text: String) -> ComponentUpdate<RootEffect> {
+        if !self.queue.component_mut().finish_edit(id, text) {
             return ComponentUpdate::render(RenderRequest::Immediate);
         }
-        if self.in_flight_turns == 0 && !self.queue.component().has_pending_steer() {
-            self.in_flight_turns = 1;
-            return ComponentUpdate {
-                effects: vec![RootEffect::Submit(text.into())],
-                render: RenderRequest::Immediate,
-            };
-        }
-        self.queue.component_mut().restore(index, text);
-        ComponentUpdate::render(RenderRequest::Immediate)
+        self.submit_next_queued()
     }
 
     fn submit_next_queued(&mut self) -> ComponentUpdate<RootEffect> {
@@ -2520,7 +2512,7 @@ impl Component for RootNode {
                     RenderRequest::Immediate,
                 )
             }
-            RootEvent::RestoreQueued { index, text } => self.restore_queued(index, text),
+            RootEvent::FinishQueuedEdit { id, text } => self.finish_queued_edit(id, text),
             RootEvent::WorkerTurnFinished { terminal_expected } => {
                 self.worker_turn_finished(terminal_expected)
             }
@@ -2912,9 +2904,9 @@ fn is_plain_key(event: &Event, character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        Component, ComposerChromeTarget, ConfirmationAction, DraftReset, Overlay, RenderRequest,
-        RootEffect, RootEvent, RootNode, SessionListKind, SubagentOverlay, ThreadState,
-        TranscriptEvent,
+        Component, ComposerChromeTarget, ConfirmationAction, DraftReset, Overlay, QueueId,
+        RenderRequest, RootEffect, RootEvent, RootNode, SessionListKind, SubagentOverlay,
+        ThreadState, TranscriptEvent,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -4372,7 +4364,7 @@ mod tests {
     }
 
     #[test]
-    fn editing_removes_a_message_until_the_editor_returns() {
+    fn editing_keeps_a_message_queued_until_the_editor_returns() {
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
         root.in_flight_turns = 1;
         root.queue.component_mut().push("original".to_owned());
@@ -4382,17 +4374,78 @@ mod tests {
         assert_eq!(
             edit.effects,
             [RootEffect::OpenQueueEditor {
-                index: 0,
+                id: QueueId::new(0),
                 text: "original".to_owned(),
             }]
         );
-        assert!(root.queue.component().is_empty());
+        assert_eq!(root.queue.component().len(), 1);
 
-        root.update(super::RootEvent::RestoreQueued {
-            index: 0,
+        root.update(super::RootEvent::FinishQueuedEdit {
+            id: QueueId::new(0),
             text: "edited".to_owned(),
         });
         assert_eq!(root.queue.component().len(), 1);
+    }
+
+    #[test]
+    fn editing_blocks_queue_dequeue_until_the_editor_returns() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.in_flight_turns = 1;
+        root.queue.component_mut().push("edit me".to_owned());
+        root.queue.component_mut().push("later".to_owned());
+        root.queue.component_mut().set_focused(true);
+        root.update(key(KeyCode::Up, KeyModifiers::NONE));
+
+        let edit = root.update(key(KeyCode::Char('e'), KeyModifiers::NONE));
+        assert!(matches!(
+            edit.effects.as_slice(),
+            [RootEffect::OpenQueueEditor { id, text }]
+                if *id == QueueId::new(0) && text == "edit me"
+        ));
+
+        let finished = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
+        assert!(finished.effects.is_empty());
+        assert_eq!(root.in_flight_turns, 0);
+
+        let restored = root.update(super::RootEvent::FinishQueuedEdit {
+            id: QueueId::new(0),
+            text: "edited".to_owned(),
+        });
+        assert_eq!(
+            restored.effects,
+            [RootEffect::Submit("edited\n\nlater".to_owned().into())]
+        );
+        assert_eq!(root.in_flight_turns, 1);
+        assert!(root.queue.component().is_empty());
+    }
+
+    #[test]
+    fn blank_queue_edit_discards_the_item_and_releases_later_messages() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.in_flight_turns = 1;
+        root.queue.component_mut().push("discard me".to_owned());
+        root.queue.component_mut().push("later".to_owned());
+        root.queue.component_mut().set_focused(true);
+        root.update(key(KeyCode::Up, KeyModifiers::NONE));
+
+        root.update(key(KeyCode::Char('e'), KeyModifiers::NONE));
+        let finished = root.update(super::RootEvent::WorkerTurnFinished {
+            terminal_expected: false,
+        });
+        assert!(finished.effects.is_empty());
+
+        let edited = root.update(super::RootEvent::FinishQueuedEdit {
+            id: QueueId::new(0),
+            text: "  \n".to_owned(),
+        });
+        assert_eq!(
+            edited.effects,
+            [RootEffect::Submit("later".to_owned().into())]
+        );
+        assert_eq!(root.in_flight_turns, 1);
+        assert!(root.queue.component().is_empty());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -37,8 +37,8 @@ use crate::{
     tui::{
         agent_events::ForwardedAgentEvent,
         components::{
-            AppEffect, AppEvent, AppNode, ComponentUpdate, RecentPromptDraft, RenderRequest,
-            RestoredSessionProjection, RootNode,
+            AppEffect, AppEvent, AppNode, ComponentUpdate, QueueId, RecentPromptDraft,
+            RenderRequest, RestoredSessionProjection, RootNode,
         },
         editor::EditorOutcome,
         handoff_controller::{HandoffCompletion, HandoffController, PreparedHandoff},
@@ -159,7 +159,7 @@ enum EditorTarget {
     },
     Queue {
         pane: PaneId,
-        index: usize,
+        id: QueueId,
         text: String,
     },
     Config(PathBuf),
@@ -173,7 +173,7 @@ enum EditorCompletion {
     },
     Queue {
         pane: PaneId,
-        index: usize,
+        id: QueueId,
         original: String,
         outcome: EditorOutcome,
     },
@@ -1159,7 +1159,7 @@ pub(crate) async fn run(
                     }
                     EditorCompletion::Queue {
                         pane,
-                        index,
+                        id,
                         original,
                         outcome,
                     } => {
@@ -1167,10 +1167,11 @@ pub(crate) async fn run(
                             EditorOutcome::Updated(text) => text,
                             EditorOutcome::Unchanged => original,
                         };
-                        schedule(
-                            app.update(AppEvent::QueueEditorFinished { pane, index, text }),
-                            &mut scheduler,
-                        );
+                        apply_app_update!(app.update(AppEvent::QueueEditorFinished {
+                            pane,
+                            id,
+                            text,
+                        }));
                     }
                     EditorCompletion::Draft { outcome: EditorOutcome::Unchanged, .. }
                     | EditorCompletion::Config
@@ -1969,8 +1970,8 @@ fn apply_pane_effect(
                         .draft()
                         .to_owned(),
                 },
-                components::RootEffect::OpenQueueEditor { index, text } => {
-                    EditorTarget::Queue { pane, index, text }
+                components::RootEffect::OpenQueueEditor { id, text } => {
+                    EditorTarget::Queue { pane, id, text }
                 }
                 components::RootEffect::OpenConfigEditor => {
                     EditorTarget::Config(context.config.path().to_path_buf())
@@ -1987,11 +1988,11 @@ fn apply_pane_effect(
                         let outcome = editor::edit(&text, &workspace).await?;
                         Ok(EditorCompletion::Draft { pane, outcome })
                     }
-                    EditorTarget::Queue { pane, index, text } => {
+                    EditorTarget::Queue { pane, id, text } => {
                         let outcome = editor::edit(&text, &workspace).await?;
                         Ok(EditorCompletion::Queue {
                             pane,
-                            index,
+                            id,
                             original: text,
                             outcome,
                         })


### PR DESCRIPTION
## Overview

- Keep a queued prompt under a stable queue ID while its external editor is open, using the editing state as a FIFO dequeue barrier.
- Finish edits in place, discard blank edits, and submit newly ready prompts through the normal effect path.
- Preserve queued and editing order when steer cancellation is acknowledged.

## Testing

- Regression tests cover turn completion while an edit is open, blank edit removal, FIFO submission after editor completion, and cancellation ordering.
- `just check-fmt`
- `cargo check --all-features --locked`
- `just clippy`
- `just test` (800 tests)

## Stack

- Base: `main`
- Next: #122

Closes #119