### PR TITLE
feat(memory): deploy shared memory on Cloudflare

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,8 +77,39 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@just
+      - name: Check standalone tact package
+        run: cargo check --package tact --locked
       - name: build
         run: just build --locked --all-features
+
+  cargo-portability:
+    runs-on: ubuntu-latest
+    name: Features + WebAssembly
+    timeout-minutes: 20
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@just
+      - name: Install Worker build tool
+        run: cargo install worker-build --version 0.8.5 --locked
+      - name: Check tact-memory feature powerset
+        run: just check-features
+      - name: Check Cloudflare Worker WebAssembly target
+        run: just check-wasm --locked
+      - name: Install Cloudflare Worker dependencies
+        run: npm ci --prefix crates/memory-cloudflare
+      - name: Bundle Cloudflare Worker
+        run: npm run deploy:check --prefix crates/memory-cloudflare
 
   cargo-lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 __pycache__/
 *.pyc
 .DS_Store
+.dev.vars
+.wrangler/
+crates/memory-cloudflare/bundled/
+crates/memory-cloudflare/node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,6 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -406,7 +405,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -414,13 +413,11 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -439,7 +436,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2197,7 +2193,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
  "unicode-general-category",
  "uuid-simd",
 ]
@@ -2358,6 +2354,12 @@ dependencies = [
  "nix 0.29.0",
  "winapi",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -3097,6 +3099,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3371,7 +3393,7 @@ dependencies = [
  "lru",
  "palette",
  "serde",
- "strum",
+ "strum 0.28.0",
  "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
@@ -3435,7 +3457,7 @@ dependencies = [
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -3586,7 +3608,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3927,6 +3949,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,11 +4279,32 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4434,6 +4488,23 @@ dependencies = [
  "tower",
  "tracing",
  "url",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "tact-memory-cloudflare"
+version = "0.5.4"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "tact-memory",
+ "thiserror 2.0.19",
+ "tower",
+ "tracing-subscriber",
+ "tracing-web",
+ "worker",
  "zeroize",
 ]
 
@@ -4873,7 +4944,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4923,6 +4993,19 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5225,6 +5308,19 @@ name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d3be8814f5ba5f074491a469eed3d73c273ffad955f25ed1635efac4b0d269"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5685,6 +5781,66 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "worker"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8adbf6c9ae45b665dee995c5e3a342c2bd7d58a2e8ca5c75b50ce8b1b8bfd9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "js-sys",
+ "matchit 0.7.3",
+ "pin-project",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "serde_urlencoded",
+ "strum 0.27.2",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.6.0",
+ "web-sys",
+ "worker-macros",
+ "worker-sys",
+]
+
+[[package]]
+name = "worker-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d908735d273dd7f9c325a842623f4e5a745e0686187ce465b34dc162ad348df"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "strum 0.27.2",
+ "syn 2.0.119",
+ "wasm-bindgen",
+ "wasm-bindgen-macro-support",
+ "worker-sys",
+]
+
+[[package]]
+name = "worker-sys"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33faa1a8fa6c7eec67b196e008859c44d468a5ad4f991855cdc856f119e0e98f"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ manual_async_fn = "allow"
 
 [workspace.dependencies]
 arboard = "3.6.1"
-axum = "0.8.4"
+axum = { version = "0.8.4", default-features = false, features = ["json"] }
 base64 = "0.22.1"
 chrono = { version = "0.4.45", default-features = false, features = ["std"] }
 clap = { version = "4.6.4", features = ["derive", "env"] }
@@ -54,7 +54,7 @@ sha2 = "0.10.9"
 shlex = "2.0.1"
 syntect = { version = "5.3.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
 tar = "0.4.44"
-tact-memory = { version = "0.5.4", path = "crates/memory" }
+tact-memory = { version = "0.5.4", path = "crates/memory", default-features = false }
 tact-subagents = { version = "0.5.4", path = "crates/subagents" }
 tempfile = "3.27.0"
 thiserror = "2.0.19"
@@ -65,8 +65,11 @@ toml_edit = "0.25.13"
 tower = "0.5.3"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
+tracing-web = "0.1.3"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 url = "2.5.7"
+web-time = "1.1.0"
+worker = { version = "0.8.5", features = ["axum", "d1", "http"] }
 zeroize = { version = "1.9.0", features = ["derive"] }
 zstd = "0.13.3"

--- a/bin/tact/Cargo.toml
+++ b/bin/tact/Cargo.toml
@@ -25,7 +25,7 @@ pkg-fmt = "tgz"
 
 [dependencies]
 arboard.workspace = true
-axum.workspace = true
+axum = { workspace = true, features = ["http1", "tokio"] }
 base64.workspace = true
 chrono.workspace = true
 clap.workspace = true
@@ -54,7 +54,7 @@ sha2.workspace = true
 shlex.workspace = true
 syntect.workspace = true
 tar.workspace = true
-tact-memory.workspace = true
+tact-memory = { workspace = true, features = ["client", "local", "native-server", "tool"] }
 tact-subagents.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/memory-cloudflare/.dev.vars.example
+++ b/crates/memory-cloudflare/.dev.vars.example
@@ -1,0 +1,1 @@
+TACT_MEMORY_CREDENTIALS="writer alice replace-with-a-long-random-token\nreader auditor replace-with-a-different-long-random-token"

--- a/crates/memory-cloudflare/Cargo.toml
+++ b/crates/memory-cloudflare/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "tact-memory-cloudflare"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "Cloudflare Worker deployment for shared Tact memory"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+axum.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tact-memory = { workspace = true, features = ["server"] }
+thiserror.workspace = true
+tower = { workspace = true, features = ["util"] }
+tracing-subscriber.workspace = true
+tracing-web.workspace = true
+worker.workspace = true
+zeroize.workspace = true

--- a/crates/memory-cloudflare/README.md
+++ b/crates/memory-cloudflare/README.md
@@ -1,0 +1,70 @@
+# Tact memory on Cloudflare
+
+This crate deploys Tact's shared memory protocol as a Rust Cloudflare Worker backed directly by
+D1. The Worker reuses `tact-memory`'s authenticated Axum server and supplies only the D1
+`MemoryStore` implementation.
+
+Use a Workers Paid plan for production so traffic is not interrupted by daily Free-plan limits and
+the database retains 30 days of point-in-time history.
+
+## Local development
+
+Install the Worker build tool and JavaScript dependencies:
+
+```sh
+cargo install worker-build --version 0.8.5 --locked
+cd crates/memory-cloudflare
+npm ci
+cp .dev.vars.example .dev.vars
+npm run migrate:local
+npm run dev
+```
+
+Edit `.dev.vars` with independent high-entropy tokens. Each non-empty credential line has the
+form `ROLE NAMESPACE TOKEN`, where `ROLE` is `reader` or `writer`. A reader can inspect and export
+the complete team corpus. A writer can additionally mutate only its own namespace.
+
+Configure Tact against the address printed by Wrangler, using the matching namespace and token.
+
+## Scan budget
+
+Tact's exact BM25 search ranks the shared corpus inside the Worker. The
+`TACT_MEMORY_SCAN_MAX_RECORDS` and `TACT_MEMORY_SCAN_MAX_CONTENT_BYTES` variables bound that work
+before D1 returns records to WebAssembly. The included values allow 10,240 records and 5 MiB of
+authored content; adjust them for the deployment's corpus and measured Worker CPU/memory use. A
+scan returns a storage-capacity error when either bound is exceeded, while export and mutation
+operations remain available so an operator can recover without direct database edits.
+
+## Production deployment
+
+Create the database:
+
+```sh
+npx wrangler d1 create tact-memory
+```
+
+Replace `REPLACE_WITH_D1_DATABASE_ID` in `wrangler.jsonc` with the returned ID. Store the production
+credential document without writing it to disk:
+
+```sh
+npx wrangler secret put TACT_MEMORY_CREDENTIALS
+```
+
+Then migrate and deploy:
+
+```sh
+npm run migrate:remote
+npm run deploy:check
+npm run deploy
+```
+
+Cloudflare Workers Logs receive structured, content-free operation records. Memory content,
+queries, authorization headers, bearer tokens, and token hashes are never logged. D1 Time Travel
+provides point-in-time recovery; production operators should also export snapshots outside its
+retention window when longer retention is required.
+
+## Credential rotation
+
+Generate a replacement token, include old and new credential lines temporarily for the same
+namespace, update clients, and then remove the old credential. Duplicate tokens are rejected when
+the Worker builds the authenticated server.

--- a/crates/memory-cloudflare/migrations/0001_initial.sql
+++ b/crates/memory-cloudflare/migrations/0001_initial.sql
@@ -1,0 +1,25 @@
+CREATE TABLE memory_namespaces (
+    namespace TEXT PRIMARY KEY NOT NULL,
+    next_id INTEGER NOT NULL DEFAULT 1 CHECK (next_id > 0)
+) STRICT;
+
+CREATE TABLE memories (
+    namespace TEXT NOT NULL,
+    id INTEGER NOT NULL CHECK (id > 0),
+    version INTEGER NOT NULL CHECK (version > 0),
+    content TEXT NOT NULL,
+    identity TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    last_scanned_at_ms INTEGER,
+    scan_count INTEGER NOT NULL DEFAULT 0 CHECK (scan_count >= 0),
+    last_used_at_ms INTEGER,
+    use_count INTEGER NOT NULL DEFAULT 0 CHECK (use_count >= 0),
+    probation_until_ms INTEGER,
+    PRIMARY KEY (namespace, id),
+    UNIQUE (namespace, identity),
+    FOREIGN KEY (namespace) REFERENCES memory_namespaces(namespace) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX memories_probation ON memories(probation_until_ms)
+WHERE probation_until_ms IS NOT NULL AND use_count = 0;

--- a/crates/memory-cloudflare/package-lock.json
+++ b/crates/memory-cloudflare/package-lock.json
@@ -1,0 +1,1537 @@
+{
+  "name": "tact-memory-cloudflare",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tact-memory-cloudflare",
+      "devDependencies": {
+        "wrangler": "4.123.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
+      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
+      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
+      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260811.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
+      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260811.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
+      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260811.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
+        "@cloudflare/workerd-linux-64": "1.20260811.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
+        "@cloudflare/workerd-windows-64": "1.20260811.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.123.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
+      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260811.1-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260811.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260811.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/crates/memory-cloudflare/package.json
+++ b/crates/memory-cloudflare/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tact-memory-cloudflare",
+  "private": true,
+  "scripts": {
+    "build": "worker-build --release",
+    "dev": "wrangler dev",
+    "migrate:local": "wrangler d1 migrations apply DB --local",
+    "migrate:remote": "wrangler d1 migrations apply DB --remote",
+    "deploy": "wrangler deploy",
+    "deploy:check": "wrangler deploy --dry-run --outdir bundled"
+  },
+  "devDependencies": {
+    "wrangler": "4.123.0"
+  }
+}

--- a/crates/memory-cloudflare/src/auth.rs
+++ b/crates/memory-cloudflare/src/auth.rs
@@ -1,0 +1,73 @@
+//! Credential loading from one encrypted Worker secret.
+
+use tact_memory::server::{Credential, protocol::RemoteRole};
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+pub(super) const CREDENTIALS_SECRET: &str = "TACT_MEMORY_CREDENTIALS";
+
+/// A content-free failure to parse the deployment credential document.
+#[derive(Debug, Error)]
+pub(super) enum CredentialDocumentError {
+    #[error("the credential document is empty")]
+    Empty,
+    #[error("credential line {line} must contain ROLE NAMESPACE TOKEN")]
+    InvalidLine { line: usize },
+    #[error("credential line {line} has an invalid role")]
+    InvalidRole { line: usize },
+    #[error("credential line {line} has an invalid namespace or bearer token")]
+    InvalidCredential { line: usize },
+}
+
+/// Parses `ROLE NAMESPACE TOKEN` lines while keeping the source document zeroizing.
+pub(super) fn parse_credentials(
+    document: Zeroizing<String>,
+) -> Result<Vec<Credential>, CredentialDocumentError> {
+    let mut credentials = Vec::new();
+    for (index, line) in document.lines().enumerate() {
+        let line_number = index + 1;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut fields = line.split_ascii_whitespace();
+        let (Some(role), Some(namespace), Some(token), None) =
+            (fields.next(), fields.next(), fields.next(), fields.next())
+        else {
+            return Err(CredentialDocumentError::InvalidLine { line: line_number });
+        };
+        let role = match role {
+            "reader" => RemoteRole::Reader,
+            "writer" => RemoteRole::Writer,
+            _ => return Err(CredentialDocumentError::InvalidRole { line: line_number }),
+        };
+        let credential = Credential::new(namespace.to_owned(), role, token.to_owned())
+            .map_err(|_| CredentialDocumentError::InvalidCredential { line: line_number })?;
+        credentials.push(credential);
+    }
+    if credentials.is_empty() {
+        return Err(CredentialDocumentError::Empty);
+    }
+    Ok(credentials)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CredentialDocumentError, parse_credentials};
+    use zeroize::Zeroizing;
+
+    #[test]
+    fn parses_reader_and_writer_lines_without_echoing_input() {
+        let credentials = parse_credentials(Zeroizing::new(
+            "writer alice alice-token\nreader auditor audit-token".to_owned(),
+        ))
+        .unwrap();
+        assert_eq!(credentials.len(), 2);
+
+        let error = parse_credentials(Zeroizing::new("writer alice".to_owned())).unwrap_err();
+        assert!(matches!(
+            error,
+            CredentialDocumentError::InvalidLine { line: 1 }
+        ));
+        assert!(!error.to_string().contains("alice"));
+    }
+}

--- a/crates/memory-cloudflare/src/config.rs
+++ b/crates/memory-cloudflare/src/config.rs
@@ -1,0 +1,37 @@
+//! Non-secret deployment configuration loaded from Worker bindings.
+
+use crate::store::ScanBudget;
+use thiserror::Error;
+use worker::Env;
+
+const SCAN_RECORDS_VARIABLE: &str = "TACT_MEMORY_SCAN_MAX_RECORDS";
+const SCAN_CONTENT_BYTES_VARIABLE: &str = "TACT_MEMORY_SCAN_MAX_CONTENT_BYTES";
+
+/// Failure to load a positive shared-scan resource budget.
+#[derive(Debug, Error)]
+pub(super) enum ConfigError {
+    #[error("missing Worker variable {name}")]
+    Missing { name: &'static str },
+    #[error("Worker variable {name} must be a positive integer")]
+    Invalid { name: &'static str },
+}
+
+/// Loads the deployment's maximum Worker-side BM25 corpus.
+pub(super) fn scan_budget(environment: &Env) -> Result<ScanBudget, ConfigError> {
+    Ok(ScanBudget {
+        records: positive_usize(environment, SCAN_RECORDS_VARIABLE)?,
+        content_bytes: positive_usize(environment, SCAN_CONTENT_BYTES_VARIABLE)?,
+    })
+}
+
+fn positive_usize(environment: &Env, name: &'static str) -> Result<usize, ConfigError> {
+    let value = environment
+        .var(name)
+        .map_err(|_| ConfigError::Missing { name })?
+        .to_string();
+    value
+        .parse()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ConfigError::Invalid { name })
+}

--- a/crates/memory-cloudflare/src/lib.rs
+++ b/crates/memory-cloudflare/src/lib.rs
@@ -1,0 +1,67 @@
+//! Cloudflare Worker deployment for the shared Tact memory protocol.
+//!
+//! The Worker binds a D1 database to the Cloudflare memory store and delegates the HTTP protocol,
+//! authentication, authorization, request bounds, and error surface to [`tact_memory`].
+
+mod auth;
+mod config;
+mod store;
+
+use auth::{CREDENTIALS_SECRET, parse_credentials};
+use axum::body::Body;
+use config::scan_budget;
+use std::sync::{Arc, Once};
+use store::CloudflareMemoryStore;
+use tact_memory::server::MemoryServer;
+use tower::ServiceExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_web::{MakeConsoleWriter, performance_layer};
+use worker::{Context, Env, HttpRequest, Result, event};
+use zeroize::Zeroizing;
+
+const DATABASE_BINDING: &str = "DB";
+static TRACING: Once = Once::new();
+
+/// Serves one authenticated memory protocol request against the bound D1 database.
+#[event(fetch)]
+pub async fn fetch(
+    request: HttpRequest,
+    environment: Env,
+    _context: Context,
+) -> Result<axum::response::Response> {
+    initialize_tracing();
+    let database = Arc::new(environment.d1(DATABASE_BINDING)?);
+    // Cloudflare owns another non-zeroizing copy behind `Secret`. This crate zeroizes only the
+    // Rust string returned by the binding and every credential copy it constructs.
+    let document = Zeroizing::new(environment.secret(CREDENTIALS_SECRET)?.to_string());
+    let credentials = parse_credentials(document).map_err(worker_error)?;
+    let scan_budget = scan_budget(&environment).map_err(worker_error)?;
+    let server = MemoryServer::new(
+        move |namespace| CloudflareMemoryStore::new(Arc::clone(&database), namespace, scan_budget),
+        credentials,
+    )
+    .map_err(worker_error)?;
+    server
+        .router()
+        .oneshot(request.map(Body::new))
+        .await
+        .map_err(worker_error)
+}
+
+fn initialize_tracing() {
+    TRACING.call_once(|| {
+        tracing_subscriber::registry()
+            .with(performance_layer())
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .without_time()
+                    .with_ansi(false)
+                    .with_writer(MakeConsoleWriter),
+            )
+            .init();
+    });
+}
+
+fn worker_error(error: impl std::error::Error) -> worker::Error {
+    worker::Error::RustError(error.to_string())
+}

--- a/crates/memory-cloudflare/src/store.rs
+++ b/crates/memory-cloudflare/src/store.rs
@@ -1,0 +1,637 @@
+//! Cloudflare D1 implementation of Tact's shared memory storage contract.
+//!
+//! Each store instance owns one writer namespace while reads span the shared database. D1 batches
+//! provide the transaction boundary for mutations and telemetry. Integer columns cross the
+//! JavaScript boundary as decimal text so 64-bit IDs, versions, counters, and timestamps retain
+//! their exact values.
+
+mod row;
+
+use row::{CapacityRow, CorpusRow, DecodeResult, ReplaceRow, SyncRow, VersionRow};
+use serde::Serialize;
+use std::{collections::HashSet, fmt::Display, future::Future, sync::Arc};
+use tact_memory::{
+    MemoryError, MemoryKey, MemoryLimits, MemoryRecord, MemoryScan, MemoryStore,
+    normalize_identity,
+    server::protocol::{self, ExportCursor, SyncReport},
+};
+use thiserror::Error;
+use worker::{
+    D1Database, Date,
+    d1::{D1PreparedStatement, D1Result, D1Type},
+    send::SendFuture,
+};
+
+const RECORD_COLUMNS: &str = "namespace, CAST(id AS TEXT) AS id, CAST(version AS TEXT) AS version, content, CAST(created_at_ms AS TEXT) AS created_at_ms, CAST(updated_at_ms AS TEXT) AS updated_at_ms, CAST(last_scanned_at_ms AS TEXT) AS last_scanned_at_ms, CAST(scan_count AS TEXT) AS scan_count, CAST(last_used_at_ms AS TEXT) AS last_used_at_ms, CAST(use_count AS TEXT) AS use_count, CAST(probation_until_ms AS TEXT) AS probation_until_ms";
+const PRUNE_SQL: &str =
+    "DELETE FROM memories WHERE probation_until_ms <= CAST(? AS INTEGER) AND use_count = 0";
+
+/// Deployment-selected bound for exact Worker-side BM25 retrieval.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScanBudget {
+    pub(crate) records: usize,
+    pub(crate) content_bytes: usize,
+}
+
+/// Namespace-bound shared memory backed by Cloudflare D1.
+#[derive(Clone, Debug)]
+pub(crate) struct CloudflareMemoryStore {
+    database: Arc<D1Database>,
+    namespace: Arc<str>,
+    scan_budget: ScanBudget,
+}
+
+impl CloudflareMemoryStore {
+    /// Binds `database` mutations to `namespace`; reads remain shared.
+    pub(crate) fn new(
+        database: impl Into<Arc<D1Database>>,
+        namespace: impl Into<String>,
+        scan_budget: ScanBudget,
+    ) -> Self {
+        Self {
+            database: database.into(),
+            namespace: Arc::from(namespace.into()),
+            scan_budget,
+        }
+    }
+
+    /// Prepares one statement and binds all parameters without exposing D1 errors to the protocol.
+    fn statement(
+        &self,
+        sql: impl Into<String>,
+        values: &[D1Type<'_>],
+    ) -> Result<D1PreparedStatement, MemoryError> {
+        self.database
+            .prepare(sql)
+            .bind_refs(values)
+            .map_err(MessageError::backend)
+    }
+
+    /// Executes one atomic D1 batch.
+    ///
+    /// Transport and statement failures become transient unavailability because D1 rolls back a
+    /// failed batch. Row decoding failures are backend contract violations.
+    async fn batch(
+        &self,
+        statements: Vec<D1PreparedStatement>,
+    ) -> Result<Vec<D1Result>, MemoryError> {
+        let results = self
+            .database
+            .batch(statements)
+            .await
+            .map_err(|error| MemoryError::unavailable(MessageError(error.to_string())))?;
+        if let Some(error) = results.iter().find_map(D1Result::error) {
+            return Err(MemoryError::unavailable(MessageError(error)));
+        }
+        Ok(results)
+    }
+}
+
+impl MemoryStore for CloudflareMemoryStore {
+    fn scan(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> impl Future<Output = Result<MemoryScan, MemoryError>> + Send {
+        let store = self.clone();
+        let query = query.to_owned();
+        SendFuture::new(async move {
+            let limits = MemoryLimits::PRODUCTION;
+            if query.len() > limits.query_bytes {
+                return Err(MemoryError::QueryTooLarge {
+                    maximum_bytes: limits.query_bytes,
+                });
+            }
+            let now = current_time_ms();
+            let scan_budget = store.scan_budget;
+            let corpus_sql = format!(
+                "SELECT {RECORD_COLUMNS} FROM memories WHERE (SELECT COUNT(*) FROM memories) <= {} AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories) <= {} ORDER BY namespace, id",
+                scan_budget.records, scan_budget.content_bytes
+            );
+            let statements = vec![
+                store.statement(PRUNE_SQL, &[D1Type::Text(&now.to_string())])?,
+                store.database.prepare("SELECT COUNT(*) AS record_count, COALESCE(SUM(length(CAST(content AS BLOB))), 0) AS content_bytes FROM memories"),
+                store.database.prepare(corpus_sql),
+            ];
+            let results = store.batch(statements).await?;
+            let corpus = results[1].one::<CorpusRow>()?;
+            if corpus.record_count > scan_budget.records
+                || corpus.content_bytes > scan_budget.content_bytes
+            {
+                return Err(MemoryError::StorageCapacity);
+            }
+            let records = results[2].records()?;
+            let scan = MemoryScan::rank(&query, &records, limit.min(limits.scan_results));
+            if !scan.candidates.is_empty() {
+                let updates = scan
+                    .candidates
+                    .iter()
+                    .map(|candidate| {
+                        let namespace = candidate.key.namespace.as_deref().unwrap_or_default();
+                        store.statement(
+                            "UPDATE memories SET last_scanned_at_ms = CAST(? AS INTEGER), scan_count = CASE WHEN scan_count < 9223372036854775807 THEN scan_count + 1 ELSE scan_count END WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER)",
+                            &[
+                                D1Type::Text(&now.to_string()),
+                                D1Type::Text(namespace),
+                                D1Type::Text(&candidate.key.id.to_string()),
+                                D1Type::Text(&candidate.key.version.to_string()),
+                            ],
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                store.batch(updates).await?;
+            }
+            Ok(scan)
+        })
+    }
+
+    fn read(
+        &self,
+        ids: &[i64],
+        keys: &[MemoryKey],
+    ) -> impl Future<Output = Result<Vec<MemoryRecord>, MemoryError>> + Send {
+        let store = self.clone();
+        let ids = ids.to_vec();
+        let keys = keys.to_vec();
+        SendFuture::new(async move {
+            let now = current_time_ms().to_string();
+            let requests = ReadRequest::collect(&store.namespace, ids, keys);
+            let request_json = serde_json::to_string(&requests).map_err(MessageError::backend)?;
+            let update_sql = "WITH requested AS (SELECT value ->> '$.namespace' AS namespace, CAST(value ->> '$.id' AS INTEGER) AS id, value ->> '$.version' AS version FROM json_each(?)) UPDATE memories SET last_used_at_ms = CAST(? AS INTEGER), use_count = CASE WHEN use_count < 9223372036854775807 THEN use_count + 1 ELSE use_count END, probation_until_ms = NULL WHERE EXISTS (SELECT 1 FROM requested WHERE requested.namespace = memories.namespace AND requested.id = memories.id AND (requested.version IS NULL OR CAST(requested.version AS INTEGER) = memories.version))";
+            let select_sql = format!(
+                "WITH requested AS (SELECT CAST(key AS INTEGER) AS ordinal, value ->> '$.namespace' AS namespace, CAST(value ->> '$.id' AS INTEGER) AS id, value ->> '$.version' AS version FROM json_each(?)) SELECT {RECORD_COLUMNS} FROM requested JOIN memories USING (namespace, id) WHERE requested.version IS NULL OR CAST(requested.version AS INTEGER) = memories.version ORDER BY requested.ordinal"
+            );
+            let results = store
+                .batch(vec![
+                    store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
+                    store.statement(
+                        update_sql,
+                        &[D1Type::Text(&request_json), D1Type::Text(&now)],
+                    )?,
+                    store.statement(select_sql, &[D1Type::Text(&request_json)])?,
+                ])
+                .await?;
+            results[2].records()
+        })
+    }
+
+    fn list(&self) -> impl Future<Output = Result<Vec<MemoryRecord>, MemoryError>> + Send {
+        let store = self.clone();
+        SendFuture::new(async move {
+            let now = current_time_ms().to_string();
+            let sql = format!(
+                "SELECT {RECORD_COLUMNS} FROM memories ORDER BY namespace, id LIMIT {}",
+                MemoryLimits::PRODUCTION.records
+            );
+            let results = store
+                .batch(vec![
+                    store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
+                    store.database.prepare(sql),
+                ])
+                .await?;
+            results[1].records()
+        })
+    }
+
+    fn put(
+        &self,
+        content: &str,
+        replacement: Option<MemoryKey>,
+    ) -> impl Future<Output = Result<MemoryRecord, MemoryError>> + Send {
+        let store = self.clone();
+        let content = content.to_owned();
+        SendFuture::new(async move {
+            validate_content(&content)?;
+            if replacement
+                .as_ref()
+                .is_some_and(|key| key.namespace.as_deref() != Some(store.namespace.as_ref()))
+            {
+                return Err(MemoryError::RemoteReadOnly);
+            }
+            match replacement {
+                Some(key) => store.replace(content, key).await,
+                None => store.insert(content).await,
+            }
+        })
+    }
+
+    fn delete(&self, key: MemoryKey) -> impl Future<Output = Result<(), MemoryError>> + Send {
+        let store = self.clone();
+        SendFuture::new(async move {
+            if key.namespace.as_deref() != Some(store.namespace.as_ref()) {
+                return Err(MemoryError::RemoteReadOnly);
+            }
+            let id = key.id.to_string();
+            let version = key.version.to_string();
+            let results = store.batch(vec![
+                store.statement("SELECT CAST(version AS TEXT) AS version FROM memories WHERE namespace = ? AND id = CAST(? AS INTEGER)", &[D1Type::Text(&store.namespace), D1Type::Text(&id)])?,
+                store.statement("DELETE FROM memories WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER)", &[D1Type::Text(&store.namespace), D1Type::Text(&id), D1Type::Text(&version)])?,
+            ]).await?;
+            let existing = results[0]
+                .results::<VersionRow>()
+                .map_err(MessageError::backend)?
+                .into_iter()
+                .next();
+            if existing.is_some_and(|row| row.version != version) {
+                return Err(MemoryError::Conflict);
+            }
+            Ok(())
+        })
+    }
+
+    fn sync(
+        &self,
+        memories: &[MemoryRecord],
+    ) -> impl Future<Output = Result<SyncReport, MemoryError>> + Send {
+        let store = self.clone();
+        let memories = memories.to_vec();
+        SendFuture::new(async move {
+            validate_snapshot(&memories)?;
+            let payload = memories.iter().map(SyncRow::from).collect::<Vec<_>>();
+            let json = serde_json::to_string(&payload).map_err(MessageError::backend)?;
+            let now = current_time_ms().to_string();
+            let namespace = store.namespace.as_ref();
+            let select_sql =
+                format!("SELECT {RECORD_COLUMNS} FROM memories WHERE namespace = ? ORDER BY id");
+            // Replacing the namespace as a set permits identities to move between stable IDs.
+            let delete_sql = "DELETE FROM memories WHERE namespace = ?";
+            let insert_sql = "INSERT INTO memories (namespace, id, version, content, identity, created_at_ms, updated_at_ms, last_scanned_at_ms, scan_count, last_used_at_ms, use_count, probation_until_ms) SELECT ?, CAST(value ->> '$.id' AS INTEGER), CAST(value ->> '$.version' AS INTEGER), value ->> '$.content', value ->> '$.identity', CAST(value ->> '$.created_at_ms' AS INTEGER), CAST(value ->> '$.updated_at_ms' AS INTEGER), CAST(value ->> '$.last_scanned_at_ms' AS INTEGER), CAST(value ->> '$.scan_count' AS INTEGER), CAST(value ->> '$.last_used_at_ms' AS INTEGER), CAST(value ->> '$.use_count' AS INTEGER), CAST(value ->> '$.probation_until_ms' AS INTEGER) FROM json_each(?)";
+            let next_sql = "UPDATE memory_namespaces SET next_id = MAX(next_id, COALESCE((SELECT MAX(CAST(value ->> '$.id' AS INTEGER)) + 1 FROM json_each(?)), 1)) WHERE namespace = ?";
+            let results = store.batch(vec![
+                store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
+                store.statement(select_sql, &[D1Type::Text(namespace)])?,
+                store.statement("INSERT INTO memory_namespaces(namespace) VALUES (?) ON CONFLICT DO NOTHING", &[D1Type::Text(namespace)])?,
+                store.statement(delete_sql, &[D1Type::Text(namespace)])?,
+                store.statement(insert_sql, &[D1Type::Text(namespace), D1Type::Text(&json)])?,
+                store.statement(next_sql, &[D1Type::Text(&json), D1Type::Text(namespace)])?,
+            ]).await?;
+            let previous = results[1].records()?;
+            Ok(sync_report(&previous, &memories, namespace))
+        })
+    }
+
+    fn export_page(
+        &self,
+        namespaces: Option<&[String]>,
+        cursor: Option<&ExportCursor>,
+        limit: usize,
+    ) -> impl Future<Output = Result<(Vec<MemoryRecord>, Option<ExportCursor>), MemoryError>> + Send
+    {
+        let store = self.clone();
+        let namespaces = namespaces.map(<[String]>::to_vec);
+        let cursor = cursor.cloned();
+        SendFuture::new(async move {
+            let now = current_time_ms().to_string();
+            let selected = serde_json::to_string(&namespaces).map_err(MessageError::backend)?;
+            let has_cursor = if cursor.is_some() { "1" } else { "0" };
+            let cursor_namespace = cursor.as_ref().map_or("", |value| value.namespace.as_str());
+            let cursor_id = cursor
+                .as_ref()
+                .map_or("0".to_owned(), |value| value.id.to_string());
+            let bounded = limit.clamp(1, protocol::MAX_EXPORT_PAGE_RECORDS);
+            let sql = format!(
+                "SELECT {RECORD_COLUMNS} FROM memories WHERE (? = 'null' OR namespace IN (SELECT value FROM json_each(?))) AND (? = '0' OR namespace > ? OR (namespace = ? AND id > CAST(? AS INTEGER))) ORDER BY namespace, id LIMIT {}",
+                bounded + 1
+            );
+            let results = store
+                .batch(vec![
+                    store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
+                    store.statement(
+                        sql,
+                        &[
+                            D1Type::Text(&selected),
+                            D1Type::Text(&selected),
+                            D1Type::Text(has_cursor),
+                            D1Type::Text(cursor_namespace),
+                            D1Type::Text(cursor_namespace),
+                            D1Type::Text(&cursor_id),
+                        ],
+                    )?,
+                ])
+                .await?;
+            let mut records = results[1].records()?;
+            let has_more = records.len() > bounded;
+            records.truncate(bounded);
+            let next = has_more.then(|| {
+                let key = &records
+                    .last()
+                    .expect("a page with more rows is non-empty")
+                    .key;
+                ExportCursor {
+                    namespace: key.namespace.clone().expect("D1 records are namespaced"),
+                    id: key.id,
+                }
+            });
+            Ok((records, next))
+        })
+    }
+}
+
+impl CloudflareMemoryStore {
+    /// Inserts one record while atomically enforcing namespace capacity and deduplication.
+    async fn insert(&self, content: String) -> Result<MemoryRecord, MemoryError> {
+        let limits = MemoryLimits::PRODUCTION;
+        let now_ms = current_time_ms();
+        let now = now_ms.to_string();
+        let identity = normalize_identity(&content);
+        let namespace = self.namespace.as_ref();
+        let diagnostics = "SELECT EXISTS(SELECT 1 FROM memories WHERE namespace = ? AND identity = ?) AS duplicate, (SELECT COUNT(*) FROM memories WHERE namespace = ?) AS record_count, (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE namespace = ?) AS content_bytes";
+        let insert_sql = "INSERT INTO memories (namespace, id, version, content, identity, created_at_ms, updated_at_ms, probation_until_ms) SELECT namespace, next_id, 1, ?, ?, CAST(? AS INTEGER), CAST(? AS INTEGER), CAST(? AS INTEGER) FROM memory_namespaces WHERE namespace = ? AND (SELECT COUNT(*) FROM memories WHERE namespace = ?) < ? AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE namespace = ?) + ? <= ? AND NOT EXISTS (SELECT 1 FROM memories WHERE namespace = ? AND identity = ?)";
+        let probation = now_ms
+            .saturating_add(limits.probation_duration_ms)
+            .to_string();
+        let count_limit = limits.records.to_string();
+        let content_len = content.len().to_string();
+        let byte_limit = limits.total_content_bytes.to_string();
+        let select_sql =
+            format!("SELECT {RECORD_COLUMNS} FROM memories WHERE namespace = ? AND identity = ?");
+        let statements = vec![
+            self.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
+            self.statement(
+                "INSERT INTO memory_namespaces(namespace) VALUES (?) ON CONFLICT DO NOTHING",
+                &[D1Type::Text(namespace)],
+            )?,
+            self.statement(
+                diagnostics,
+                &[
+                    D1Type::Text(namespace),
+                    D1Type::Text(&identity),
+                    D1Type::Text(namespace),
+                    D1Type::Text(namespace),
+                ],
+            )?,
+            self.statement(
+                insert_sql,
+                &[
+                    D1Type::Text(&content),
+                    D1Type::Text(&identity),
+                    D1Type::Text(&now),
+                    D1Type::Text(&now),
+                    D1Type::Text(&probation),
+                    D1Type::Text(namespace),
+                    D1Type::Text(namespace),
+                    D1Type::Text(&count_limit),
+                    D1Type::Text(namespace),
+                    D1Type::Text(&content_len),
+                    D1Type::Text(&byte_limit),
+                    D1Type::Text(namespace),
+                    D1Type::Text(&identity),
+                ],
+            )?,
+            self.statement(
+                "UPDATE memory_namespaces SET next_id = next_id + 1 WHERE namespace = ? AND changes() = 1",
+                &[D1Type::Text(namespace)],
+            )?,
+            self.statement(
+                select_sql,
+                &[D1Type::Text(namespace), D1Type::Text(&identity)],
+            )?,
+        ];
+        let results = self.batch(statements).await?;
+        let diagnostic = results[2].one::<CapacityRow>()?;
+        if diagnostic.duplicate != 0 {
+            return Err(MemoryError::Duplicate);
+        }
+        if diagnostic.record_count >= limits.records {
+            return Err(MemoryError::RecordCapacity {
+                maximum: limits.records,
+            });
+        }
+        if diagnostic.content_bytes.saturating_add(content.len()) > limits.total_content_bytes {
+            return Err(MemoryError::ContentCapacity {
+                maximum_bytes: limits.total_content_bytes,
+            });
+        }
+        results[5].record()
+    }
+
+    /// Replaces one record with optimistic concurrency and namespace capacity checks.
+    async fn replace(&self, content: String, key: MemoryKey) -> Result<MemoryRecord, MemoryError> {
+        let limits = MemoryLimits::PRODUCTION;
+        if key.version >= i64::MAX as u64 {
+            return Err(MemoryError::Conflict);
+        }
+        let now_ms = current_time_ms();
+        let now = now_ms.to_string();
+        let probation = now_ms
+            .saturating_add(limits.probation_duration_ms)
+            .to_string();
+        let identity = normalize_identity(&content);
+        let namespace = self.namespace.as_ref();
+        let id = key.id.to_string();
+        let old_version = key.version.to_string();
+        let new_version = key
+            .version
+            .checked_add(1)
+            .ok_or(MemoryError::Conflict)?
+            .to_string();
+        let diagnostics = "SELECT EXISTS(SELECT 1 FROM memories WHERE namespace = ? AND identity = ? AND id != CAST(? AS INTEGER)) AS duplicate, CAST((SELECT version FROM memories WHERE namespace = ? AND id = CAST(? AS INTEGER)) AS TEXT) AS version, (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE namespace = ?) AS content_bytes, (SELECT length(CAST(content AS BLOB)) FROM memories WHERE namespace = ? AND id = CAST(? AS INTEGER)) AS replaced_bytes";
+        let update = "UPDATE memories SET version = CAST(? AS INTEGER), content = ?, identity = ?, updated_at_ms = CAST(? AS INTEGER), last_scanned_at_ms = NULL, scan_count = 0, last_used_at_ms = NULL, use_count = 0, probation_until_ms = CAST(? AS INTEGER) WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER) AND NOT EXISTS (SELECT 1 FROM memories other WHERE other.namespace = ? AND other.identity = ? AND other.id != CAST(? AS INTEGER)) AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE namespace = ?) - length(CAST(memories.content AS BLOB)) + ? <= ?";
+        let content_len = content.len().to_string();
+        let byte_limit = limits.total_content_bytes.to_string();
+        let select_sql = format!(
+            "SELECT {RECORD_COLUMNS} FROM memories WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER)"
+        );
+        let results = self
+            .batch(vec![
+                self.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
+                self.statement(
+                    diagnostics,
+                    &[
+                        D1Type::Text(namespace),
+                        D1Type::Text(&identity),
+                        D1Type::Text(&id),
+                        D1Type::Text(namespace),
+                        D1Type::Text(&id),
+                        D1Type::Text(namespace),
+                        D1Type::Text(namespace),
+                        D1Type::Text(&id),
+                    ],
+                )?,
+                self.statement(
+                    update,
+                    &[
+                        D1Type::Text(&new_version),
+                        D1Type::Text(&content),
+                        D1Type::Text(&identity),
+                        D1Type::Text(&now),
+                        D1Type::Text(&probation),
+                        D1Type::Text(namespace),
+                        D1Type::Text(&id),
+                        D1Type::Text(&old_version),
+                        D1Type::Text(namespace),
+                        D1Type::Text(&identity),
+                        D1Type::Text(&id),
+                        D1Type::Text(namespace),
+                        D1Type::Text(&content_len),
+                        D1Type::Text(&byte_limit),
+                    ],
+                )?,
+                self.statement(
+                    select_sql,
+                    &[
+                        D1Type::Text(namespace),
+                        D1Type::Text(&id),
+                        D1Type::Text(&new_version),
+                    ],
+                )?,
+            ])
+            .await?;
+        let diagnostic = results[1].one::<ReplaceRow>()?;
+        if diagnostic.duplicate != 0 {
+            return Err(MemoryError::Duplicate);
+        }
+        let Some(version) = diagnostic.version else {
+            return Err(MemoryError::NotFound);
+        };
+        if version != old_version {
+            return Err(MemoryError::Conflict);
+        }
+        if diagnostic
+            .content_bytes
+            .saturating_sub(diagnostic.replaced_bytes.unwrap_or(0))
+            .saturating_add(content.len())
+            > limits.total_content_bytes
+        {
+            return Err(MemoryError::ContentCapacity {
+                maximum_bytes: limits.total_content_bytes,
+            });
+        }
+        results[3].record()
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("{0}")]
+struct MessageError(String);
+
+impl MessageError {
+    /// Erases a backend-specific failure at the storage boundary.
+    fn backend(error: impl Display) -> MemoryError {
+        MemoryError::backend(Self(error.to_string()))
+    }
+}
+
+/// One normalized read selector passed to SQLite's `json_each` table.
+#[derive(Serialize)]
+struct ReadRequest {
+    namespace: String,
+    id: String,
+    version: Option<String>,
+}
+
+impl ReadRequest {
+    /// Combines versioned remote keys and namespace-relative IDs in caller order.
+    fn collect(namespace: &str, ids: Vec<i64>, keys: Vec<MemoryKey>) -> Vec<Self> {
+        let mut seen = HashSet::new();
+        let mut requests = Vec::new();
+        for key in keys {
+            let Some(owner) = key.namespace else {
+                continue;
+            };
+            if seen.insert((owner.clone(), key.id)) {
+                requests.push(Self {
+                    namespace: owner,
+                    id: key.id.to_string(),
+                    version: Some(key.version.to_string()),
+                });
+            }
+        }
+        for id in ids {
+            if seen.insert((namespace.to_owned(), id)) {
+                requests.push(Self {
+                    namespace: namespace.to_owned(),
+                    id: id.to_string(),
+                    version: None,
+                });
+            }
+        }
+        requests
+    }
+}
+
+fn sync_report(
+    previous: &[MemoryRecord],
+    incoming: &[MemoryRecord],
+    namespace: &str,
+) -> SyncReport {
+    let incoming_ids = incoming
+        .iter()
+        .map(|record| record.key.id)
+        .collect::<HashSet<_>>();
+    let mut report = SyncReport {
+        deleted: previous
+            .iter()
+            .filter(|record| !incoming_ids.contains(&record.key.id))
+            .count(),
+        ..SyncReport::default()
+    };
+    for record in incoming {
+        let mut normalized = record.clone();
+        normalized.key.namespace = Some(namespace.to_owned());
+        match previous.iter().find(|old| old.key.id == record.key.id) {
+            Some(old) if old == &normalized => report.unchanged += 1,
+            Some(_) => report.replaced += 1,
+            None => report.inserted += 1,
+        }
+    }
+    report
+}
+
+fn validate_content(content: &str) -> Result<(), MemoryError> {
+    let limits = MemoryLimits::PRODUCTION;
+    if content.trim().is_empty() {
+        return Err(MemoryError::EmptyContent);
+    }
+    if content.len() > limits.content_bytes {
+        return Err(MemoryError::ContentTooLarge {
+            maximum_bytes: limits.content_bytes,
+        });
+    }
+    Ok(())
+}
+
+fn validate_snapshot(memories: &[MemoryRecord]) -> Result<(), MemoryError> {
+    let limits = MemoryLimits::PRODUCTION;
+    if memories.len() > limits.records {
+        return Err(MemoryError::RecordCapacity {
+            maximum: limits.records,
+        });
+    }
+    let mut ids = HashSet::new();
+    let mut identities = HashSet::new();
+    let mut bytes = 0usize;
+    for memory in memories {
+        if !memory.key.is_local()
+            || memory.key.id <= 0
+            || memory.key.version == 0
+            || memory.key.version > i64::MAX as u64
+            || memory.scan_count > i64::MAX as u64
+            || memory.use_count > i64::MAX as u64
+            || memory.created_at_ms < 0
+            || memory.updated_at_ms < memory.created_at_ms
+            || !ids.insert(memory.key.id)
+        {
+            return Err(MemoryError::Conflict);
+        }
+        validate_content(&memory.content)?;
+        if !identities.insert(normalize_identity(&memory.content)) {
+            return Err(MemoryError::Duplicate);
+        }
+        bytes = bytes
+            .checked_add(memory.content.len())
+            .ok_or(MemoryError::ContentCapacity {
+                maximum_bytes: limits.total_content_bytes,
+            })?;
+    }
+    if bytes > limits.total_content_bytes {
+        return Err(MemoryError::ContentCapacity {
+            maximum_bytes: limits.total_content_bytes,
+        });
+    }
+    Ok(())
+}
+
+fn current_time_ms() -> i64 {
+    Date::now().as_millis().try_into().unwrap_or(i64::MAX)
+}

--- a/crates/memory-cloudflare/src/store/row.rs
+++ b/crates/memory-cloudflare/src/store/row.rs
@@ -1,0 +1,156 @@
+//! Exact conversion between D1 result objects and memory domain records.
+
+use super::MessageError;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use tact_memory::{MemoryError, MemoryKey, MemoryRecord, normalize_identity};
+use worker::d1::D1Result;
+
+/// Typed decoding for D1 result objects returned by this backend's query contracts.
+pub(super) trait DecodeResult {
+    /// Decodes all records using the shared record projection.
+    fn records(&self) -> Result<Vec<MemoryRecord>, MemoryError>;
+
+    /// Decodes the one record returned by a successful mutation.
+    fn record(&self) -> Result<MemoryRecord, MemoryError>;
+
+    /// Decodes a query whose contract requires exactly one result row.
+    fn one<T: for<'de> Deserialize<'de>>(&self) -> Result<T, MemoryError>;
+}
+
+impl DecodeResult for D1Result {
+    fn records(&self) -> Result<Vec<MemoryRecord>, MemoryError> {
+        self.results::<RecordRow>()
+            .map_err(MessageError::backend)?
+            .into_iter()
+            .map(MemoryRecord::try_from)
+            .collect()
+    }
+
+    fn record(&self) -> Result<MemoryRecord, MemoryError> {
+        self.records()?
+            .into_iter()
+            .next()
+            .ok_or_else(|| MessageError::backend("D1 mutation produced no record"))
+    }
+
+    fn one<T: for<'de> Deserialize<'de>>(&self) -> Result<T, MemoryError> {
+        self.results::<T>()
+            .map_err(MessageError::backend)?
+            .into_iter()
+            .next()
+            .ok_or_else(|| MessageError::backend("D1 query produced no row"))
+    }
+}
+
+/// D1 representation that preserves SQLite integers across JavaScript.
+#[derive(Deserialize)]
+struct RecordRow {
+    namespace: String,
+    id: String,
+    version: String,
+    content: String,
+    created_at_ms: String,
+    updated_at_ms: String,
+    last_scanned_at_ms: Option<String>,
+    scan_count: String,
+    last_used_at_ms: Option<String>,
+    use_count: String,
+    probation_until_ms: Option<String>,
+}
+
+impl TryFrom<RecordRow> for MemoryRecord {
+    type Error = MemoryError;
+
+    fn try_from(row: RecordRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: MemoryKey::remote(row.namespace, parse(&row.id)?, parse(&row.version)?),
+            content: row.content,
+            created_at_ms: parse(&row.created_at_ms)?,
+            updated_at_ms: parse(&row.updated_at_ms)?,
+            last_scanned_at_ms: parse_optional(row.last_scanned_at_ms)?,
+            scan_count: parse(&row.scan_count)?,
+            last_used_at_ms: parse_optional(row.last_used_at_ms)?,
+            use_count: parse(&row.use_count)?,
+            probation_until_ms: parse_optional(row.probation_until_ms)?,
+        })
+    }
+}
+
+fn parse<T: std::str::FromStr>(value: &str) -> Result<T, MemoryError>
+where
+    T::Err: Display,
+{
+    value.parse().map_err(MessageError::backend)
+}
+
+fn parse_optional<T: std::str::FromStr>(value: Option<String>) -> Result<Option<T>, MemoryError>
+where
+    T::Err: Display,
+{
+    value.map(|value| parse(&value)).transpose()
+}
+
+/// Current version used to distinguish absent and stale deletes.
+#[derive(Deserialize)]
+pub(super) struct VersionRow {
+    pub(super) version: String,
+}
+
+/// Shared corpus size measured before records enter the Worker isolate.
+#[derive(Deserialize)]
+pub(super) struct CorpusRow {
+    pub(super) record_count: usize,
+    pub(super) content_bytes: usize,
+}
+
+/// Namespace capacity and duplicate state measured before insertion.
+#[derive(Deserialize)]
+pub(super) struct CapacityRow {
+    pub(super) duplicate: usize,
+    pub(super) record_count: usize,
+    pub(super) content_bytes: usize,
+}
+
+/// Existing-record state used to classify a rejected replacement.
+#[derive(Deserialize)]
+pub(super) struct ReplaceRow {
+    pub(super) duplicate: usize,
+    pub(super) version: Option<String>,
+    pub(super) content_bytes: usize,
+    pub(super) replaced_bytes: Option<usize>,
+}
+
+/// Snapshot representation encoded for exact `json_each` ingestion.
+#[derive(Serialize)]
+pub(super) struct SyncRow {
+    id: String,
+    version: String,
+    content: String,
+    identity: String,
+    created_at_ms: String,
+    updated_at_ms: String,
+    last_scanned_at_ms: Option<String>,
+    scan_count: String,
+    last_used_at_ms: Option<String>,
+    use_count: String,
+    probation_until_ms: Option<String>,
+}
+
+impl From<&MemoryRecord> for SyncRow {
+    fn from(record: &MemoryRecord) -> Self {
+        Self {
+            id: record.key.id.to_string(),
+            version: record.key.version.to_string(),
+            content: record.content.clone(),
+            identity: normalize_identity(&record.content),
+            created_at_ms: record.created_at_ms.to_string(),
+            updated_at_ms: record.updated_at_ms.to_string(),
+            last_scanned_at_ms: record.last_scanned_at_ms.map(|value| value.to_string()),
+            scan_count: record.scan_count.to_string(),
+            last_used_at_ms: record.last_used_at_ms.map(|value| value.to_string()),
+            use_count: record.use_count.to_string(),
+            probation_until_ms: record.probation_until_ms.map(|value| value.to_string()),
+        }
+    }
+}

--- a/crates/memory-cloudflare/wrangler.jsonc
+++ b/crates/memory-cloudflare/wrangler.jsonc
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "tact-memory",
+  "main": "build/worker/shim.mjs",
+  "compatibility_date": "2026-08-14",
+  "workers_dev": true,
+  "vars": {
+    "TACT_MEMORY_SCAN_MAX_RECORDS": "10240",
+    "TACT_MEMORY_SCAN_MAX_CONTENT_BYTES": "5242880"
+  },
+  "build": {
+    "command": "worker-build --release"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "tact-memory",
+      "database_id": "REPLACE_WITH_D1_DATABASE_ID",
+      "migrations_dir": "migrations"
+    }
+  ],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+  "limits": {
+    "cpu_ms": 1000
+  }
+}

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -12,22 +12,34 @@ description = "Bounded local and remote memory for Tact"
 [lints]
 workspace = true
 
+[features]
+default = ["client", "local", "native-server", "tool"]
+client = ["dep:reqwest", "dep:rustls", "dep:tokio", "dep:url", "dep:zeroize"]
+local = ["dep:rusqlite", "dep:tokio", "dep:zeroize"]
+native-server = ["server", "dep:tokio", "tower/limit"]
+server = ["dep:axum", "dep:sha2", "dep:tower", "dep:tracing", "dep:web-time", "dep:zeroize"]
+tool = ["client", "local", "dep:nanocodex", "dep:zeroize"]
+
 [dependencies]
-axum.workspace = true
+axum = { workspace = true, optional = true }
 const_format.workspace = true
-nanocodex.workspace = true
-reqwest.workspace = true
-rusqlite.workspace = true
-rustls.workspace = true
+nanocodex = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+rusqlite = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
-sha2.workspace = true
+sha2 = { workspace = true, optional = true }
 thiserror.workspace = true
-tokio.workspace = true
-tower = { workspace = true, features = ["limit", "util"] }
-tracing.workspace = true
-url.workspace = true
-zeroize.workspace = true
+tower = { workspace = true, features = ["util"], optional = true }
+tracing = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+web-time = { workspace = true, optional = true }
+zeroize = { workspace = true, optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
+axum = { workspace = true, features = ["http1", "tokio"] }
 tempfile.workspace = true

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -30,20 +30,26 @@ pub const VERSION: u32 = 1;
 
 mod model;
 mod retrieval;
+#[cfg(any(feature = "client", feature = "local"))]
 mod secrets;
 pub mod server;
 mod store;
+#[cfg(feature = "tool")]
 mod tool;
 
 pub use model::{
     MemoryAccess, MemoryCandidate, MemoryImportReport, MemoryKey, MemoryLimits, MemoryRecord,
-    MemoryScan, MemorySource,
+    MemoryScan, MemorySource, normalize_identity,
 };
 pub use server::protocol::RemoteRole;
-pub use store::{
-    LocalMemoryStore, MemoryError, MemoryStore, RemoteClientError, RemoteMemoryClient, RemoteToken,
-    SelectedMemoryStore,
-};
+#[cfg(feature = "local")]
+pub use store::LocalMemoryStore;
+#[cfg(all(feature = "client", feature = "local"))]
+pub use store::SelectedMemoryStore;
+pub use store::{MemoryError, MemoryStore};
+#[cfg(feature = "client")]
+pub use store::{RemoteClientError, RemoteMemoryClient, RemoteToken};
+#[cfg(feature = "tool")]
 pub use tool::{MemoryTool, MutationAuthorizer};
 
 #[cfg(test)]

--- a/crates/memory/src/model.rs
+++ b/crates/memory/src/model.rs
@@ -201,7 +201,8 @@ impl From<StoredMemory> for MemoryRecord {
     }
 }
 
-pub(crate) fn normalize_identity(content: &str) -> String {
+/// Normalizes authored content for backend-enforced duplicate detection.
+pub fn normalize_identity(content: &str) -> String {
     content
         .split_whitespace()
         .map(str::to_lowercase)

--- a/crates/memory/src/server/mod.rs
+++ b/crates/memory/src/server/mod.rs
@@ -9,14 +9,18 @@
 //! the same [crate::MemoryStore] contract. The workspace's `tact-memory-server-example` package
 //! demonstrates the server with a process-lifetime in-memory backend.
 
+#[cfg(feature = "server")]
 mod credential;
 pub mod protocol;
+#[cfg(feature = "server")]
 mod router;
 
+#[cfg(feature = "server")]
 pub use credential::{Credential, CredentialError};
 #[cfg(test)]
 pub(crate) use router::MAX_JSON_BODY_BYTES;
+#[cfg(feature = "server")]
 pub use router::{MemoryServer, ServerBuildError};
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server"))]
 mod tests;

--- a/crates/memory/src/server/router.rs
+++ b/crates/memory/src/server/router.rs
@@ -17,20 +17,25 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
+#[cfg(feature = "native-server")]
+use std::time::Duration;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
     sync::Arc,
-    time::{Duration, Instant},
 };
 use thiserror::Error;
+#[cfg(feature = "native-server")]
 use tower::limit::ConcurrencyLimitLayer;
 use tracing::info;
+use web_time::Instant;
 
 /// Covers worst-case JSON escaping for a full local corpus while bounding allocation.
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 2 * 1024 * 1024;
 
+#[cfg(feature = "native-server")]
 const MAX_IN_FLIGHT_REQUESTS: usize = 64;
+#[cfg(feature = "native-server")]
 const STORE_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Failure to assemble the server's authentication table.
@@ -88,10 +93,10 @@ impl<S: MemoryStore> MemoryServer<S> {
 
     /// Constructs an Axum router sharing this server's credentials and namespace factory.
     ///
-    /// Each router enforces a two-MiB JSON body limit, at most 64 in-flight requests, and a
-    /// 30-second timeout per store operation. Operation futures remain owned by request tasks.
+    /// Each router enforces a two-MiB JSON body limit. The `native-server` feature additionally
+    /// limits the process to 64 in-flight requests and applies a 30-second store timeout.
     pub fn router(&self) -> Router {
-        Router::new()
+        let router = Router::new()
             .route(&route(protocol::SESSION_PATH), get(session))
             .route(&route(protocol::SCAN_PATH), post(scan))
             .route(&route(protocol::READ_PATH), post(read))
@@ -100,9 +105,10 @@ impl<S: MemoryStore> MemoryServer<S> {
             .route(&route(protocol::DELETE_PATH), post(delete))
             .route(&route(protocol::SYNC_PATH), post(sync))
             .route(&route(protocol::EXPORT_PATH), post(export))
-            .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
-            .layer(ConcurrencyLimitLayer::new(MAX_IN_FLIGHT_REQUESTS))
-            .with_state(self.state.clone())
+            .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES));
+        #[cfg(feature = "native-server")]
+        let router = router.layer(ConcurrencyLimitLayer::new(MAX_IN_FLIGHT_REQUESTS));
+        router.with_state(self.state.clone())
     }
 }
 
@@ -607,19 +613,26 @@ where
     T: Send + 'static,
     C: FnOnce(&T) -> OperationCounts,
 {
-    match tokio::time::timeout(STORE_OPERATION_TIMEOUT, operation).await {
+    #[cfg(not(feature = "native-server"))]
+    let result = operation.await;
+    #[cfg(feature = "native-server")]
+    let result = match tokio::time::timeout(STORE_OPERATION_TIMEOUT, operation).await {
         Err(_) => {
             let error = ApiError::unavailable();
             trace.failure(error, request_counts);
-            Err(error)
+            return Err(error);
         }
-        Ok(Ok(value)) => {
+        Ok(result) => result,
+    };
+
+    match result {
+        Ok(value) => {
             let mut counts = success_counts(&value);
             counts.input_count = request_counts.input_count;
             trace.success(counts);
             Ok(value)
         }
-        Ok(Err(source)) => {
+        Err(source) => {
             let error = ApiError::from(source);
             trace.failure(error, request_counts);
             Err(error)

--- a/crates/memory/src/store/mod.rs
+++ b/crates/memory/src/store/mod.rs
@@ -1,21 +1,25 @@
 //! Storage contract, backend selection, and shared failures.
 
+#[cfg(feature = "local")]
 mod local;
+#[cfg(feature = "client")]
 mod remote;
 
+#[cfg(all(feature = "client", feature = "local"))]
+use crate::{MemoryAccess, MemorySource, secrets::contains_likely_secret};
 use crate::{
-    MemoryAccess, MemoryKey, MemoryLimits, MemoryRecord, MemoryScan, MemorySource,
-    secrets::contains_likely_secret,
+    MemoryKey, MemoryLimits, MemoryRecord, MemoryScan,
     server::protocol::{self, ExportCursor, SyncReport},
 };
+#[cfg(feature = "local")]
 pub use local::LocalMemoryStore;
+#[cfg(feature = "client")]
 pub use remote::{RemoteClientError, RemoteMemoryClient, RemoteToken};
-use std::{
-    error::Error,
-    future::Future,
-    path::PathBuf,
-    time::{SystemTime, UNIX_EPOCH},
-};
+#[cfg(all(feature = "client", feature = "local"))]
+use std::path::PathBuf;
+#[cfg(feature = "local")]
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{error::Error, future::Future};
 use thiserror::Error;
 
 /// Ordinary operations shared by local and authenticated remote memory backends.
@@ -130,6 +134,7 @@ pub trait MemoryStore: Clone + Send + Sync + 'static {
 }
 
 /// Runtime-selected local-or-remote memory backend.
+#[cfg(all(feature = "client", feature = "local"))]
 #[derive(Clone, Debug)]
 pub enum SelectedMemoryStore {
     /// Private local SQLite storage.
@@ -138,6 +143,7 @@ pub enum SelectedMemoryStore {
     Remote(RemoteMemoryClient),
 }
 
+#[cfg(all(feature = "client", feature = "local"))]
 impl SelectedMemoryStore {
     /// Selects a private local SQLite backend.
     pub fn local(path: impl Into<PathBuf>) -> Self {
@@ -174,6 +180,7 @@ impl SelectedMemoryStore {
     }
 }
 
+#[cfg(all(feature = "client", feature = "local"))]
 impl MemoryStore for SelectedMemoryStore {
     fn scan(
         &self,
@@ -262,6 +269,7 @@ impl MemoryStore for SelectedMemoryStore {
     }
 }
 
+#[cfg(all(feature = "client", feature = "local"))]
 fn reject_unsafe(content: &str) -> Result<(), MemoryError> {
     if contains_likely_secret(content) {
         return Err(MemoryError::SecretRejected);
@@ -269,6 +277,7 @@ fn reject_unsafe(content: &str) -> Result<(), MemoryError> {
     Ok(())
 }
 
+#[cfg(feature = "local")]
 fn current_time_ms() -> i64 {
     let milliseconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -375,6 +384,7 @@ impl MemoryError {
     }
 }
 
+#[cfg(feature = "client")]
 impl From<RemoteClientError> for MemoryError {
     fn from(source: RemoteClientError) -> Self {
         match source {

--- a/examples/memory-server/Cargo.toml
+++ b/examples/memory-server/Cargo.toml
@@ -13,9 +13,9 @@ description = "In-memory example deployment for the tact-memory server module"
 workspace = true
 
 [dependencies]
-axum.workspace = true
+axum = { workspace = true, features = ["http1", "tokio"] }
 clap.workspace = true
-tact-memory.workspace = true
+tact-memory = { workspace = true, features = ["native-server"] }
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/justfile
+++ b/justfile
@@ -37,6 +37,12 @@ test-docs:
 check-docs:
     cargo doc --no-deps
 
+check-features *args='':
+    cargo hack check --package tact-memory --feature-powerset --no-dev-deps {{args}}
+
+check-wasm *args='':
+    cargo check --package tact-memory-cloudflare --target wasm32-unknown-unknown {{args}}
+
 bench *args='':
     cargo bench {{args}}
 


### PR DESCRIPTION
## Summary

- add a Cloudflare Worker implementation of the shared memory server backed by D1
- implement authenticated namespace roles, bounded storage, exact BM25 retrieval, telemetry, and transactional mutations
- add D1 migrations and deployment configuration
- add WASM compilation and feature-powerset coverage to CI
- document local setup, credentials, limits, and production deployment

## Validation

- `just check-fmt`
- `cargo check --all-features --locked`
- `just clippy --locked`
- `just test --locked` (880 tests)
- `just check-wasm --locked`

## Dependency

Depends on #136 and the memory/server contracts introduced below it.

## Stack

Official GitHub stack [#140](https://github.com/clabby/tact/stacks/140):

1. #135 — shared memory and workspace extraction
2. #136 — reusable subagent runtime crate
3. #137 — Cloudflare/D1 memory deployment
4. #138 — Cloudflare Worker as the deployment example
5. #139 — bounded transcript search