### PR TITLE
feat(tui): select expanded tool results

### DIFF
--- a/src/tui/components/root.rs
+++ b/src/tui/components/root.rs
@@ -4784,6 +4784,126 @@ mod tests {
     }
 
     #[test]
+    fn transcript_selection_copies_shell_command_and_output_without_chrome_or_soft_wraps() {
+        let mut terminal = Terminal::new(TestBackend::new(40, 16)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        let command = "$HOME/bin/printf output";
+        let output = "alpha beta gamma delta epsilon zeta\nsecond line";
+        root.update(super::RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow",
+                "tool": "exec",
+                "arguments": "await tools.exec_command({cmd: '$HOME/bin/printf output'})",
+            }),
+        )));
+        root.update(super::RootEvent::Transcript(agent_record(
+            2,
+            AgentEventKind::ToolCall,
+            json!({
+                "call_id": "workflow/shell",
+                "tool": "exec_command",
+                "arguments": {"cmd": command},
+            }),
+        )));
+        root.update(super::RootEvent::Transcript(agent_record(
+            3,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "workflow/shell",
+                "tool": "exec_command",
+                "status": "completed",
+                "duration_ns": 1_u64,
+                "result": format!(
+                    "Wall time: 0.0000 seconds\nProcess exited with code 0\nOutput:\n{output}"
+                ),
+                "structured_result": {
+                    "output": output,
+                    "exit_code": 0,
+                    "wall_time_seconds": 0.0,
+                },
+                "metadata": null,
+            }),
+        )));
+        root.update(key(KeyCode::Char('o'), KeyModifiers::CONTROL));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let command_row = (0..buffer.area.height)
+            .rfind(|&row| {
+                (0..buffer.area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains(command)
+            })
+            .expect("the expanded shell command should be visible");
+        let command_start = text_column(buffer, command_row, command);
+        let command_end = command_start + u16::try_from(command.len()).unwrap();
+
+        root.update(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            command_start,
+            command_row,
+        ));
+        root.update(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            command_end,
+            command_row,
+        ));
+        let update = root.update(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            command_end,
+            command_row,
+        ));
+        assert_eq!(update.effects, [RootEffect::Copy(command.to_owned())]);
+
+        let first_row = (0..buffer.area.height)
+            .find(|&row| {
+                (0..buffer.area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("alpha")
+            })
+            .expect("the first output line should be visible");
+        let last_row = (0..buffer.area.height)
+            .find(|&row| {
+                (0..buffer.area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("second line")
+            })
+            .expect("the second output line should be visible");
+        let start = text_column(buffer, first_row, "alpha");
+        let end = text_column(buffer, last_row, "second line") + 10;
+
+        root.update(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            start,
+            first_row,
+        ));
+        root.update(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            end,
+            last_row,
+        ));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        assert_ne!(buffer[(0, first_row)].bg, Color::Yellow);
+        assert_ne!(
+            buffer[(start.saturating_sub(1), first_row)].bg,
+            Color::Yellow
+        );
+        assert_eq!(buffer[(start, first_row)].bg, Color::Yellow);
+
+        let update = root.update(mouse(MouseEventKind::Up(MouseButton::Left), end, last_row));
+        assert_eq!(update.effects, [RootEffect::Copy(output.to_owned())]);
+    }
+
+    #[test]
     fn transcript_selection_copies_original_markdown_syntax() {
         let mut terminal = Terminal::new(TestBackend::new(64, 12)).unwrap();
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);

--- a/src/tui/components/transcript/markdown.rs
+++ b/src/tui/components/transcript/markdown.rs
@@ -14,6 +14,7 @@ pub(super) struct Layout {
     pub(super) links: Vec<Vec<LinkSpan>>,
     pub(super) selections: Vec<Vec<SourceSpan>>,
     pub(super) envelopes: Vec<SourceEnvelope>,
+    pub(super) selection_source: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -42,6 +43,7 @@ pub(super) fn render(markdown: &str, width: u16, theme: &Theme) -> Layout {
             links: Vec::new(),
             selections: Vec::new(),
             envelopes: Vec::new(),
+            selection_source: None,
         };
     }
     let options = Options::ENABLE_TABLES
@@ -75,8 +77,16 @@ pub(super) fn render(markdown: &str, width: u16, theme: &Theme) -> Layout {
 }
 
 pub(super) fn plain_selection_spans(source: &str, lines: &[Line<'static>]) -> Vec<Vec<SourceSpan>> {
+    plain_selection_spans_excluding(source, lines, &[])
+}
+
+pub(super) fn plain_selection_spans_excluding(
+    source: &str,
+    lines: &[Line<'static>],
+    exclusions: &[Vec<Range<u16>>],
+) -> Vec<Vec<SourceSpan>> {
     let graphemes = source_graphemes(source, source, 0..source.len());
-    align_source_graphemes(&graphemes, lines, &[])
+    align_source_graphemes(&graphemes, lines, exclusions)
 }
 
 pub(super) fn wrap_plain(text: &str, width: u16, style: Style) -> Vec<Line<'static>> {
@@ -677,6 +687,7 @@ impl<'a> Renderer<'a> {
                 links,
                 selections: Vec::new(),
                 envelopes: Vec::new(),
+                selection_source: None,
             },
             self.selection_exclusions,
         )

--- a/src/tui/components/transcript/mod.rs
+++ b/src/tui/components/transcript/mod.rs
@@ -103,6 +103,7 @@ struct CachedEntry {
     links: Vec<Vec<markdown::LinkSpan>>,
     selections: Vec<Vec<markdown::SourceSpan>>,
     envelopes: Vec<markdown::SourceEnvelope>,
+    selection_source: Option<String>,
 }
 
 #[derive(Default)]
@@ -611,7 +612,11 @@ impl Transcript {
         };
         let anchor = if self.cache.selections(exact).is_empty() {
             if !across_entries {
-                selection_source(self.model.entry(exact.entry)?)?;
+                let entry = self.model.entry(exact.entry)?;
+                if matches!(entry.kind, EntryKind::Tool(_)) {
+                    return None;
+                }
+                self.cache.selection_source(entry)?;
             }
             self.selection_rows
                 .iter()
@@ -653,7 +658,7 @@ impl Transcript {
             if block < start.block || block > end.block {
                 continue;
             }
-            let Some(source) = selection_source(entry) else {
+            let Some(source) = self.cache.selection_source(entry) else {
                 continue;
             };
             let Some(selected) = range.source_range(block, source.len()) else {
@@ -1355,6 +1360,13 @@ impl LayoutCache {
             .map_or(&[], Vec::as_slice)
     }
 
+    fn selection_source<'a>(&'a self, entry: &'a TranscriptEntry) -> Option<&'a str> {
+        self.entries
+            .get(&entry.id)
+            .and_then(|cached| cached.selection_source.as_deref())
+            .or_else(|| entry_selection_source(entry))
+    }
+
     fn expand_selection(&self, entry: EntryId, mut selected: Range<usize>) -> Range<usize> {
         let Some(cached) = self.entries.get(&entry) else {
             return selected;
@@ -1400,6 +1412,7 @@ impl CachedEntry {
             links: layout.links,
             selections: layout.selections,
             envelopes: layout.envelopes,
+            selection_source: layout.selection_source,
         }
     }
 
@@ -1601,15 +1614,22 @@ fn render_entry(
         EntryKind::Tool(tool) => {
             let indent = nested_tool_indent(entry, width);
             let tool_width = width.saturating_sub(indent);
-            let mut lines = if let Some(duration_ns) = live_duration_ns {
-                tool::render_live(tool, duration_ns, tool_width, theme, expanded)
-            } else if expanded {
-                tool::render_expanded(tool, tool_width, theme)
-            } else {
-                tool::render(tool, tool_width, theme)
-            };
-            indent_nested_tool(indent, &mut lines, theme, expanded, entry.trailing_spacer);
-            layout_without_links(lines)
+            let mut layout =
+                tool::render_layout(tool, live_duration_ns, tool_width, theme, expanded);
+            indent_nested_tool(
+                indent,
+                &mut layout.lines,
+                theme,
+                expanded,
+                entry.trailing_spacer,
+            );
+            for spans in &mut layout.selections {
+                for span in spans {
+                    span.columns.start = span.columns.start.saturating_add(indent);
+                    span.columns.end = span.columns.end.saturating_add(indent);
+                }
+            }
+            layout
         }
         EntryKind::DirectedMessage(thread) => {
             layout_without_links(message::render(thread, width, theme, expanded))
@@ -1760,7 +1780,7 @@ fn indent_nested_tool(
     }
 }
 
-fn selection_source(entry: &TranscriptEntry) -> Option<&str> {
+fn entry_selection_source(entry: &TranscriptEntry) -> Option<&str> {
     match &entry.kind {
         EntryKind::User { text }
         | EntryKind::Assistant { text, .. }
@@ -1777,6 +1797,7 @@ fn layout_without_links(lines: Vec<Line<'static>>) -> markdown::Layout {
         links,
         selections,
         envelopes: Vec::new(),
+        selection_source: None,
     }
 }
 
@@ -1816,6 +1837,7 @@ fn render_user(text: &str, width: u16, theme: &Theme) -> markdown::Layout {
         lines,
         selections,
         envelopes: Vec::new(),
+        selection_source: None,
     }
 }
 
@@ -2456,6 +2478,31 @@ mod tests {
 
         assert!(transcript.selection_span(position).is_none());
         assert!(transcript.selection_span_nearest(position).is_some());
+    }
+
+    #[test]
+    fn expanded_tool_details_are_selectable_but_the_summary_remains_clickable() {
+        let mut transcript = Transcript::new();
+        shell(&mut transcript, 1, "selectable output");
+        drop(render(&mut transcript, 60, 12));
+        transcript.focus_expandables();
+        transcript.update(TranscriptEvent::Expandable(ExpandableCommand::Toggle));
+        let backend = render(&mut transcript, 60, 12);
+        let row_containing = |text: &str| {
+            (0..backend.buffer().area.height)
+                .find(|&row| {
+                    (0..backend.buffer().area.width)
+                        .map(|column| backend.buffer()[(column, row)].symbol())
+                        .collect::<String>()
+                        .contains(text)
+                })
+                .unwrap()
+        };
+        let summary = Position::new(10, row_containing("Shell"));
+        let output = Position::new(10, row_containing("selectable output"));
+
+        assert!(transcript.selection_span(summary).is_none());
+        assert!(transcript.selection_span(output).is_some());
     }
 
     #[test]

--- a/src/tui/components/transcript/tool.rs
+++ b/src/tui/components/transcript/tool.rs
@@ -7,7 +7,9 @@ mod send_message;
 mod shell;
 mod web;
 
-use super::markdown::{sanitize, wrap_plain, wrap_spans};
+use super::markdown::{
+    Layout, SourceSpan, plain_selection_spans_excluding, sanitize, wrap_plain, wrap_spans,
+};
 use crate::tui::{
     format::{format_duration, humanize_tool},
     theme::Theme,
@@ -18,17 +20,21 @@ use ratatui::{
     text::{Line, Span},
 };
 use serde_json::Value;
+use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+#[cfg(test)]
 pub(super) fn render(tool: &ToolEntry, width: u16, theme: &Theme) -> Vec<Line<'static>> {
-    render_state(tool, None, width, theme, false)
+    render_layout(tool, None, width, theme, false).lines
 }
 
+#[cfg(test)]
 pub(super) fn render_expanded(tool: &ToolEntry, width: u16, theme: &Theme) -> Vec<Line<'static>> {
-    render_state(tool, None, width, theme, true)
+    render_layout(tool, None, width, theme, true).lines
 }
 
+#[cfg(test)]
 pub(super) fn render_live(
     tool: &ToolEntry,
     duration_ns: u64,
@@ -36,18 +42,24 @@ pub(super) fn render_live(
     theme: &Theme,
     expanded: bool,
 ) -> Vec<Line<'static>> {
-    render_state(tool, Some(duration_ns), width, theme, expanded)
+    render_layout(tool, Some(duration_ns), width, theme, expanded).lines
 }
 
-fn render_state(
+pub(super) fn render_layout(
     tool: &ToolEntry,
     live_duration_ns: Option<u64>,
     width: u16,
     theme: &Theme,
     expanded: bool,
-) -> Vec<Line<'static>> {
+) -> Layout {
     if width == 0 {
-        return Vec::new();
+        return Layout {
+            lines: Vec::new(),
+            links: Vec::new(),
+            selections: Vec::new(),
+            envelopes: Vec::new(),
+            selection_source: None,
+        };
     }
     let detail_width = width.saturating_sub(6).max(1);
     let presentation = present(tool, detail_width, theme, expanded);
@@ -60,10 +72,42 @@ fn render_state(
         expanded,
     );
     if !expanded {
-        return lines;
+        return Layout {
+            links: vec![Vec::new(); lines.len()],
+            selections: vec![Vec::new(); lines.len()],
+            lines,
+            envelopes: Vec::new(),
+            selection_source: None,
+        };
     }
-    append_details(&mut lines, presentation, width, theme);
-    lines
+    let detail_start = lines.len();
+    let Presentation {
+        details,
+        footer,
+        selection_source,
+        mut detail_selections,
+        ..
+    } = presentation;
+    let selection_source = (!selection_source.is_empty()).then_some(selection_source);
+    append_details(&mut lines, details, footer, width, theme);
+    let mut selections = vec![Vec::new(); lines.len()];
+    let prefix = if width < 7 { 0 } else { 6 };
+    for (index, spans) in detail_selections.iter_mut().enumerate() {
+        let row = detail_start + index;
+        for span in &mut *spans {
+            span.columns.start = span.columns.start.saturating_add(prefix);
+            span.columns.end = span.columns.end.saturating_add(prefix).min(width);
+        }
+        spans.retain(|span| span.columns.start < span.columns.end);
+        selections[row] = std::mem::take(spans);
+    }
+    Layout {
+        links: vec![Vec::new(); lines.len()],
+        lines,
+        selections,
+        envelopes: Vec::new(),
+        selection_source,
+    }
 }
 
 pub(super) fn render_live_summary(
@@ -108,6 +152,8 @@ pub(super) struct Presentation {
     details: Vec<Line<'static>>,
     footer: Option<String>,
     summary_overflow: SummaryOverflow,
+    selection_source: String,
+    detail_selections: Vec<Vec<SourceSpan>>,
 }
 
 enum Subject {
@@ -132,6 +178,8 @@ impl Presentation {
             details: Vec::new(),
             footer: None,
             summary_overflow: SummaryOverflow::Wrap,
+            selection_source: String::new(),
+            detail_selections: Vec::new(),
         }
     }
 
@@ -143,6 +191,8 @@ impl Presentation {
             details: Vec::new(),
             footer: None,
             summary_overflow: SummaryOverflow::Wrap,
+            selection_source: String::new(),
+            detail_selections: Vec::new(),
         }
     }
 
@@ -151,9 +201,56 @@ impl Presentation {
         self
     }
 
-    pub(super) fn details(mut self, details: Vec<Line<'static>>) -> Self {
-        self.details = details;
+    pub(super) fn unselectable_details(mut self, details: Vec<Line<'static>>) -> Self {
+        self.detail_selections
+            .resize_with(self.detail_selections.len() + details.len(), Vec::new);
+        self.details.extend(details);
         self
+    }
+
+    pub(super) fn selectable_details(
+        self,
+        source: impl Into<String>,
+        details: Vec<Line<'static>>,
+    ) -> Self {
+        self.selectable_details_excluding(source, details, &[])
+    }
+
+    pub(super) fn selectable_details_excluding(
+        mut self,
+        source: impl Into<String>,
+        details: Vec<Line<'static>>,
+        exclusions: &[Vec<Range<u16>>],
+    ) -> Self {
+        let source = source.into();
+        let offset = if self.selection_source.is_empty() {
+            0
+        } else {
+            self.selection_source.push('\n');
+            self.selection_source.len()
+        };
+        let mut selections = plain_selection_spans_excluding(&source, &details, exclusions);
+        for spans in &mut selections {
+            for span in spans {
+                span.source.start = span.source.start.saturating_add(offset);
+                span.source.end = span.source.end.saturating_add(offset);
+            }
+        }
+        self.selection_source.push_str(&source);
+        self.details.extend(details);
+        self.detail_selections.extend(selections);
+        self
+    }
+
+    pub(super) fn selectable_plain(
+        self,
+        source: impl Into<String>,
+        width: u16,
+        style: Style,
+    ) -> Self {
+        let source = source.into();
+        let lines = wrap_plain(&source, width, style);
+        self.selectable_details(source, lines)
     }
 
     pub(super) fn footer(mut self, footer: impl Into<String>) -> Self {
@@ -368,19 +465,15 @@ fn push_subject(spans: &mut Vec<Span<'static>>, subject: &Subject, theme: &Theme
 
 fn append_details(
     lines: &mut Vec<Line<'static>>,
-    presentation: Presentation,
+    details: Vec<Line<'static>>,
+    footer: Option<String>,
     width: u16,
     theme: &Theme,
 ) {
     let rail = Style::default().fg(theme.border());
     if width < 7 {
-        lines.extend(
-            presentation
-                .details
-                .into_iter()
-                .map(|line| truncate_line(line, width)),
-        );
-        if let Some(footer) = presentation.footer {
+        lines.extend(details.into_iter().map(|line| truncate_line(line, width)));
+        if let Some(footer) = footer {
             lines.push(Line::from(Span::styled(
                 truncate(&sanitize(&footer), width),
                 Style::default().fg(theme.muted()),
@@ -388,14 +481,14 @@ fn append_details(
         }
         return;
     }
-    for detail in presentation.details {
+    for detail in details {
         lines.push(Line::from(
             std::iter::once(Span::styled("    │ ", rail))
                 .chain(detail.spans)
                 .collect::<Vec<_>>(),
         ));
     }
-    let footer = presentation.footer.unwrap_or_else(|| "details".to_owned());
+    let footer = footer.unwrap_or_else(|| "details".to_owned());
     let footer = truncate(&sanitize(&footer), width.saturating_sub(6));
     lines.push(Line::from(vec![
         Span::styled("    └ ", rail),
@@ -425,27 +518,41 @@ fn generic(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Prese
     if !expanded {
         return presentation;
     }
-    let mut details = pretty_value(&tool.arguments, width, theme);
+    let details = pretty_value(&tool.arguments, width, theme);
+    presentation = presentation.unselectable_details(details);
     if let Some(result) = &tool.result {
-        details.extend(render_result(result, width, theme));
+        let (source, details) = selectable_result(result, width, theme);
+        presentation = presentation.selectable_details(source, details);
     }
-    presentation.details = details;
     presentation.footer = Some("arguments and result".to_owned());
     presentation
 }
 
-pub(super) fn render_result(value: &Value, width: u16, theme: &Theme) -> Vec<Line<'static>> {
+pub(super) fn selectable_result(
+    value: &Value,
+    width: u16,
+    theme: &Theme,
+) -> (String, Vec<Line<'static>>) {
     if contains_image_data(value) {
-        return wrap_plain(
-            &format!("image data · {}", format_bytes(value.to_string().len())),
-            width,
-            Style::default().fg(theme.muted()),
-        );
+        let source = format!("image data · {}", format_bytes(value.to_string().len()));
+        let details = wrap_plain(&source, width, Style::default().fg(theme.muted()));
+        return (source, details);
     }
     if let Some(text) = value.as_str() {
-        return wrap_plain(text, width, Style::default().fg(theme.text()));
+        return (
+            text.to_owned(),
+            wrap_plain(text, width, Style::default().fg(theme.text())),
+        );
     }
-    pretty_value(value, width, theme)
+    let source = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    let details = wrap_plain(
+        &source,
+        width,
+        Style::default()
+            .fg(theme.code_text())
+            .bg(theme.code_background()),
+    );
+    (source, details)
 }
 
 pub(super) fn pretty_value(value: &Value, width: u16, theme: &Theme) -> Vec<Line<'static>> {
@@ -544,7 +651,7 @@ fn status_style(state: ToolState, theme: &Theme) -> Style {
 
 #[cfg(test)]
 mod tests {
-    use super::{render, render_expanded, render_live};
+    use super::{render, render_expanded, render_layout, render_live};
     use crate::tui::{
         theme::Theme,
         transcript::{ToolEntry, ToolState},
@@ -919,6 +1026,11 @@ mod tests {
         assert!(rendered.contains("Second line"));
         assert!(!rendered.contains("cite"));
         assert!(!rendered.contains("wordlim"));
+
+        let source = render_layout(&web, None, 80, &Theme::default(), true)
+            .selection_source
+            .expect("expanded web results should be selectable");
+        assert_eq!(source, " Useful content\nSecond line");
     }
 
     #[test]

--- a/src/tui/components/transcript/tool/code.rs
+++ b/src/tui/components/transcript/tool/code.rs
@@ -33,31 +33,31 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
     if !expanded {
         return presentation;
     }
-    let mut details =
+    let details =
         super::super::markdown::render(&format!("```javascript\n{source}\n```"), width, theme)
             .lines;
+    let mut presentation = presentation.unselectable_details(details);
     if let Some(result) = &tool.result {
         if let Some(items) = result.as_array() {
             for item in items {
                 if let Some(text) = item.get("text").and_then(Value::as_str) {
-                    details.extend(super::super::markdown::wrap_plain(
+                    presentation = presentation.selectable_plain(
                         text,
                         width,
                         Style::default().fg(theme.text()),
-                    ));
+                    );
                 }
             }
         } else {
-            details.extend(super::render_result(result, width, theme));
+            let (source, details) = super::selectable_result(result, width, theme);
+            presentation = presentation.selectable_details(source, details);
         }
     }
     let size = tool
         .result
         .as_ref()
         .map_or(0, |result| result.to_string().len());
-    presentation
-        .details(details)
-        .footer(format!("{emitted} outputs · {}", format_bytes(size)))
+    presentation.footer(format!("{emitted} outputs · {}", format_bytes(size)))
 }
 
 fn wait(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
@@ -65,9 +65,11 @@ fn wait(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presenta
     if !expanded {
         return presentation;
     }
-    let mut details = super::pretty_value(&tool.arguments, width, theme);
+    let details = super::pretty_value(&tool.arguments, width, theme);
+    let mut presentation = presentation.unselectable_details(details);
     if let Some(result) = &tool.result {
-        details.extend(super::render_result(result, width, theme));
+        let (source, details) = super::selectable_result(result, width, theme);
+        presentation = presentation.selectable_details(source, details);
     }
-    presentation.details(details).footer("wait diagnostics")
+    presentation.footer("wait diagnostics")
 }

--- a/src/tui/components/transcript/tool/media.rs
+++ b/src/tui/components/transcript/tool/media.rs
@@ -36,7 +36,9 @@ fn view_image(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Pr
         width,
         Style::default().fg(theme.accent()),
     );
-    presentation.details(details).footer("binary data hidden")
+    presentation
+        .unselectable_details(details)
+        .footer("binary data hidden")
 }
 
 fn image_generation(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
@@ -73,6 +75,6 @@ fn image_generation(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool)
         ));
     }
     presentation
-        .details(details)
+        .unselectable_details(details)
         .footer("image generation details")
 }

--- a/src/tui/components/transcript/tool/memory.rs
+++ b/src/tui/components/transcript/tool/memory.rs
@@ -239,19 +239,18 @@ fn scan(
     }
 
     let shown = candidates.len().min(MAX_SCAN_CANDIDATES);
-    let mut details = Vec::new();
+    let mut presentation = presentation;
     for candidate in candidates.iter().take(shown) {
-        details.extend(wrap(
-            &format!(
-                "{} · score {}",
-                candidate.key.display(),
-                format_score(candidate.score)
-            ),
-            width,
-            Style::default().fg(theme.accent()),
-        ));
+        let label = format!(
+            "{} · score {}",
+            candidate.key.display(),
+            format_score(candidate.score)
+        );
+        presentation =
+            presentation.selectable_plain(&label, width, Style::default().fg(theme.accent()));
         let preview = super::truncate(candidate.preview, MAX_PREVIEW_WIDTH);
-        details.extend(wrap(&preview, width, Style::default().fg(theme.text())));
+        presentation =
+            presentation.selectable_plain(&preview, width, Style::default().fg(theme.text()));
     }
     let footer = if abstained {
         "memory scan abstained".to_owned()
@@ -260,7 +259,7 @@ fn scan(
     } else {
         count_label(candidates.len(), "candidate", "candidates")
     };
-    presentation.details(details).footer(footer)
+    presentation.footer(footer)
 }
 
 fn read(
@@ -284,11 +283,11 @@ fn read(
         return presentation;
     }
 
-    let mut details = Vec::new();
+    let mut presentation = presentation;
     for memory in &memories {
-        details.extend(memory_details(memory, width, theme));
+        presentation = selectable_memory_details(presentation, memory, width, theme);
     }
-    presentation.details(details).footer(count)
+    presentation.footer(count)
 }
 
 fn put(
@@ -313,7 +312,7 @@ fn put(
             return presentation;
         }
         return presentation
-            .details(wrap(content, width, Style::default().fg(theme.text())))
+            .unselectable_details(wrap(content, width, Style::default().fg(theme.text())))
             .footer("memory content");
     };
 
@@ -326,9 +325,7 @@ fn put(
     if !expanded {
         return presentation;
     }
-    presentation
-        .details(memory_details(&memory, width, theme))
-        .footer("memory record")
+    selectable_memory_details(presentation, &memory, width, theme).footer("memory record")
 }
 
 fn delete(
@@ -346,30 +343,28 @@ fn delete(
     if !expanded {
         return presentation;
     }
+    let key = key.display();
     presentation
-        .details(wrap(
-            &key.display(),
-            width,
-            Style::default().fg(theme.accent()),
-        ))
+        .selectable_plain(&key, width, Style::default().fg(theme.accent()))
         .footer("memory key")
 }
 
-fn memory_details(memory: &Memory<'_>, width: u16, theme: &Theme) -> Vec<Line<'static>> {
-    let mut details = wrap(
-        &memory.key.display(),
-        width,
-        Style::default().fg(theme.accent()),
-    );
-    details.extend(wrap(
-        memory.content,
-        width,
-        Style::default().fg(theme.text()),
-    ));
+fn selectable_memory_details(
+    presentation: Presentation,
+    memory: &Memory<'_>,
+    width: u16,
+    theme: &Theme,
+) -> Presentation {
+    let key = memory.key.display();
+    let mut presentation =
+        presentation.selectable_plain(&key, width, Style::default().fg(theme.accent()));
+    presentation =
+        presentation.selectable_plain(memory.content, width, Style::default().fg(theme.text()));
     if let Some(metadata) = selected_metadata(memory.fields) {
-        details.extend(wrap(&metadata, width, Style::default().fg(theme.muted())));
+        presentation =
+            presentation.selectable_plain(&metadata, width, Style::default().fg(theme.muted()));
     }
-    details
+    presentation
 }
 
 fn selected_metadata(fields: &Map<String, Value>) -> Option<String> {
@@ -448,7 +443,7 @@ fn format_score(score: f64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{render, render_expanded};
+    use super::super::{render, render_expanded, render_layout};
     use crate::tui::{
         theme::Theme,
         transcript::{ToolEntry, ToolState},
@@ -659,6 +654,15 @@ mod tests {
         assert!(!rendered.contains("must not be shown"));
         assert!(rendered.contains("8 of 12 candidates"));
         assert!(!rendered.contains(&"x".repeat(241)));
+
+        let source = render_layout(&tool, None, 80, &Theme::default(), true)
+            .selection_source
+            .expect("scan results should be selectable");
+        assert!(source.contains("0@v3 · score 0.875"));
+        assert!(source.contains("preview-0"));
+        assert!(!source.contains("8@v3 · score"));
+        assert!(!source.contains("must not be shown"));
+        assert!(!source.contains(&"x".repeat(241)));
     }
 
     #[test]
@@ -686,6 +690,12 @@ mod tests {
             assert!(rendered.contains("created 10 · updated 20"), "{rendered}");
             assert!(rendered.contains("scans 2"), "{rendered}");
             assert!(rendered.contains("uses 1"), "{rendered}");
+
+            let source = render_layout(&tool, None, 100, &Theme::default(), true)
+                .selection_source
+                .expect("memory records should be selectable");
+            assert!(source.contains("Use explicit data flow."));
+            assert!(source.contains("created 10 · updated 20"));
         }
     }
 

--- a/src/tui/components/transcript/tool/patch.rs
+++ b/src/tui/components/transcript/tool/patch.rs
@@ -41,7 +41,9 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
     } else {
         super::super::markdown::render(&format!("```diff\n{patch}\n```"), width, theme).lines
     };
-    presentation.details(details).footer("patch details")
+    presentation
+        .unselectable_details(details)
+        .footer("patch details")
 }
 
 fn file_operation(line: &str) -> Option<(&'static str, &str)> {

--- a/src/tui/components/transcript/tool/plan.rs
+++ b/src/tui/components/transcript/tool/plan.rs
@@ -56,6 +56,6 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         }
     }
     presentation
-        .details(details)
+        .unselectable_details(details)
         .footer(format!("{completed}/{total} complete"))
 }

--- a/src/tui/components/transcript/tool/send_message.rs
+++ b/src/tui/components/transcript/tool/send_message.rs
@@ -66,7 +66,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
             Style::default().fg(theme.muted()),
         ));
     }
-    presentation = presentation.details(details).footer(footer);
+    presentation = presentation.unselectable_details(details).footer(footer);
     presentation
 }
 

--- a/src/tui/components/transcript/tool/shell.rs
+++ b/src/tui/components/transcript/tool/shell.rs
@@ -26,24 +26,28 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         return presentation;
     }
 
-    let mut details = Vec::new();
     if let Some(workdir) = tool.arguments.get("workdir").and_then(Value::as_str) {
-        details.extend(super::super::markdown::wrap_plain(
+        presentation = presentation.unselectable_details(super::super::markdown::wrap_plain(
             &format!("cwd {}", shorten_home(Path::new(workdir))),
             width,
             Style::default().fg(theme.muted()),
         ));
     }
-    let command = command_spans(command)
+    let rendered_command = command_spans(command)
         .into_iter()
         .map(|mut span| {
             span.style = span.style.bg(theme.code_background());
             span
         })
         .collect::<Vec<_>>();
-    details.extend(super::super::markdown::wrap_spans(&command, width, true));
+    let prompt_exclusions = [std::iter::once(0..2).collect::<Vec<_>>()];
+    presentation = presentation.selectable_details_excluding(
+        command,
+        super::super::markdown::wrap_spans(&rendered_command, width, true),
+        &prompt_exclusions,
+    );
     for substep in &tool.substeps {
-        details.extend(super::super::markdown::wrap_plain(
+        presentation = presentation.unselectable_details(super::super::markdown::wrap_plain(
             &format!("↳ {substep}"),
             width,
             Style::default().fg(theme.muted()),
@@ -56,15 +60,12 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         .and_then(Value::as_str)
         .unwrap_or_default();
     if !output.is_empty() {
-        details.extend(super::super::markdown::wrap_plain(
-            output,
-            width,
-            Style::default().fg(theme.text()),
-        ));
+        presentation =
+            presentation.selectable_plain(output, width, Style::default().fg(theme.text()));
     }
     let line_count = output.lines().count();
     let line_label = if line_count == 1 { "line" } else { "lines" };
-    presentation.details(details).footer(format!(
+    presentation.footer(format!(
         "{line_count} {line_label} · {}",
         format_bytes(output.len())
     ))
@@ -105,10 +106,15 @@ fn stdin(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Present
     if !expanded {
         return presentation;
     }
-    let details = tool.result.as_ref().map_or_else(Vec::new, |result| {
-        super::render_result(result, width, theme)
-    });
-    presentation.details(details).footer("process interaction")
+    match &tool.result {
+        Some(result) => {
+            let (source, details) = super::selectable_result(result, width, theme);
+            presentation
+                .selectable_details(source, details)
+                .footer("process interaction")
+        }
+        None => presentation.footer("process interaction"),
+    }
 }
 
 fn shell_outcome(result: Option<&Value>) -> Option<String> {

--- a/src/tui/components/transcript/tool/web.rs
+++ b/src/tui/components/transcript/tool/web.rs
@@ -22,23 +22,21 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         return presentation;
     }
 
-    let mut details = operation_details(&tool.arguments, width, theme);
+    let details = operation_details(&tool.arguments, width, theme);
+    let mut presentation = presentation.unselectable_details(details);
     let result_size = tool
         .result
         .as_ref()
         .map_or(0, |result| result.to_string().len());
     if let Some(result) = tool.result.as_ref().and_then(Value::as_str) {
-        details.extend(super::super::markdown::wrap_plain(
-            &clean_result(result),
-            width,
-            Style::default().fg(theme.text()),
-        ));
+        let result = clean_result(result);
+        presentation =
+            presentation.selectable_plain(result, width, Style::default().fg(theme.text()));
     } else if let Some(result) = &tool.result {
-        details.extend(super::render_result(result, width, theme));
+        let (source, details) = super::selectable_result(result, width, theme);
+        presentation = presentation.selectable_details(source, details);
     }
-    presentation
-        .details(details)
-        .footer(format!("web result · {}", format_bytes(result_size)))
+    presentation.footer(format!("web result · {}", format_bytes(result_size)))
 }
 
 fn summary(arguments: &Value) -> String {


### PR DESCRIPTION
## Overview

- Make expanded tool commands and results selectable with mouse drag and copy.
- Copy the visible semantic content with hard newlines intact while excluding soft-wrap newlines and presentation chrome.
- Support shell, code, web, memory, generic, and nested tool presentations without exposing hidden structured fields.

## Testing

- Regression tests cover shell command and wrapped output selection, bounded memory records, cleaned web results, redaction, nested indentation, and unselectable summary rows.
- `just check-fmt`
- `cargo check --all-features --locked`
- `just clippy`
- `just test` (800 tests)

## Stack

- Depends on #122
- Next: #124