### PR TITLE
feat(session): search referenced transcripts in one bounded scan

### DIFF
--- a/bin/tact/src/core/extensions/sessions.rs
+++ b/bin/tact/src/core/extensions/sessions.rs
@@ -1,7 +1,7 @@
 //! Bounded, read-only access to V2 session transcripts.
 
 use crate::tui::{
-    storage::{DecodedStoredRecord, SessionStorage, StorageError, StoredRecord},
+    storage::{DecodedStoredRecord, SessionStorage, StorageError},
     transcript::TranscriptRecord,
 };
 use nanocodex::{
@@ -17,9 +17,12 @@ use thiserror::Error;
 
 const APPROX_BYTES_PER_TOKEN: usize = 4;
 const CURSOR_RESERVE_BYTES: usize = 32;
-const DEFAULT_PAGE_SIZE: usize = 20;
-const MAX_PAGE_SIZE: usize = 100;
+const STORAGE_PAGE_SIZE: usize = 100;
+const MAX_SCANNED_RECORDS: usize = 10_000;
+const MAX_SCANNED_BYTES: usize = 16 * 1024 * 1024;
 const MAX_KIND_FILTERS: usize = 16;
+const MAX_TEXT_FILTERS: usize = 16;
+const MAX_TEXT_FILTER_BYTES: usize = 256;
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -28,9 +31,9 @@ struct ReadSessionInput {
     #[serde(default)]
     cursor: Option<i64>,
     #[serde(default)]
-    limit: Option<usize>,
-    #[serde(default)]
     kinds: Option<Vec<String>>,
+    #[serde(default)]
+    contains_any: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -51,6 +54,12 @@ struct OutputRecord {
 struct BorrowedOutputRecord<'a> {
     event_id: i64,
     record: &'a TranscriptRecord,
+}
+
+#[derive(Clone, Copy)]
+struct TextMatch {
+    start: usize,
+    len: usize,
 }
 
 #[derive(Debug, Error)]
@@ -76,8 +85,8 @@ impl SessionTool {
         &self,
         session_id: String,
         cursor: Option<i64>,
-        limit: Option<usize>,
         kinds: Option<Vec<String>>,
+        contains_any: Option<Vec<String>>,
         output_token_budget: usize,
     ) -> ToolResult {
         if session_id.trim().is_empty() {
@@ -85,10 +94,6 @@ impl SessionTool {
         }
         if cursor.is_some_and(|cursor| cursor < 0) {
             return Err(io::Error::other("session cursor cannot be negative").into());
-        }
-        let limit = limit.unwrap_or(DEFAULT_PAGE_SIZE);
-        if !(1..=MAX_PAGE_SIZE).contains(&limit) {
-            return Err(io::Error::other("session page size must be between 1 and 100").into());
         }
         if kinds
             .as_ref()
@@ -103,6 +108,21 @@ impl SessionTool {
         }) {
             return Err(io::Error::other("record kinds must contain 1 to 64 bytes").into());
         }
+        if contains_any
+            .as_ref()
+            .is_some_and(|patterns| patterns.is_empty() || patterns.len() > MAX_TEXT_FILTERS)
+        {
+            return Err(io::Error::other("provide between 1 and 16 session text patterns").into());
+        }
+        if contains_any.as_ref().is_some_and(|patterns| {
+            patterns
+                .iter()
+                .any(|pattern| pattern.is_empty() || pattern.len() > MAX_TEXT_FILTER_BYTES)
+        }) {
+            return Err(
+                io::Error::other("session text patterns must contain 1 to 256 bytes").into(),
+            );
+        }
 
         let config_path = self.config_path.clone();
         let requested_id = session_id.clone();
@@ -110,18 +130,14 @@ impl SessionTool {
             let Some(storage) = SessionStorage::open_read_only(&config_path)? else {
                 return Ok(None);
             };
-            let Some(page) = storage.load_record_page(&requested_id, cursor, limit)? else {
-                return Ok(None);
-            };
             bounded_output(
+                &storage,
                 requested_id,
                 cursor,
-                page.records,
-                page.next_cursor.is_some(),
                 kinds.as_deref(),
+                contains_any.as_deref(),
                 output_token_budget,
             )
-            .map(Some)
         })
         .await??
         .ok_or_else(|| io::Error::other(format!("session {session_id} was not found")))?;
@@ -134,7 +150,7 @@ impl Tool for SessionTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
             "read_session",
-            "Reads at most one bounded page of a referenced Tact V2 session; it never loads the full transcript. Use kinds to return only relevant record types, and pass next_cursor back as cursor only when another page is needed. For broad searches, call this tool from code mode, iterate pages, filter results, and stop as soon as sufficient evidence is found.",
+            "Scans a referenced Tact V2 session incrementally and returns one bounded set of relevant records without loading the full transcript. Use kinds and contains_any to filter during the scan. Pass next_cursor back as cursor only when the bounded scan could not finish and more evidence is needed.",
             input_schema(),
         )
         .with_output_schema(output_schema())
@@ -144,14 +160,14 @@ impl Tool for SessionTool {
         let ReadSessionInput {
             session_id,
             cursor,
-            limit,
             kinds,
+            contains_any,
         } = input.decode_json()?;
         self.read(
             session_id,
             cursor,
-            limit,
             kinds,
+            contains_any,
             context.output_token_budget(),
         )
         .await
@@ -159,17 +175,16 @@ impl Tool for SessionTool {
 }
 
 fn bounded_output(
+    storage: &SessionStorage,
     session_id: String,
     initial_cursor: Option<i64>,
-    records: Vec<StoredRecord>,
-    storage_has_more: bool,
     kinds: Option<&[String]>,
+    contains_any: Option<&[String]>,
     output_token_budget: usize,
-) -> Result<ReadSessionOutput, ReadError> {
-    let page_records = records.len();
+) -> Result<Option<ReadSessionOutput>, ReadError> {
     let max_bytes = output_token_budget.saturating_mul(APPROX_BYTES_PER_TOKEN);
     let mut cursor = initial_cursor.unwrap_or(0);
-    let mut stopped_early = false;
+    let mut scanned_bytes = 0usize;
     let mut output = ReadSessionOutput {
         session_id,
         records: Vec::new(),
@@ -177,75 +192,139 @@ fn bounded_output(
         next_cursor: None,
     };
     let empty_output_bytes = serialized_len(&output)?;
-
-    for (index, stored) in records.into_iter().enumerate() {
-        let stored = stored.decode()?;
-        output.scanned_records = output.scanned_records.saturating_add(1);
-        if kinds.is_some_and(|kinds| !kinds.iter().any(|kind| kind == stored.record.kind())) {
-            cursor = stored.event_id;
-            continue;
-        }
-
-        let event_id = stored.event_id;
-        let full_record_bytes = serialized_len(&BorrowedOutputRecord {
-            event_id,
-            record: &stored.record,
-        })?
-        .saturating_add(1);
-        let remaining = max_bytes
-            .saturating_sub(serialized_len(&output)?)
-            .saturating_sub(CURSOR_RESERVE_BYTES);
-        if full_record_bytes <= remaining
-            && push_if_fits(
-                &mut output,
-                OutputRecord {
-                    event_id,
-                    record: serde_json::to_value(&stored.record)?,
-                },
-                max_bytes,
-            )?
-        {
-            cursor = event_id;
-            continue;
-        }
-        let empty_page_capacity = max_bytes
-            .saturating_sub(empty_output_bytes)
-            .saturating_sub(CURSOR_RESERVE_BYTES);
-        if full_record_bytes <= empty_page_capacity {
-            stopped_early = true;
-            break;
-        }
-
-        let truncated = OutputRecord {
-            event_id,
-            record: truncated_record(&stored, 256)?,
-        };
-        let included = if push_if_fits(&mut output, truncated, max_bytes)? {
-            true
-        } else {
-            push_if_fits(
-                &mut output,
-                OutputRecord {
-                    event_id,
-                    record: truncated_record(&stored, 0)?,
-                },
-                max_bytes,
-            )?
-        };
-        if included {
-            cursor = event_id;
-            stopped_early = index.saturating_add(1) < page_records;
-        } else {
-            return Err(ReadError::OutputBudgetTooSmall);
-        }
-        break;
+    if empty_output_bytes.saturating_add(CURSOR_RESERVE_BYTES) > max_bytes {
+        return Err(ReadError::OutputBudgetTooSmall);
     }
 
-    output.next_cursor = (stopped_early || storage_has_more).then_some(cursor);
+    loop {
+        let remaining_records = MAX_SCANNED_RECORDS.saturating_sub(output.scanned_records);
+        let page_size = STORAGE_PAGE_SIZE.min(remaining_records);
+        if page_size == 0 {
+            return finish_output(output, Some(cursor), max_bytes);
+        }
+        let remaining_bytes = MAX_SCANNED_BYTES.saturating_sub(scanned_bytes);
+        let Some(page) = storage.load_record_page(
+            &output.session_id,
+            Some(cursor),
+            page_size,
+            remaining_bytes,
+        )?
+        else {
+            return Ok(None);
+        };
+        let storage_has_more = page.next_cursor.is_some();
+        let page_records = page.records.len();
+        if page_records == 0 {
+            return finish_output(output, None, max_bytes);
+        }
+
+        for (index, stored) in page.records.into_iter().enumerate() {
+            let stored = stored.decode()?;
+            output.scanned_records = output.scanned_records.saturating_add(1);
+            scanned_bytes = scanned_bytes.saturating_add(stored.encoded_bytes);
+            let records_remain = index.saturating_add(1) < page_records || storage_has_more;
+            let matches_kind =
+                kinds.is_none_or(|kinds| kinds.iter().any(|kind| kind == stored.record.kind()));
+            let text_match = contains_any.and_then(|patterns| {
+                patterns.iter().find_map(|pattern| {
+                    find_ignore_ascii_case(stored.record.payload_json(), pattern)
+                })
+            });
+            let matches_text = contains_any.is_none() || text_match.is_some();
+            if !matches_kind || !matches_text {
+                cursor = stored.event_id;
+                if scan_budget_exhausted(&output, scanned_bytes) {
+                    return finish_output(output, records_remain.then_some(cursor), max_bytes);
+                }
+                continue;
+            }
+
+            let event_id = stored.event_id;
+            let full_record_bytes = serialized_len(&BorrowedOutputRecord {
+                event_id,
+                record: &stored.record,
+            })?
+            .saturating_add(1);
+            let remaining = max_bytes
+                .saturating_sub(serialized_len(&output)?)
+                .saturating_sub(CURSOR_RESERVE_BYTES);
+            if full_record_bytes <= remaining
+                && push_if_fits(
+                    &mut output,
+                    OutputRecord {
+                        event_id,
+                        record: serde_json::to_value(&stored.record)?,
+                    },
+                    max_bytes,
+                )?
+            {
+                cursor = event_id;
+                if scan_budget_exhausted(&output, scanned_bytes) {
+                    return finish_output(output, records_remain.then_some(cursor), max_bytes);
+                }
+                continue;
+            }
+            let empty_page_capacity = max_bytes
+                .saturating_sub(empty_output_bytes)
+                .saturating_sub(CURSOR_RESERVE_BYTES);
+            if full_record_bytes <= empty_page_capacity {
+                return finish_output(output, Some(cursor), max_bytes);
+            }
+
+            let truncated = OutputRecord {
+                event_id,
+                record: truncated_record(&stored, 256, text_match)?,
+            };
+            let included = if push_if_fits(&mut output, truncated, max_bytes)? {
+                true
+            } else {
+                push_if_fits(
+                    &mut output,
+                    OutputRecord {
+                        event_id,
+                        record: truncated_record(&stored, 0, text_match)?,
+                    },
+                    max_bytes,
+                )?
+            };
+            if !included {
+                return Err(ReadError::OutputBudgetTooSmall);
+            }
+            cursor = event_id;
+            return finish_output(output, records_remain.then_some(cursor), max_bytes);
+        }
+
+        if !storage_has_more {
+            return finish_output(output, None, max_bytes);
+        }
+    }
+}
+
+fn finish_output(
+    mut output: ReadSessionOutput,
+    next_cursor: Option<i64>,
+    max_bytes: usize,
+) -> Result<Option<ReadSessionOutput>, ReadError> {
+    output.next_cursor = next_cursor;
     if serialized_len(&output)? > max_bytes {
         return Err(ReadError::OutputBudgetTooSmall);
     }
-    Ok(output)
+    Ok(Some(output))
+}
+
+fn scan_budget_exhausted(output: &ReadSessionOutput, scanned_bytes: usize) -> bool {
+    output.scanned_records >= MAX_SCANNED_RECORDS || scanned_bytes >= MAX_SCANNED_BYTES
+}
+
+fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<TextMatch> {
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+        .map(|start| TextMatch {
+            start,
+            len: needle.len(),
+        })
 }
 
 fn push_if_fits(
@@ -283,9 +362,29 @@ impl Write for ByteCounter {
 fn truncated_record(
     stored: &DecodedStoredRecord,
     preview_bytes: usize,
+    text_match: Option<TextMatch>,
 ) -> Result<Value, serde_json::Error> {
     let payload = stored.record.payload_json();
-    let mut preview_end = preview_bytes.min(payload.len());
+    let required_bytes = text_match.map_or(0, |text_match| text_match.len);
+    let preview_bytes = preview_bytes.max(required_bytes).min(payload.len());
+    let mut preview_start = text_match.map_or(0, |text_match| {
+        text_match
+            .start
+            .saturating_sub(preview_bytes.saturating_sub(text_match.len) / 2)
+    });
+    let mut preview_end = preview_start
+        .saturating_add(preview_bytes)
+        .min(payload.len());
+    if let Some(text_match) = text_match {
+        let match_end = text_match.start.saturating_add(text_match.len);
+        if preview_end < match_end {
+            preview_end = match_end.min(payload.len());
+            preview_start = preview_end.saturating_sub(preview_bytes);
+        }
+    }
+    while !payload.is_char_boundary(preview_start) {
+        preview_start = preview_start.saturating_sub(1);
+    }
     while !payload.is_char_boundary(preview_end) {
         preview_end = preview_end.saturating_sub(1);
     }
@@ -294,7 +393,8 @@ fn truncated_record(
     record["payload"] = json!({
         "truncated": true,
         "original_bytes": payload.len(),
-        "preview": &payload[..preview_end]
+        "preview_start": preview_start,
+        "preview": &payload[preview_start..preview_end]
     });
     Ok(record)
 }
@@ -311,14 +411,7 @@ fn input_schema() -> Value {
             "cursor": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "The next_cursor returned by the preceding page. Omit for the first page."
-            },
-            "limit": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": MAX_PAGE_SIZE,
-                "default": DEFAULT_PAGE_SIZE,
-                "description": "Maximum records read from disk in this page before applying kinds."
+                "description": "The next_cursor returned by a preceding bounded scan. Omit for the first scan."
             },
             "kinds": {
                 "type": "array",
@@ -326,7 +419,15 @@ fn input_schema() -> Value {
                 "minItems": 1,
                 "maxItems": MAX_KIND_FILTERS,
                 "uniqueItems": true,
-                "description": "Optional exact transcript record types to return, such as user.submitted or assistant.message. Filtering is confined to this bounded page."
+                "description": "Optional exact transcript record types to return, such as user.submitted or assistant.message."
+            },
+            "contains_any": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1, "maxLength": MAX_TEXT_FILTER_BYTES },
+                "minItems": 1,
+                "maxItems": MAX_TEXT_FILTERS,
+                "uniqueItems": true,
+                "description": "Optional ASCII-case-insensitive literal patterns matched against each record payload; a record is returned when any pattern matches."
             }
         },
         "required": ["session_id"],
@@ -361,7 +462,10 @@ fn output_schema() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{APPROX_BYTES_PER_TOKEN, MAX_PAGE_SIZE, SessionTool, truncated_record};
+    use super::{
+        APPROX_BYTES_PER_TOKEN, MAX_TEXT_FILTERS, STORAGE_PAGE_SIZE, SessionTool,
+        find_ignore_ascii_case, truncated_record,
+    };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::{
@@ -388,7 +492,11 @@ mod tests {
 
         assert_eq!(definition.name(), "read_session");
         assert_eq!(input["additionalProperties"], json!(false));
-        assert_eq!(input["properties"]["limit"]["maximum"], MAX_PAGE_SIZE);
+        assert!(input["properties"].get("limit").is_none());
+        assert_eq!(
+            input["properties"]["contains_any"]["maxItems"],
+            MAX_TEXT_FILTERS
+        );
         assert_eq!(output["additionalProperties"], json!(false));
     }
 
@@ -396,6 +504,7 @@ mod tests {
     fn truncated_agent_records_preserve_correlation_metadata() {
         let stored = DecodedStoredRecord {
             event_id: 7,
+            encoded_bytes: 10_000,
             record: TranscriptRecord::from_agent(
                 11,
                 13,
@@ -411,11 +520,40 @@ mod tests {
             ),
         };
 
-        let truncated = truncated_record(&stored, 0).unwrap();
+        let truncated = truncated_record(&stored, 0, None).unwrap();
 
         assert_eq!(truncated["agent"]["protocol_version"], 2);
         assert_eq!(truncated["agent"]["request_id"], "request");
         assert_eq!(truncated["agent"]["sequence"], 17);
+    }
+
+    #[test]
+    fn truncated_search_results_include_a_late_match() {
+        let text = format!("{}Session Needle{}", "x".repeat(5_000), "y".repeat(5_000));
+        let stored = DecodedStoredRecord {
+            event_id: 7,
+            encoded_bytes: text.len(),
+            record: TranscriptRecord::from_local(
+                1,
+                1,
+                LocalEvent::UserSubmitted {
+                    id: TurnId::new(1),
+                    text,
+                },
+            )
+            .unwrap(),
+        };
+        let text_match = find_ignore_ascii_case(stored.record.payload_json(), "session needle");
+
+        let truncated = truncated_record(&stored, 256, text_match).unwrap();
+
+        assert!(truncated["payload"]["preview_start"].as_u64().unwrap() > 0);
+        assert!(
+            truncated["payload"]["preview"]
+                .as_str()
+                .unwrap()
+                .contains("Session Needle")
+        );
     }
 
     #[tokio::test]
@@ -424,24 +562,7 @@ mod tests {
         let config_path = directory.path().join("config.toml");
         let mut storage = SessionStorage::open(&config_path).unwrap();
         let records = [
-            Arc::new(
-                TranscriptRecord::from_local(
-                    1,
-                    1,
-                    LocalEvent::SessionStarted(SessionStarted {
-                        session_id: "referenced".to_owned(),
-                        parent_session_id: None,
-                        parent_sequence: None,
-                        model: "model".to_owned(),
-                        effort: ReasoningEffort::Medium,
-                        reasoning_mode: ReasoningMode::Standard,
-                        fast_mode: false,
-                        workspace: "/work".into(),
-                        application_version: "test".to_owned(),
-                    }),
-                )
-                .unwrap(),
-            ),
+            session_started("referenced"),
             Arc::new(
                 TranscriptRecord::from_local(
                     2,
@@ -463,7 +584,6 @@ mod tests {
         let input = ToolInput::Function(
             to_raw_value(&json!({
                 "session_id": "referenced",
-                "limit": 3,
                 "kinds": ["user.submitted"]
             }))
             .unwrap(),
@@ -486,7 +606,6 @@ mod tests {
         let input = ToolInput::Function(
             to_raw_value(&json!({
                 "session_id": "referenced",
-                "limit": 2,
                 "kinds": ["does.not.exist"]
             }))
             .unwrap(),
@@ -499,5 +618,148 @@ mod tests {
             error.to_string(),
             "the tool output budget is too small to read the next session record"
         );
+    }
+
+    #[tokio::test]
+    async fn one_call_searches_across_storage_pages() {
+        let directory = tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config_path).unwrap();
+        let final_sequence = u64::try_from(STORAGE_PAGE_SIZE * 2 + 2).unwrap();
+        let mut records = vec![session_started("searched")];
+        for sequence in 2..=final_sequence {
+            let text = if sequence == final_sequence {
+                "A CommonWare session needle"
+            } else {
+                "irrelevant"
+            };
+            records.push(Arc::new(
+                TranscriptRecord::from_local(
+                    sequence,
+                    sequence,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(sequence),
+                        text: text.to_owned(),
+                    },
+                )
+                .unwrap(),
+            ));
+        }
+        storage.append_records("searched", &records).unwrap();
+
+        let tool = SessionTool::new(config_path);
+        let input = ToolInput::Function(
+            to_raw_value(&json!({
+                "session_id": "searched",
+                "kinds": ["user.submitted"],
+                "contains_any": ["commonware", "another needle"]
+            }))
+            .unwrap(),
+        );
+        let context = ToolContext::new("test-model", "current", "search-call", &[], 1_000);
+        let output = tool.execute(input, context).await.unwrap();
+        let ToolOutputBody::Text(output) = output.output else {
+            panic!("session reader returned non-text output");
+        };
+        let output: Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(output["records"].as_array().unwrap().len(), 1);
+        assert_eq!(output["records"][0]["record"]["type"], "user.submitted");
+        assert_eq!(output["scanned_records"], final_sequence);
+        assert!(output["next_cursor"].is_null());
+    }
+
+    #[tokio::test]
+    async fn output_continuation_resumes_before_the_first_omitted_match() {
+        let directory = tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config_path).unwrap();
+        let records = [
+            session_started("continued"),
+            Arc::new(
+                TranscriptRecord::from_local(
+                    2,
+                    2,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(2),
+                        text: format!("match first {}", "x".repeat(600)),
+                    },
+                )
+                .unwrap(),
+            ),
+            Arc::new(
+                TranscriptRecord::from_local(
+                    3,
+                    3,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(3),
+                        text: format!("match second {}", "x".repeat(600)),
+                    },
+                )
+                .unwrap(),
+            ),
+        ];
+        storage.append_records("continued", &records).unwrap();
+
+        let tool = SessionTool::new(config_path);
+        let first = execute_search(&tool, None, 300).await;
+        assert_eq!(first["records"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            first["records"][0]["record"]["payload"]["text"]
+                .as_str()
+                .unwrap()
+                .len(),
+            612
+        );
+        let cursor = first["next_cursor"].as_i64().unwrap();
+
+        let second = execute_search(&tool, Some(cursor), 300).await;
+        assert_eq!(second["records"].as_array().unwrap().len(), 1);
+        assert!(
+            second["records"][0]["record"]["payload"]["text"]
+                .as_str()
+                .unwrap()
+                .starts_with("match second")
+        );
+        assert!(second["next_cursor"].is_null());
+    }
+
+    async fn execute_search(tool: &SessionTool, cursor: Option<i64>, budget: usize) -> Value {
+        let input = ToolInput::Function(
+            to_raw_value(&json!({
+                "session_id": "continued",
+                "cursor": cursor,
+                "kinds": ["user.submitted"],
+                "contains_any": ["match"]
+            }))
+            .unwrap(),
+        );
+        let context = ToolContext::new("test-model", "current", "continuation-call", &[], budget);
+        let output = tool.execute(input, context).await.unwrap();
+        let ToolOutputBody::Text(output) = output.output else {
+            panic!("session reader returned non-text output");
+        };
+        serde_json::from_str(&output).unwrap()
+    }
+
+    fn session_started(session_id: &str) -> Arc<TranscriptRecord> {
+        Arc::new(
+            TranscriptRecord::from_local(
+                1,
+                1,
+                LocalEvent::SessionStarted(SessionStarted {
+                    session_id: session_id.to_owned(),
+                    parent_session_id: None,
+                    parent_sequence: None,
+                    model: "model".to_owned(),
+                    effort: ReasoningEffort::Medium,
+                    reasoning_mode: ReasoningMode::Standard,
+                    fast_mode: false,
+                    workspace: "/work".into(),
+                    application_version: "test".to_owned(),
+                }),
+            )
+            .unwrap(),
+        )
     }
 }

--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -77,10 +77,10 @@ const TACT_INSTRUCTIONS: &str = concat!(
 
 const SESSION_REFERENCE_INSTRUCTIONS: &str = concat!(
     "Session references use `@@<session-id>`. When the user references one, use `read_session` ",
-    "to inspect only the relevant bounded transcript pages. Prefer record-kind filters. For broad ",
-    "searches, use code mode to page with `next_cursor`, filter the results, and stop as soon as ",
-    "you have enough evidence. Do not treat the ID itself as session content or load additional ",
-    "pages unless they are needed."
+    "to scan the relevant transcript records in one bounded call. Prefer record-kind and text ",
+    "filters, and provide multiple text patterns together when useful. Pass `next_cursor` back only ",
+    "when the scan could not finish and more evidence is needed. Do not treat the ID itself as ",
+    "session content."
 );
 
 const MEMORY_INSTRUCTIONS: &str = concat!(

--- a/bin/tact/src/tui/storage.rs
+++ b/bin/tact/src/tui/storage.rs
@@ -84,13 +84,16 @@ pub(crate) struct StoredRecord {
 #[derive(Debug)]
 pub(crate) struct DecodedStoredRecord {
     pub(crate) event_id: i64,
+    pub(crate) encoded_bytes: usize,
     pub(crate) record: TranscriptRecord,
 }
 
 impl StoredRecord {
     pub(crate) fn decode(self) -> Result<DecodedStoredRecord, StorageError> {
+        let encoded_bytes = self.encoded.len();
         Ok(DecodedStoredRecord {
             event_id: self.event_id,
+            encoded_bytes,
             record: decode_record(&self.encoded)?,
         })
     }
@@ -308,6 +311,7 @@ impl SessionStorage {
         session_id: &str,
         after_event_id: Option<i64>,
         limit: usize,
+        max_bytes: usize,
     ) -> Result<Option<StoredRecordPage>, StorageError> {
         let exists = self
             .connection
@@ -326,25 +330,41 @@ impl SessionStorage {
         let mut statement = self
             .connection
             .prepare(
-                "SELECT event_id, record_json FROM events\n\
+                "SELECT event_id, length(record_json), record_json FROM events\n\
                  WHERE session_id = ?1 AND event_id > ?2\n\
                  ORDER BY event_id LIMIT ?3",
             )
             .map_err(|source| query(&self.path, source))?;
-        let rows = statement
-            .query_map(params![session_id, after_event_id, row_limit], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?))
-            })
+        let mut rows = statement
+            .query(params![session_id, after_event_id, row_limit])
             .map_err(|source| query(&self.path, source))?;
-        let mut encoded = rows
-            .map(|row| row.map_err(|source| query(&self.path, source)))
-            .collect::<Result<Vec<_>, StorageError>>()?;
-        let has_more = encoded.len() > limit;
-        encoded.truncate(limit);
-        let records = encoded
-            .into_iter()
-            .map(|(event_id, encoded)| StoredRecord { event_id, encoded })
-            .collect::<Vec<_>>();
+        let mut records = Vec::new();
+        let mut loaded_bytes = 0usize;
+        let mut has_more = false;
+        while let Some(row) = rows.next().map_err(|source| query(&self.path, source))? {
+            if records.len() == limit {
+                has_more = true;
+                break;
+            }
+            let encoded_bytes = row
+                .get::<_, i64>(1)
+                .map_err(|source| query(&self.path, source))?;
+            let encoded_bytes = usize::try_from(encoded_bytes).unwrap_or(usize::MAX);
+            // The first record is always admitted so a caller can advance past a single oversized
+            // event. Every additional record must fit within the requested page byte budget.
+            if !records.is_empty() && loaded_bytes.saturating_add(encoded_bytes) > max_bytes {
+                has_more = true;
+                break;
+            }
+            let encoded = row
+                .get::<_, Vec<u8>>(2)
+                .map_err(|source| query(&self.path, source))?;
+            loaded_bytes = loaded_bytes.saturating_add(encoded.len());
+            records.push(StoredRecord {
+                event_id: row.get(0).map_err(|source| query(&self.path, source))?,
+                encoded,
+            });
+        }
         let next_cursor = has_more
             .then(|| records.last().map(|record| record.event_id))
             .flatten();
@@ -874,14 +894,14 @@ mod tests {
         append_prompt_record(&mut storage, "session", 3, 200, "second prompt");
 
         let first = storage
-            .load_record_page("session", None, 2)
+            .load_record_page("session", None, 2, usize::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(first.records.len(), 2);
         assert!(first.next_cursor.is_some());
 
         let second = storage
-            .load_record_page("session", first.next_cursor, 2)
+            .load_record_page("session", first.next_cursor, 2, usize::MAX)
             .unwrap()
             .unwrap();
         assert_eq!(second.records.len(), 1);
@@ -898,12 +918,34 @@ mod tests {
         storage.append_raw_record("session", b"not-json").unwrap();
 
         let page = storage
-            .load_record_page("session", None, 2)
+            .load_record_page("session", None, 2, usize::MAX)
             .unwrap()
             .unwrap();
 
         assert_eq!(page.records.len(), 2);
         assert!(page.next_cursor.is_some());
+    }
+
+    #[test]
+    fn transcript_page_byte_budget_allows_one_oversized_record_for_progress() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config).unwrap();
+        append_prompt(&mut storage, "session", 100, "prompt");
+
+        let first = storage
+            .load_record_page("session", None, 100, 1)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first.records.len(), 1);
+        assert!(first.next_cursor.is_some());
+        let second = storage
+            .load_record_page("session", first.next_cursor, 100, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(second.records.len(), 1);
+        assert!(second.next_cursor.is_none());
     }
 
     #[test]
@@ -914,7 +956,7 @@ mod tests {
 
         assert!(
             storage
-                .load_record_page("missing", None, 10)
+                .load_record_page("missing", None, 10, usize::MAX)
                 .unwrap()
                 .is_none()
         );


### PR DESCRIPTION
## Summary

- replace repeated paginated `read_session` calls with one bounded transcript search
- support record-kind filters and multiple text patterns in a single request
- return continuation state only when the bounded scan cannot finish
- preserve transcript metadata while reducing agent tool-call spam
- update agent instructions and session-reader tests for the new contract

## Validation

- `just check-fmt`
- `cargo check --all-features --locked`
- `just clippy --locked`
- `just test --locked` (880 tests)

## Dependency

Depends on #138 because it is the top revision of the same workspace stack.

## Stack

Official GitHub stack [#140](https://github.com/clabby/tact/stacks/140):

1. #135 — shared memory and workspace extraction
2. #136 — reusable subagent runtime crate
3. #137 — Cloudflare/D1 memory deployment
4. #138 — Cloudflare Worker as the deployment example
5. #139 — bounded transcript search