### PR TITLE
feat(tui): add guided session reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,26 @@ Config reload applies memory-browser availability immediately. Like other agent 
 settings, the agent-facing memory setting applies when a new session starts or is restored; an
 already-running agent retains the tool surface and instructions with which it was created.
 
+### Reflection
+
+Choose **Reflect on session** from the Actions menu while the session is idle. The composer accepts
+optional instructions for the reflection; press Enter with an empty composer to use the default
+scope, or press Escape to cancel. Tact submits the reflection to the existing agent so it can use
+the conversation already in context.
+
+The transcript shows a muted **Reflection started** marker instead of the internal prompt, followed
+by the agent's report as a normal assistant response. Reflection is read-only: the report ends with
+findings and recommended actions for discussion, and memory updates or other durable actions require
+a later explicit request.
+
+The built-in workflow starts with the current conversation, then samples relevant historical
+sessions from the current workspace through bounded, read-only queries against Tact's session
+database. It uses `read_session` to inspect only the strongest candidates, checks supported lessons
+against existing memories and active instructions, and recommends whether each lesson belongs in
+memory, always-on configuration, or nowhere. Additional instructions can narrow the topic or expand
+the workspace and task-family scope. The report states the coverage and uncertainty of its evidence;
+it does not apply its recommendations.
+
 ### Review
 
 Enter `/review` while no agent work is active to open a browser-based human review tool for

--- a/bin/tact/src/core/extensions/sessions.rs
+++ b/bin/tact/src/core/extensions/sessions.rs
@@ -150,7 +150,7 @@ impl Tool for SessionTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
             "read_session",
-            "Scans a referenced Tact V2 session incrementally and returns one bounded set of relevant records without loading the full transcript. Use kinds and contains_any to filter during the scan. Pass next_cursor back as cursor only when the bounded scan could not finish and more evidence is needed.",
+            "Scans a known Tact V2 session incrementally and returns one bounded set of relevant records without loading the full transcript. The session ID may come from an explicit @@ reference or Tact's built-in reflection workflow. Use kinds and contains_any to filter during the scan. Cursor is an exclusive event-ID boundary: pass next_cursor back to continue a bounded scan, or pass a matched event_id to read following context.",
             input_schema(),
         )
         .with_output_schema(output_schema())
@@ -406,12 +406,12 @@ fn input_schema() -> Value {
             "session_id": {
                 "type": "string",
                 "minLength": 1,
-                "description": "The exact ID following @@ in the user's prompt."
+                "description": "An exact Tact V2 session ID from an explicit @@ reference or the built-in reflection workflow."
             },
             "cursor": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "The next_cursor returned by a preceding bounded scan. Omit for the first scan."
+                "description": "An exclusive event-ID boundary. Use next_cursor to continue a bounded scan or a matched event_id to read following context; omit to start at the beginning."
             },
             "kinds": {
                 "type": "array",
@@ -491,7 +491,25 @@ mod tests {
         let output = definition.output_schema().unwrap().as_value();
 
         assert_eq!(definition.name(), "read_session");
+        assert!(definition.description().contains("built-in reflection"));
+        assert!(
+            definition
+                .description()
+                .contains("exclusive event-ID boundary")
+        );
         assert_eq!(input["additionalProperties"], json!(false));
+        assert!(
+            input["properties"]["session_id"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("built-in reflection")
+        );
+        assert!(
+            input["properties"]["cursor"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("matched event_id")
+        );
         assert!(input["properties"].get("limit").is_none());
         assert_eq!(
             input["properties"]["contains_any"]["maxItems"],
@@ -670,6 +688,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn matched_event_id_reads_the_following_context() {
+        let directory = tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        let mut storage = SessionStorage::open(&config_path).unwrap();
+        let records = [
+            session_started("adjacent"),
+            Arc::new(
+                TranscriptRecord::from_local(
+                    2,
+                    2,
+                    LocalEvent::UserSubmitted {
+                        id: TurnId::new(1),
+                        text: "validation needle".to_owned(),
+                    },
+                )
+                .unwrap(),
+            ),
+            Arc::new(TranscriptRecord::from_agent(
+                3,
+                3,
+                AgentEvent {
+                    protocol_version: 2,
+                    request_id: Arc::from("request"),
+                    seq: 1,
+                    kind: AgentEventKind::AssistantMessage,
+                    payload: to_raw_value(&json!({
+                        "model_call_index": 1,
+                        "item_id": "answer",
+                        "phase": "final_answer",
+                        "text": "following response"
+                    }))
+                    .unwrap()
+                    .into(),
+                },
+            )),
+        ];
+        storage.append_records("adjacent", &records).unwrap();
+        let tool = SessionTool::new(config_path);
+
+        let matched = execute(
+            &tool,
+            json!({
+                "session_id": "adjacent",
+                "kinds": ["user.submitted"],
+                "contains_any": ["validation needle"]
+            }),
+            1_000,
+        )
+        .await;
+        let event_id = matched["records"][0]["event_id"].as_i64().unwrap();
+        let following = execute(
+            &tool,
+            json!({
+                "session_id": "adjacent",
+                "cursor": event_id,
+                "kinds": ["assistant.message"]
+            }),
+            1_000,
+        )
+        .await;
+
+        assert_eq!(following["records"].as_array().unwrap().len(), 1);
+        assert_eq!(following["records"][0]["event_id"], 3);
+        assert_eq!(
+            following["records"][0]["record"]["payload"]["text"],
+            "following response"
+        );
+    }
+
+    #[tokio::test]
     async fn output_continuation_resumes_before_the_first_omitted_match() {
         let directory = tempdir().unwrap();
         let config_path = directory.path().join("config.toml");
@@ -725,15 +813,21 @@ mod tests {
     }
 
     async fn execute_search(tool: &SessionTool, cursor: Option<i64>, budget: usize) -> Value {
-        let input = ToolInput::Function(
-            to_raw_value(&json!({
+        execute(
+            tool,
+            json!({
                 "session_id": "continued",
                 "cursor": cursor,
                 "kinds": ["user.submitted"],
                 "contains_any": ["match"]
-            }))
-            .unwrap(),
-        );
+            }),
+            budget,
+        )
+        .await
+    }
+
+    async fn execute(tool: &SessionTool, input: Value, budget: usize) -> Value {
+        let input = ToolInput::Function(to_raw_value(&input).unwrap());
         let context = ToolContext::new("test-model", "current", "continuation-call", &[], budget);
         let output = tool.execute(input, context).await.unwrap();
         let ToolOutputBody::Text(output) = output.output else {

--- a/bin/tact/src/tui/components/actions.rs
+++ b/bin/tact/src/tui/components/actions.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const ACTIONS: [Action; 15] = [
+const ACTIONS: [Action; 16] = [
     Action::Effort,
     Action::FastMode,
     Action::Theme,
@@ -29,6 +29,7 @@ const ACTIONS: [Action; 15] = [
     Action::Memory,
     Action::Subagents,
     Action::DebugContext,
+    Action::Reflection,
     Action::Handoff,
     Action::Review,
     Action::Model,
@@ -66,6 +67,7 @@ pub(super) enum Action {
     EditConfig,
     Memory,
     DebugContext,
+    Reflection,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -263,7 +265,7 @@ impl ActionsMenu {
 
     const fn is_enabled(&self, action: Action) -> bool {
         match action {
-            Action::Handoff | Action::Review => self.availability.new_session,
+            Action::Handoff | Action::Review | Action::Reflection => self.availability.new_session,
             Action::Subagents => true,
             Action::Effort => true,
             Action::Model => self.availability.model,
@@ -295,6 +297,9 @@ impl ActionsMenu {
             Action::Handoff if !self.availability.new_session => {
                 "Prepare handoff · finish active work first"
             }
+            Action::Reflection if !self.availability.new_session => {
+                "Reflect on session · finish active work first"
+            }
             Action::FastMode if self.availability.fast_mode => "Disable fast mode",
             Action::Model if !self.availability.model => "Select model · start a new session first",
             Action::Memory if !self.availability.memory => {
@@ -323,6 +328,7 @@ impl Action {
             Self::EditConfig => "Edit config",
             Self::Memory => "Memory",
             Self::DebugContext => "Debug context",
+            Self::Reflection => "Reflect on session",
         }
     }
 
@@ -340,6 +346,7 @@ impl Action {
             Self::Fork => Some("btw"),
             Self::ReloadConfig => Some("refresh"),
             Self::Memory => Some("remember/forget"),
+            Self::Reflection => Some("reflection"),
             Self::Keybindings | Self::EditConfig | Self::DebugContext => None,
         }
     }
@@ -369,7 +376,7 @@ impl Component for ActionsMenu {
             return;
         }
 
-        let layout = Floating::new("Actions", 58, 18, &KEY_BINDINGS).render(frame, area, theme);
+        let layout = Floating::new("Actions", 58, 19, &KEY_BINDINGS).render(frame, area, theme);
         if layout.body.is_empty() {
             return;
         }
@@ -453,60 +460,64 @@ mod tests {
         let terminal = render(&mut menu);
 
         assert_eq!(
-            row_segment(&terminal, 1, 1, 58),
+            row_segment(&terminal, 0, 1, 58),
             "╭─────────────────────── Actions ────────────────────────╮"
         );
         assert_eq!(
-            row_segment(&terminal, 2, 1, 58),
+            row_segment(&terminal, 1, 1, 58),
             "│  Search:                                               │"
         );
         assert_eq!(
-            row_segment(&terminal, 3, 1, 58),
+            row_segment(&terminal, 2, 1, 58),
             "│› Change effort (alias: thinking)                       │"
         );
         assert_eq!(
-            row_segment(&terminal, 4, 1, 58),
+            row_segment(&terminal, 3, 1, 58),
             "│  Enable fast mode (alias: priority)                    │"
         );
         assert_eq!(
-            row_segment(&terminal, 5, 1, 58),
+            row_segment(&terminal, 4, 1, 58),
             "│  Select theme (alias: appearance)                      │"
         );
         assert_eq!(
-            row_segment(&terminal, 6, 1, 58),
+            row_segment(&terminal, 5, 1, 58),
             "│  New session (alias: clear)                            │"
         );
         assert_eq!(
-            row_segment(&terminal, 7, 1, 58),
+            row_segment(&terminal, 6, 1, 58),
             "│  Resume session (alias: restore)                       │"
         );
         assert_eq!(
-            row_segment(&terminal, 8, 1, 58),
+            row_segment(&terminal, 7, 1, 58),
             "│  Fork session (alias: btw)                             │"
         );
         assert_eq!(
-            row_segment(&terminal, 9, 1, 58),
+            row_segment(&terminal, 8, 1, 58),
             "│  Keyboard shortcuts                                    │"
         );
         assert_eq!(
-            row_segment(&terminal, 10, 1, 58),
+            row_segment(&terminal, 9, 1, 58),
             "│  Reload config (alias: refresh)                        │"
         );
         assert_eq!(
-            row_segment(&terminal, 11, 1, 58),
+            row_segment(&terminal, 10, 1, 58),
             "│  Edit config                                           │"
         );
         assert_eq!(
-            row_segment(&terminal, 12, 1, 58),
+            row_segment(&terminal, 11, 1, 58),
             "│  Memory (alias: remember/forget)                       │"
         );
         assert_eq!(
-            row_segment(&terminal, 13, 1, 58),
+            row_segment(&terminal, 12, 1, 58),
             "│  Subagents (alias: agents)                             │"
         );
         assert_eq!(
-            row_segment(&terminal, 14, 1, 58),
+            row_segment(&terminal, 13, 1, 58),
             "│  Debug context                                         │"
+        );
+        assert_eq!(
+            row_segment(&terminal, 14, 1, 58),
+            "│  Reflect on session (alias: reflection)                │"
         );
         assert_eq!(
             row_segment(&terminal, 15, 1, 58),
@@ -525,7 +536,7 @@ mod tests {
             "╰────────────────────────────────────────────────────────╯"
         );
         assert_eq!(
-            terminal.backend().buffer()[(18, 3)].fg,
+            terminal.backend().buffer()[(18, 2)].fg,
             Theme::default().muted()
         );
     }
@@ -640,6 +651,26 @@ mod tests {
     }
 
     #[test]
+    fn reflection_action_is_searchable_and_waits_for_idle_work() {
+        let mut enabled = ActionsMenu::new(available());
+        for character in "reflection".chars() {
+            enabled.update(key(KeyCode::Char(character)));
+        }
+        assert_eq!(
+            enabled.update(key(KeyCode::Enter)).effects,
+            [ActionsEffect::Trigger(Action::Reflection)]
+        );
+
+        let mut availability = available();
+        availability.new_session = false;
+        let mut disabled = ActionsMenu::new(availability);
+        for character in "reflection".chars() {
+            disabled.update(key(KeyCode::Char(character)));
+        }
+        assert!(disabled.update(key(KeyCode::Enter)).effects.is_empty());
+    }
+
+    #[test]
     fn fast_mode_action_reflects_the_current_setting() {
         let mut enabled = ActionsMenu::new(available());
         for character in "priority".chars() {
@@ -655,7 +686,7 @@ mod tests {
         let mut disabled = ActionsMenu::new(availability);
         let terminal = render(&mut disabled);
         assert_eq!(
-            row_segment(&terminal, 4, 1, 58),
+            row_segment(&terminal, 3, 1, 58),
             "│  Disable fast mode (alias: priority)                   │"
         );
     }
@@ -701,11 +732,11 @@ mod tests {
         disabled.update(key(KeyCode::Down));
         let terminal = render(&mut disabled);
         assert_eq!(
-            row_segment(&terminal, 6, 1, 58),
+            row_segment(&terminal, 5, 1, 58),
             "│› New session · finish active work first (alias: clear) │"
         );
         assert_eq!(
-            terminal.backend().buffer()[(4, 6)].fg,
+            terminal.backend().buffer()[(4, 5)].fg,
             Theme::default().muted()
         );
     }
@@ -784,11 +815,11 @@ mod tests {
 
         let terminal = render(&mut disabled);
         assert_eq!(
-            row_segment(&terminal, 3, 1, 58),
+            row_segment(&terminal, 2, 1, 58),
             "│› Memory · enable in config: memory.enabled = true      │"
         );
         assert_eq!(
-            terminal.backend().buffer()[(4, 3)].fg,
+            terminal.backend().buffer()[(4, 2)].fg,
             Theme::default().muted()
         );
     }

--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -69,6 +69,7 @@ pub(crate) enum ComposerEvent {
     SetModel(Model),
     SetReasoningMode(ReasoningMode),
     SetFastMode(bool),
+    InputMode(Option<String>),
     Activity {
         active: bool,
         status: Option<String>,
@@ -106,6 +107,7 @@ pub(crate) struct Composer {
     model: Model,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
+    input_mode: Option<String>,
     activity_wave: Option<WavedText>,
     activity_status: Option<String>,
     review_wave: Option<WavedText>,
@@ -204,6 +206,7 @@ impl Composer {
             model: Model::Sol,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
+            input_mode: None,
             activity_wave: None,
             activity_status: None,
             review_wave: None,
@@ -281,6 +284,13 @@ impl Composer {
                     return ComposerUpdate::unchanged();
                 }
                 self.fast_mode = enabled;
+                ComposerUpdate::changed()
+            }
+            ComposerEvent::InputMode(mode) => {
+                if self.input_mode == mode {
+                    return ComposerUpdate::unchanged();
+                }
+                self.input_mode = mode;
                 ComposerUpdate::changed()
             }
             ComposerEvent::Activity {
@@ -594,6 +604,30 @@ impl Composer {
         self.layout = None;
     }
 
+    pub(crate) fn take_submission(&mut self) -> Option<Submission> {
+        let trimmed = self.draft.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let start = self.draft.len() - self.draft.trim_start().len();
+        let end = start + trimmed.len();
+        let text = trimmed.to_owned();
+        let images = self
+            .images
+            .iter()
+            .filter(|image| image.range.start >= start && image.range.end <= end)
+            .map(|image| {
+                (
+                    image.range.start - start..image.range.end - start,
+                    image.data_url.clone(),
+                )
+            });
+        let prompt = Submission::multimodal(text, images);
+        self.replace_draft(String::new());
+        Some(prompt)
+    }
+
     pub(crate) fn take_draft(&mut self) -> Option<ComposerDraft> {
         if self.draft.is_empty() {
             return None;
@@ -707,9 +741,6 @@ impl Composer {
             return ComposerUpdate::unchanged();
         }
 
-        let start = self.draft.len() - self.draft.trim_start().len();
-        let end = start + trimmed.len();
-
         if self.images.is_empty() && self.draft.starts_with('!') {
             let command = trimmed.trim_start_matches('!').trim().to_owned();
             if command.is_empty() {
@@ -720,20 +751,10 @@ impl Composer {
             return ComposerUpdate::effect(ComposerEffect::RunShell(command), true);
         }
 
-        let text = trimmed.to_owned();
-        let images = self
-            .images
-            .iter()
-            .filter(|image| image.range.start >= start && image.range.end <= end)
-            .map(|image| {
-                (
-                    image.range.start - start..image.range.end - start,
-                    image.data_url.clone(),
-                )
-            });
-        let prompt = Submission::multimodal(text.clone(), images);
-        self.history.record(text);
-        self.replace_draft(String::new());
+        let prompt = self
+            .take_submission()
+            .expect("non-empty composer draft must produce a submission");
+        self.history.record(prompt.display_text().to_owned());
         ComposerUpdate::effect(ComposerEffect::Submit(prompt), true)
     }
 
@@ -1133,6 +1154,11 @@ impl Composer {
         let content_width = usize::from(area.width - 4);
         let content_end = content_start + u16::try_from(content_width).unwrap_or(u16::MAX);
         let usage_prefix = format!(" {}%/272k ", context_percent(self.context_tokens));
+        let input_mode_segment = self
+            .input_mode
+            .as_ref()
+            .map(|mode| format!("{mode} "))
+            .unwrap_or_default();
         let review_segment = self
             .review_status
             .as_ref()
@@ -1144,7 +1170,7 @@ impl Composer {
         } else {
             String::new()
         };
-        let usage_before_activity = format!("{usage_prefix}{review_segment}");
+        let usage_before_activity = format!("{usage_prefix}{input_mode_segment}{review_segment}");
         let usage_before_subagents = self.activity_wave.as_ref().map_or_else(
             || usage_before_activity.clone(),
             |_| format!("{usage_before_activity}{status_segment} "),

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -229,6 +229,7 @@ pub(crate) enum SessionListKind {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum RootEffect {
     Submit(Submission),
+    Reflect(Submission),
     RunShell(String),
     OpenDraftEditor,
     OpenQueueEditor {
@@ -346,6 +347,7 @@ pub(crate) struct RootNode {
     context_diagnostics: ContextDiagnostics,
     recent_prompts: Vec<RecentPromptDraft>,
     pending_session_mention: Option<usize>,
+    reflection_input: bool,
 }
 
 impl RootNode {
@@ -382,6 +384,7 @@ impl RootNode {
             context_diagnostics: ContextDiagnostics::default(),
             recent_prompts: Vec::new(),
             pending_session_mention: None,
+            reflection_input: false,
         }
     }
 
@@ -746,6 +749,9 @@ impl RootNode {
         if is_confirmation_key_repeat(&event) {
             return ComponentUpdate::none();
         }
+        if self.reflection_input && is_escape(&event) {
+            return self.cancel_reflection();
+        }
         if self.blocking_task.is_some() && is_control_c(&event) {
             return self.update_key_confirmation(ConfirmationAction::Exit, Instant::now());
         }
@@ -789,6 +795,9 @@ impl RootNode {
     ) -> ComponentUpdate<RootEffect> {
         if !self.interactive {
             return ComponentUpdate::none();
+        }
+        if self.reflection_input && is_plain_enter(&event) {
+            return self.submit_reflection();
         }
         if let Some(Overlay::Subagents(SubagentOverlay::Transcript(id))) = self.overlay
             && is_control_key(&event, 'o')
@@ -935,7 +944,10 @@ impl RootNode {
             }));
             return update;
         }
-        if self.composer.component().draft().is_empty() && is_actions_trigger(&event) {
+        if !self.reflection_input
+            && self.composer.component().draft().is_empty()
+            && is_actions_trigger(&event)
+        {
             let new_session_enabled = self.in_flight_turns == 0
                 && self.in_flight_shells == 0
                 && self.blocking_task.is_none()
@@ -1466,6 +1478,16 @@ impl RootNode {
                 self.overlay = Some(Overlay::ContextDiagnostics(Node::new(
                     ContextDiagnosticsPanel::new(self.context_diagnostics.clone()),
                 )));
+            }
+            Some(ActionsEffect::Trigger(Action::Reflection)) => {
+                self.overlay = None;
+                self.reflection_input = true;
+                return self.update_composer(
+                    ComposerEvent::InputMode(Some(
+                        "Reflection instructions · enter start · esc cancel".to_owned(),
+                    )),
+                    RenderRequest::Immediate,
+                );
             }
             Some(ActionsEffect::Trigger(Action::Review)) => {
                 self.overlay = None;
@@ -2048,6 +2070,29 @@ impl RootNode {
         };
 
         ComponentUpdate { effects, render }
+    }
+
+    fn submit_reflection(&mut self) -> ComponentUpdate<RootEffect> {
+        let instructions = self
+            .composer
+            .component_mut()
+            .take_submission()
+            .unwrap_or_else(|| Submission::text(String::new()));
+        self.reflection_input = false;
+        let mode = self.update_composer(ComposerEvent::InputMode(None), RenderRequest::Immediate);
+        self.thread = ThreadState::Started;
+        self.in_flight_turns = self.in_flight_turns.saturating_add(1);
+        let transcript = self.update_transcript(TranscriptEvent::FollowTail);
+        ComponentUpdate {
+            effects: vec![RootEffect::Reflect(instructions)],
+            render: mode.render.max(transcript.render),
+        }
+    }
+
+    fn cancel_reflection(&mut self) -> ComponentUpdate<RootEffect> {
+        self.reflection_input = false;
+        self.composer.component_mut().replace_draft(String::new());
+        self.update_composer(ComposerEvent::InputMode(None), RenderRequest::Immediate)
     }
 
     fn discard_draft(&mut self) -> ComponentUpdate<RootEffect> {
@@ -5626,6 +5671,63 @@ mod tests {
         assert!(root.overlay.is_none());
         assert_eq!(update.effects, [RootEffect::OpenConfigEditor]);
         assert_eq!(update.render, super::RenderRequest::Immediate);
+    }
+
+    #[test]
+    fn reflection_action_collects_hidden_optional_instructions() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "reflection".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert!(root.reflection_input);
+        assert!(render_root_text(&mut root, 100, 20).contains("Reflection instructions"));
+        for character in "Focus on validation gaps.".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        let submitted = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(
+            submitted.effects,
+            [RootEffect::Reflect(
+                "Focus on validation gaps.".to_owned().into()
+            )]
+        );
+        assert!(!root.reflection_input);
+        assert!(root.thread == ThreadState::Started);
+        assert_eq!(root.in_flight_turns, 1);
+        assert!(root.composer().draft().is_empty());
+        root.update(key(KeyCode::Up, KeyModifiers::NONE));
+        assert!(root.composer().draft().is_empty());
+    }
+
+    #[test]
+    fn reflection_can_start_without_instructions_or_be_cancelled() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "reflection".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        root.update(key(KeyCode::Char('x'), KeyModifiers::NONE));
+
+        let cancelled = root.update(key(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(cancelled.effects.is_empty());
+        assert!(!root.reflection_input);
+        assert!(root.composer().draft().is_empty());
+
+        root.update(key(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "reflection".chars() {
+            root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        let submitted = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            submitted.effects,
+            [RootEffect::Reflect("".to_owned().into())]
+        );
     }
 
     #[test]

--- a/bin/tact/src/tui/components/transcript/mod.rs
+++ b/bin/tact/src/tui/components/transcript/mod.rs
@@ -1674,6 +1674,10 @@ fn render_entry(
                 ),
             ])])
         }
+        EntryKind::ReflectionStarted => layout_without_links(vec![Line::from(Span::styled(
+            "◇ Reflection started",
+            Style::default().fg(theme.muted()),
+        ))]),
         EntryKind::Interrupted { count } => {
             let label = if *count == 1 {
                 "◇ Interrupted response".to_owned()
@@ -2528,6 +2532,27 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(rendered.contains("◇ Turn completed · 1m 5s"));
+    }
+
+    #[test]
+    fn reflection_start_renders_as_a_marker() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(Arc::new(
+            TranscriptRecord::from_local(
+                1,
+                1,
+                LocalEvent::ReflectionStarted { id: TurnId::new(1) },
+            )
+            .unwrap(),
+        )));
+
+        let rendered = render(&mut transcript, 60, 4)
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("◇ Reflection started"));
     }
 
     #[test]

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -48,7 +48,7 @@ use crate::{
             LocalEvent, SessionEnded, SessionOutcome, SessionStarted, ShellId, TranscriptError,
             TranscriptJournal, TurnId,
         },
-        worker::{AuxiliaryContext, AuxiliaryError, WorkerCommand, WorkerEvent},
+        worker::{AuxiliaryContext, AuxiliaryError, ReflectionContext, WorkerCommand, WorkerEvent},
     },
 };
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
@@ -1933,6 +1933,35 @@ fn apply_pane_effect(
                 debug_assert!(runtime.pending_submission.is_none());
                 runtime.pending_submission = Some(submission);
             }
+        }
+        components::RootEffect::Reflect(instructions) => {
+            let runtime = context
+                .panes
+                .get_mut(&pane)
+                .expect("UI pane must have a runtime");
+            debug_assert_eq!(runtime.active_shells, 0);
+            let id = TurnId::new(runtime.next_turn);
+            runtime.next_turn = runtime.next_turn.saturating_add(1);
+            let record = runtime
+                .journal_mut()?
+                .append_local(LocalEvent::ReflectionStarted { id })?;
+            schedule(
+                context.app.update(AppEvent::Transcript { pane, record }),
+                context.scheduler,
+            );
+            context
+                .commands
+                .send(WorkerCommand::Reflect {
+                    pane,
+                    id,
+                    instructions,
+                    context: ReflectionContext::new(
+                        context.config.path(),
+                        context.workspace,
+                        &runtime.session_id,
+                    ),
+                })
+                .map_err(|_| RuntimeError::AgentWorkerStopped)?;
         }
         components::RootEffect::RunShell(command) => {
             let runtime = context

--- a/bin/tact/src/tui/transcript/entry.rs
+++ b/bin/tact/src/tui/transcript/entry.rs
@@ -49,6 +49,7 @@ pub(crate) enum EntryKind {
     ForkedFrom { session_id: String },
     EffortChanged { to: ReasoningEffort },
     FastModeChanged { enabled: bool },
+    ReflectionStarted,
     Interrupted { count: usize },
     ContextCompacted { duration_ns: u64 },
     TurnCompleted { duration_ns: u64 },

--- a/bin/tact/src/tui/transcript/model.rs
+++ b/bin/tact/src/tui/transcript/model.rs
@@ -238,6 +238,9 @@ impl TranscriptModel {
             "user.steered" => self.decode_local::<UserSteered>(record).map(|payload| {
                 self.push(EntryKind::User { text: payload.text });
             }),
+            "reflection.started" => self.decode_local::<ReflectionStarted>(record).map(|_| {
+                self.push(EntryKind::ReflectionStarted);
+            }),
             "shell.started" => self
                 .decode_local::<ShellStarted>(record)
                 .map(|payload| self.shell_started(payload, record.recorded_at_unix_ms())),
@@ -1045,6 +1048,7 @@ fn visibility(source: &str, kind: &str) -> EventVisibility {
     if source == "tact" {
         return match kind {
             "user.submitted"
+            | "reflection.started"
             | "worker.turns_interrupted"
             | "effort.changed"
             | "fast_mode.changed" => EventVisibility::Persistent,
@@ -1148,6 +1152,12 @@ struct UserSubmitted {
 #[derive(Deserialize)]
 struct UserSteered {
     text: String,
+}
+
+#[derive(Deserialize)]
+struct ReflectionStarted {
+    #[serde(rename = "id")]
+    _id: u64,
 }
 
 #[derive(Deserialize)]
@@ -1655,6 +1665,24 @@ mod tests {
         assert!(
             matches!(&model.entries()[0].kind, EntryKind::User { text, .. } if text == "hello")
         );
+    }
+
+    #[test]
+    fn reflection_start_is_a_persistent_typed_entry() {
+        let mut model = TranscriptModel::default();
+        let record = TranscriptRecord::from_local(
+            1,
+            1,
+            LocalEvent::ReflectionStarted { id: TurnId::new(3) },
+        )
+        .unwrap();
+
+        model.apply(&record);
+
+        assert!(matches!(
+            model.entries().first().map(|entry| &entry.kind),
+            Some(EntryKind::ReflectionStarted)
+        ));
     }
 
     #[test]

--- a/bin/tact/src/tui/transcript/record.rs
+++ b/bin/tact/src/tui/transcript/record.rs
@@ -68,6 +68,9 @@ pub(crate) enum LocalEvent {
     UserSteered {
         text: String,
     },
+    ReflectionStarted {
+        id: TurnId,
+    },
     ShellStarted {
         id: ShellId,
         command: String,
@@ -163,6 +166,10 @@ impl TranscriptRecord {
             LocalEvent::UserSteered { text } => {
                 ("user.steered", to_raw_value(&UserSteered { text })?)
             }
+            LocalEvent::ReflectionStarted { id } => (
+                "reflection.started",
+                to_raw_value(&ReflectionStarted { id })?,
+            ),
             LocalEvent::ShellStarted {
                 id,
                 command,
@@ -282,6 +289,11 @@ struct UserSubmitted {
 #[derive(Serialize)]
 struct UserSteered {
     text: String,
+}
+
+#[derive(Serialize)]
+struct ReflectionStarted {
+    id: TurnId,
 }
 
 #[derive(Serialize)]
@@ -487,5 +499,19 @@ mod tests {
 
         assert_eq!(encoded["type"], "user.steered");
         assert_eq!(encoded["payload"]["text"], "change direction");
+    }
+
+    #[test]
+    fn reflection_start_contains_only_its_turn_id() {
+        let record = TranscriptRecord::from_local(
+            1,
+            123,
+            LocalEvent::ReflectionStarted { id: TurnId::new(9) },
+        )
+        .unwrap();
+        let encoded = serde_json::to_value(record).unwrap();
+
+        assert_eq!(encoded["type"], "reflection.started");
+        assert_eq!(encoded["payload"], json!({"id": 9}));
     }
 }

--- a/bin/tact/src/tui/worker.rs
+++ b/bin/tact/src/tui/worker.rs
@@ -3,7 +3,10 @@
 use crate::{
     app::config::ReasoningEffort,
     core::MEMORY_REVIEW_CHECKPOINT,
-    tui::{components::QueueId, pane::PaneId, prompt::Submission, transcript::TurnId},
+    tui::{
+        components::QueueId, pane::PaneId, prompt::Submission, storage::database_path,
+        transcript::TurnId,
+    },
 };
 use nanocodex::{
     AgentEvents, Nanocodex, NanocodexError, TurnControl,
@@ -12,7 +15,10 @@ use nanocodex::{
         session::SessionSnapshot,
     },
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 use tokio::{
     sync::{mpsc, oneshot},
     task::{JoinError, JoinSet},
@@ -24,6 +30,12 @@ pub(crate) enum WorkerCommand {
         pane: PaneId,
         id: TurnId,
         prompt: Submission,
+    },
+    Reflect {
+        pane: PaneId,
+        id: TurnId,
+        instructions: Submission,
+        context: ReflectionContext,
     },
     Auxiliary {
         pane: PaneId,
@@ -64,6 +76,34 @@ pub(crate) enum WorkerCommand {
 pub(crate) enum AuxiliaryContext {
     Clean,
     CurrentConversation,
+}
+
+pub(crate) struct ReflectionContext {
+    config_path: PathBuf,
+    current_session: String,
+    session_database: PathBuf,
+    workspace: PathBuf,
+}
+
+impl ReflectionContext {
+    pub(crate) fn new(config_path: &Path, workspace: &Path, current_session: &str) -> Self {
+        Self {
+            config_path: config_path.to_path_buf(),
+            current_session: current_session.to_owned(),
+            session_database: database_path(config_path),
+            workspace: workspace.to_path_buf(),
+        }
+    }
+
+    fn prompt(&self) -> String {
+        let context = serde_json::json!({
+            "config_path": self.config_path.to_string_lossy(),
+            "current_session": self.current_session,
+            "session_database": self.session_database.to_string_lossy(),
+            "workspace": self.workspace.to_string_lossy(),
+        });
+        format!("<reflection_context>\n{context}\n</reflection_context>")
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -141,6 +181,22 @@ enum TurnPurpose {
     Auxiliary(oneshot::Sender<Result<String, AuxiliaryError>>),
 }
 
+enum PromptKind {
+    Conversation,
+    Reflection(ReflectionContext),
+    Auxiliary,
+}
+
+impl PromptKind {
+    fn prepare(&self, prompt: &Submission, memory_review: MemoryReviewState) -> Prompt {
+        match self {
+            Self::Conversation => memory_review.submission_prompt(prompt),
+            Self::Reflection(context) => reflection_prompt(prompt, context),
+            Self::Auxiliary => prompt.agent_prompt(),
+        }
+    }
+}
+
 struct TurnRequest {
     pane: PaneId,
     id: TurnId,
@@ -148,7 +204,60 @@ struct TurnRequest {
     purpose: TurnPurpose,
     auxiliary_context: Option<AuxiliaryContext>,
     shutdown: Option<CancellationToken>,
+    prompt_kind: PromptKind,
 }
+
+const REFLECTION_PROMPT: &str = concat!(
+    "This is a self-contained Tact reflection turn. Reflect on the conversation available in this ",
+    "session and produce a report for the user. Start with the current conversation. Use the ",
+    "additional instructions to narrow the topic or identify other workspaces, sessions, or task ",
+    "families; otherwise sample relevant recent history from the current workspace.\n\n",
+    "Discover historical candidates in bounded stages. Use code mode to run bounded `SELECT` ",
+    "queries with `sqlite3 -readonly` against the supplied Tact V2 session database. Inspect only ",
+    "`sessions(session_id, workspace, started_at_ms, updated_at_ms, preview)` and ",
+    "`events(session_id, event_id, prompt_text, prompt_recorded_at_ms)`: first summarize workspaces ",
+    "and recent sessions, then inspect short recent prompt previews for the selected scope. By ",
+    "default, stay within the current workspace, inspect at most 30 recent sessions, and return at ",
+    "most 100 prompt previews truncated to 512 characters. Expand in another bounded batch only when ",
+    "the user's instructions or the evidence justify it. Exclude the supplied current session ID ",
+    "from historical candidates so current evidence is not counted twice. Never select `record_json` or ",
+    "`resume_states`, issue a write or pragma that changes state, or emit an unbounded result. If ",
+    "SQLite is unavailable, state that limitation instead of adding tooling. ",
+    "After selecting a small number of high-value session IDs, use `read_session` with exact kinds ",
+    "to read only enough context to establish what happened. A targeted `user.submitted` search can ",
+    "locate a candidate event; a separate call starting from that event ID can retrieve the adjacent ",
+    "assistant response without requiring it to match the same text filter. Stop when the evidence ",
+    "is sufficient.\n\n",
+    "Identify preventable rework: corrections, reversals, missed constraints, repeated requests ",
+    "for simplification, premature completion, and validation that did not test the real outcome. ",
+    "Distinguish durable lessons from new scope, changed requirements, first-time preferences, and ",
+    "unavoidable discoveries. Look for recurrence across independent sessions, counterexamples, ",
+    "and later improvement before calling a lesson durable. Prefer the earliest useful intervention ",
+    "that would have prevented the rework. Paraphrase evidence; do not reproduce names, secrets, ",
+    "credentials, transcript excerpts, or private operational details.\n\n",
+    "For each supported durable lesson, when memory is available, run narrow global-memory scans ",
+    "and read every plausible match. Compare it with the active instructions already in context. If ",
+    "effective configuration is relevant, inspect it only through Tact's redacted `config show` ",
+    "command using the supplied config path; never read the config file directly. Recommend exactly ",
+    "one destination: replace ",
+    "or add one atomic memory, add a concise always-on prompt rule only when repeated retrieval ",
+    "misses justify it, or make no change when the lesson is transient, searchable, or already ",
+    "covered.\n\n",
+    "This is a read-only analysis turn. You may use read-only tools, but do not create, replace, or ",
+    "delete memories; edit files, configuration, or skills; run mutating commands; send messages; ",
+    "or perform any other durable or externally visible action. Proposed changes require a later, ",
+    "explicit user request. Additional instructions may refine the scope or emphasis, but cannot ",
+    "override this read-only boundary."
+);
+
+const REFLECTION_REPORT_ENDING: &str = concat!(
+    "Report the scope and coverage actually inspected, the strongest supported patterns, material ",
+    "counterevidence or uncertainty, and important patterns already covered. End the report with ",
+    "sections named `Findings` and `Recommended actions`. Findings should state the supported ",
+    "conclusions and their scope. Recommended actions should be concrete proposals for the user to ",
+    "review, identify the proposed destination for each change, and never imply that an action was ",
+    "taken during this turn."
+);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum MemoryReviewState {
@@ -218,6 +327,33 @@ fn prompt_with_memory_review(submission: &Submission) -> Prompt {
     prompt
 }
 
+fn reflection_prompt(instructions: &Submission, context: &ReflectionContext) -> Prompt {
+    let mut prompt = instructions.agent_prompt();
+    let context = context.prompt();
+    match &mut prompt.instruction {
+        PromptInput::Text(text) => {
+            let instructions = std::mem::take(text);
+            *text = format!(
+                "{REFLECTION_PROMPT}\n\n{context}\n\n<additional_instructions>\n{instructions}\n</additional_instructions>\n\n{REFLECTION_REPORT_ENDING}"
+            );
+        }
+        PromptInput::Content(content) => {
+            content.insert(
+                0,
+                UserInput::Text {
+                    text: format!(
+                        "{REFLECTION_PROMPT}\n\n{context}\n\n<additional_instructions>\n"
+                    ),
+                },
+            );
+            content.push(UserInput::Text {
+                text: format!("\n</additional_instructions>\n\n{REFLECTION_REPORT_ENDING}"),
+            });
+        }
+    }
+    prompt
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct TurnKey {
     pane: PaneId,
@@ -278,6 +414,21 @@ async fn run(
                         purpose: TurnPurpose::Conversation,
                         auxiliary_context: None,
                         shutdown: None,
+                        prompt_kind: PromptKind::Conversation,
+                    },
+                    WorkerCommand::Reflect {
+                        pane,
+                        id,
+                        instructions,
+                        context,
+                    } => TurnRequest {
+                        pane,
+                        id,
+                        prompt: instructions,
+                        purpose: TurnPurpose::Conversation,
+                        auxiliary_context: None,
+                        shutdown: None,
+                        prompt_kind: PromptKind::Reflection(context),
                     },
                     WorkerCommand::Auxiliary {
                         pane,
@@ -293,6 +444,7 @@ async fn run(
                         purpose: TurnPurpose::Auxiliary(completion),
                         auxiliary_context: Some(context),
                         shutdown: Some(shutdown),
+                        prompt_kind: PromptKind::Auxiliary,
                     },
                     WorkerCommand::Steer {
                         pane,
@@ -510,6 +662,7 @@ async fn start_turn(
         purpose,
         auxiliary_context,
         shutdown,
+        prompt_kind,
     } = request;
     let auxiliary = auxiliary_context.is_some();
     let (isolated_agent, event_drain) = if let Some(context) = auxiliary_context {
@@ -530,6 +683,7 @@ async fn start_turn(
                         purpose,
                         auxiliary_context: Some(context),
                         shutdown,
+                        prompt_kind,
                     });
                     return false;
                 }
@@ -548,6 +702,7 @@ async fn start_turn(
                         purpose,
                         auxiliary_context: Some(context),
                         shutdown,
+                        prompt_kind,
                     },
                     error.to_string(),
                     updates,
@@ -561,11 +716,7 @@ async fn start_turn(
         (None, None)
     };
     let turn_agent = isolated_agent.as_ref().unwrap_or(agent);
-    let agent_prompt = if auxiliary {
-        prompt.agent_prompt()
-    } else {
-        memory_review.submission_prompt(&prompt)
-    };
+    let agent_prompt = prompt_kind.prepare(&prompt, memory_review);
     let turn = match turn_agent.prompt(agent_prompt).await {
         Ok(turn) => turn,
         Err(error) => {
@@ -583,6 +734,7 @@ async fn start_turn(
                     purpose,
                     auxiliary_context,
                     shutdown,
+                    prompt_kind,
                 },
                 error.to_string(),
                 updates,
@@ -852,7 +1004,9 @@ async fn shutdown_agent(agent: Option<Nanocodex>) -> Result<(), NanocodexError> 
 
 #[cfg(test)]
 mod tests {
-    use super::{MemoryReviewState, WorkerCommand, WorkerEvent, spawn};
+    use super::{
+        MemoryReviewState, ReflectionContext, WorkerCommand, WorkerEvent, reflection_prompt, spawn,
+    };
     use crate::{
         app::config::ReasoningEffort,
         core::MEMORY_REVIEW_CHECKPOINT,
@@ -868,6 +1022,7 @@ mod tests {
     };
     use std::{
         future::{Pending, pending},
+        path::Path,
         result::Result as StdResult,
         sync::{
             Arc,
@@ -958,6 +1113,34 @@ mod tests {
 
         let disabled = MemoryReviewState::fresh(false);
         assert!(!prompt_text(disabled.steer_prompt(&steer)).contains(MEMORY_REVIEW_CHECKPOINT));
+    }
+
+    #[test]
+    fn reflection_prompt_is_read_only_and_ends_with_reviewable_actions() {
+        let context = ReflectionContext::new(
+            Path::new("/tact/config.toml"),
+            Path::new("/work/current"),
+            "current-session",
+        );
+        let prompt = reflection_prompt(
+            &Submission::text("Focus on validation gaps.".to_owned()),
+            &context,
+        );
+        let text = prompt_text(prompt);
+
+        assert!(text.contains("Focus on validation gaps."));
+        assert!(text.contains("self-contained Tact reflection turn"));
+        assert!(text.contains("sqlite3 -readonly"));
+        assert!(text.contains(r#""session_database":"/tact/sessions/v2.sqlite3""#));
+        assert!(text.contains(r#""workspace":"/work/current""#));
+        assert!(text.contains(r#""current_session":"current-session""#));
+        assert!(text.contains("global-memory scans"));
+        assert!(text.contains("config show"));
+        assert!(text.contains("read-only analysis turn"));
+        assert!(text.contains("do not create, replace, or delete memories"));
+        assert!(text.contains("`Findings`"));
+        assert!(text.contains("`Recommended actions`"));
+        assert!(!text.contains(MEMORY_REVIEW_CHECKPOINT));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a guided TUI reflection action with optional user instructions
- prompt the active agent to analyze the current and relevant prior sessions before proposing durable actions
- keep the reflection request hidden in transcript rendering while showing a compact “Reflection started” event
- require the report to conclude with findings and recommended actions, leaving memory changes and other durable work to the normal conversation

## Testing

- `just test`
- `just clippy`
- `cargo check --all-features`
- `just check-fmt`

## Stack

Depends on #139.