### PR TITLE
chore(release): prepare 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "arboard",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tact"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]


### PR DESCRIPTION
## Overview

Prepare Tact 0.5.4 by updating the package version in `Cargo.toml` and the root package entry in `Cargo.lock`. Release notes remain generated from tagged Conventional Commit history and include the completion-hook feature and review-prefix fix.

## Testing

- `cargo check --all-features`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo package --locked --allow-dirty --list`
- `git-cliff --unreleased --strip all`

## Stack

3 of 3. Depends on #130 and #131.