### PR TITLE
feat: add turn completion hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ web_search = true
 image_generation = true
 websocket_url = ""
 api_base_url = ""
+completion_hook = ""
 
 [mcp_servers]
 
@@ -178,6 +179,11 @@ thinking_high = "yellow"
 thinking_xhigh = "red"
 thinking_max = "magenta"
 ```
+
+Set `agent.completion_hook` to a shell command to run after each conversation turn finishes. Tact
+runs the command in the configured workspace and ignores its output and exit status. Interactive
+sessions start the hook asynchronously so it does not block the UI; `tact run` waits for the hook
+before exiting.
 
 The workspace defaults to the directory where tact starts. Relative paths in the configuration are
 resolved from the configuration file's directory; relative command-line paths are resolved from the

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -153,6 +153,8 @@ pub(crate) struct AgentConfig {
     websocket_url: Option<String>,
     #[serde(serialize_with = "serialize_optional_string")]
     api_base_url: Option<String>,
+    #[serde(serialize_with = "serialize_optional_string")]
+    completion_hook: Option<String>,
 }
 
 /// Filesystem locations from which local model skills may be discovered.
@@ -289,6 +291,7 @@ struct AgentConfigFile {
     image_generation: Option<bool>,
     websocket_url: Option<String>,
     api_base_url: Option<String>,
+    completion_hook: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -400,6 +403,7 @@ impl Config {
                     overrides.websocket_url.or(file.agent.websocket_url),
                 ),
                 api_base_url: optional_string(overrides.api_base_url.or(file.agent.api_base_url)),
+                completion_hook: optional_string(file.agent.completion_hook),
             },
             mcp_servers,
             skills,
@@ -929,6 +933,10 @@ impl AgentConfig {
     pub(crate) fn api_base_url(&self) -> Option<&str> {
         self.api_base_url.as_deref()
     }
+
+    pub(crate) fn completion_hook(&self) -> Option<&str> {
+        self.completion_hook.as_deref()
+    }
 }
 
 impl SkillsConfig {
@@ -1229,6 +1237,7 @@ mod tests {
                 "image_generation",
                 "websocket_url",
                 "api_base_url",
+                "completion_hook",
             ],
         );
         assert_table_fields(&rendered["mcp_servers"], &[]);
@@ -1268,6 +1277,7 @@ mod tests {
             "append_instructions",
             "websocket_url",
             "api_base_url",
+            "completion_hook",
         ] {
             assert_eq!(rendered["agent"][field].as_str(), Some(""), "{field}");
         }
@@ -1279,10 +1289,23 @@ mod tests {
         assert_eq!(rendered["theme"]["dark"]["accent"].as_str(), Some("blue"));
 
         let reloaded = load_config(&config.to_toml().unwrap()).unwrap();
+        assert!(reloaded.agent.completion_hook.is_none());
         assert!(reloaded.agent.instructions.is_none());
         assert!(reloaded.agent.append_instructions.is_none());
         assert!(reloaded.agent.websocket_url.is_none());
         assert!(reloaded.agent.api_base_url.is_none());
+    }
+
+    #[test]
+    fn completion_hook_can_be_configured() {
+        let config = load_config("[agent]\ncompletion_hook = \"notify-send done\"\n").unwrap();
+
+        assert_eq!(config.agent().completion_hook(), Some("notify-send done"));
+        let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+        assert_eq!(
+            rendered["agent"]["completion_hook"].as_str(),
+            Some("notify-send done")
+        );
     }
 
     #[test]

--- a/src/app/hook.rs
+++ b/src/app/hook.rs
@@ -1,0 +1,60 @@
+//! User-configured lifecycle hooks.
+
+#[cfg(unix)]
+use std::env;
+use std::{
+    io,
+    path::Path,
+    process::{ExitStatus, Stdio},
+};
+use tokio::process::Command;
+
+pub(crate) async fn execute(command: &str, workspace: &Path) -> io::Result<ExitStatus> {
+    let mut process = shell_command(command);
+    process
+        .current_dir(workspace)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .status()
+        .await
+}
+
+#[cfg(unix)]
+fn shell_command(command: &str) -> Command {
+    let shell = env::var_os("SHELL").unwrap_or_else(|| "/bin/sh".into());
+    let mut process = Command::new(shell);
+    process.args(["-lc", command]);
+    process
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut process = Command::new("cmd");
+    process.args(["/C", command]);
+    process
+}
+
+#[cfg(test)]
+mod tests {
+    use super::execute;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn executes_completion_hook_in_the_workspace() {
+        let workspace = tempdir().unwrap();
+        #[cfg(unix)]
+        let command = "printf completed > completion.txt";
+        #[cfg(windows)]
+        let command = "echo completed> completion.txt";
+
+        let status = execute(command, workspace.path()).await.unwrap();
+
+        assert!(status.success());
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("completion.txt")).unwrap(),
+            "completed"
+        );
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod browser;
 mod cli;
 pub(crate) mod config;
 pub(crate) mod error;
+pub(crate) mod hook;
 pub(crate) mod installation;
 mod secret;
 mod shutdown;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     app::{
         config::{Config, ReasoningEffort, ReasoningMode, SkillsConfig},
         error::{Result, RuntimeError},
+        hook,
     },
     core::extensions::{
         Skill, SkillCatalog, mcp_provider,
@@ -149,7 +150,7 @@ impl ConfiguredAgent {
         shutdown: CancellationToken,
         #[cfg(feature = "harbor-evals")] orchestration_log: Option<PathBuf>,
     ) -> Result<()> {
-        Self::from_config(config)?
+        let result = Self::from_config(config)?
             .run(
                 prompt,
                 shutdown,
@@ -157,7 +158,11 @@ impl ConfiguredAgent {
                 #[cfg(feature = "harbor-evals")]
                 orchestration_log,
             )
-            .await
+            .await;
+        if let Some(command) = config.agent().completion_hook() {
+            drop(hook::execute(command, config.agent().workspace()).await);
+        }
+        result
     }
 
     pub(crate) fn from_config(config: &Config) -> Result<Self> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     app::{
         config::{Config, ReasoningEffort, ReasoningMode},
         error::{Result, RuntimeError},
+        hook,
     },
     core::{
         ConfiguredAgent,
@@ -920,6 +921,13 @@ pub(crate) async fn run(
                             None => runtime.journal_mut()?.append_local(event)?,
                         };
                         schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
+                        if let Some(command) = config.agent().completion_hook() {
+                            let command = command.to_owned();
+                            let workspace = workspace.clone();
+                            tokio::spawn(async move {
+                                drop(hook::execute(&command, &workspace).await);
+                            });
+                        }
                         apply_app_update!(app.update(AppEvent::WorkerTurnFinished {
                             pane,
                             terminal_expected,


### PR DESCRIPTION
## Overview

related: https://github.com/clabby/tact/issues/128

Add an optional `agent.completion_hook` shell command that runs after each conversation turn. Interactive sessions launch the hook asynchronously through Tokio so the UI remains responsive, while `tact run` waits for the hook before exiting. Hook output and exit status do not alter the completed turn.

## Testing

- `cargo test completion_hook`
- `just check-fmt`
- `just clippy`
- `just test` (802 tests)

## Stack

1 of 3. Base: `main`. Followed by #131 and #132.

Closes #128