### PR TITLE
chore(release): prepare 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Overview

- Bump the Tact package version from 0.5.2 to 0.5.3.
- Synchronize the package version in Cargo.lock.

## Testing

- `just check-fmt`
- `cargo check --all-features --locked`
- `just clippy`
- `just test` (800 tests)

## Stack

- Depends on #125
- Top of stack