### PR TITLE
fix(tui): render selection across link destinations

### DIFF
--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -5014,6 +5014,56 @@ mod tests {
     }
 
     #[test]
+    fn transcript_selection_highlights_rendered_link_destinations() {
+        let mut terminal = Terminal::new(TestBackend::new(120, 12)).unwrap();
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        let markdown = "See [inclusion.rs](/workspace/glue/src/inclusion.rs) or [mailbox.rs](/workspace/glue/src/mailbox.rs).";
+        root.update(super::RootEvent::Transcript(agent_record(
+            1,
+            AgentEventKind::AssistantMessage,
+            json!({
+                "model_call_index": 1,
+                "item_id": "answer",
+                "phase": "final_answer",
+                "text": markdown,
+            }),
+        )));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let row = (0..buffer.area.height)
+            .find(|&row| {
+                (0..buffer.area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+                    .contains("See inclusion.rs")
+            })
+            .expect("message should be visible");
+        let start = text_column(buffer, row, "See");
+        let rendered_link = "mailbox.rs ↗ /workspace/glue/src/mailbox.rs";
+        let end = text_column(buffer, row, rendered_link)
+            + u16::try_from(rendered_link.chars().count()).unwrap();
+
+        root.update(mouse(MouseEventKind::Down(MouseButton::Left), start, row));
+        root.update(mouse(MouseEventKind::Drag(MouseButton::Left), end, row));
+        terminal
+            .draw(|frame| root.render(frame, frame.area(), &Theme::default()))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        for column in start..end {
+            let cell = &buffer[(column, row)];
+            assert_eq!(
+                (cell.fg, cell.bg, cell.modifier),
+                (Color::Black, Color::Yellow, Modifier::empty()),
+                "selected cell at column {column} ({:?}) retained link styling",
+                cell.symbol()
+            );
+        }
+    }
+
+    #[test]
     fn partial_transcript_selection_does_not_copy_unmatched_markdown_delimiters() {
         let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);

--- a/bin/tact/src/tui/components/transcript/markdown.rs
+++ b/bin/tact/src/tui/components/transcript/markdown.rs
@@ -707,31 +707,63 @@ fn markdown_selection_spans(
     exclusions: &[Vec<Range<u16>>],
 ) -> (Vec<Vec<SourceSpan>>, Vec<SourceEnvelope>) {
     let mut graphemes = Vec::<SourceGrapheme>::new();
-    let mut envelopes = Vec::<(TagEnd, Range<usize>, usize, bool)>::new();
+    let mut envelopes = Vec::<(TagEnd, Range<usize>, usize, bool, Option<String>)>::new();
     let mut source_envelopes = Vec::new();
     for (event, range) in Parser::new_ext(markdown, options).into_offset_iter() {
         match event {
             Event::Start(tag) => {
+                let destination = match &tag {
+                    Tag::Link { dest_url, .. } => Some(sanitize(dest_url)),
+                    _ => None,
+                };
                 let preserve_delimiters = !matches!(tag, Tag::CodeBlock(_));
-                envelopes.push((tag.to_end(), range, graphemes.len(), preserve_delimiters));
+                envelopes.push((
+                    tag.to_end(),
+                    range,
+                    graphemes.len(),
+                    preserve_delimiters,
+                    destination,
+                ));
             }
             Event::End(end) => {
                 let Some(index) = envelopes.iter().rposition(|(tag, ..)| *tag == end) else {
                     continue;
                 };
-                let (_, range, first, preserve_delimiters) = envelopes.remove(index);
-                if !preserve_delimiters || first == graphemes.len() {
-                    continue;
+                let (_, source, first, preserve_delimiters, destination) = envelopes.remove(index);
+                if preserve_delimiters && first != graphemes.len() {
+                    source_envelopes.push(SourceEnvelope {
+                        content: graphemes[first].source.start
+                            ..graphemes
+                                .last()
+                                .expect("the envelope has content")
+                                .source
+                                .end,
+                        source: source.clone(),
+                    });
                 }
-                source_envelopes.push(SourceEnvelope {
-                    content: graphemes[first].source.start
-                        ..graphemes
-                            .last()
-                            .expect("the envelope has content")
-                            .source
-                            .end,
-                    source: range,
-                });
+                if let Some(destination) = destination {
+                    let label = graphemes[first..]
+                        .iter()
+                        .map(|grapheme| grapheme.text.as_str())
+                        .collect::<String>();
+                    if label.trim() != destination {
+                        let destination_source = markdown
+                            .get(source.clone())
+                            .and_then(|link| link.rfind(&destination))
+                            .map_or_else(
+                                || source.clone(),
+                                |offset| {
+                                    let start = source.start.saturating_add(offset);
+                                    start..start.saturating_add(destination.len())
+                                },
+                            );
+                        graphemes.extend(source_graphemes(
+                            markdown,
+                            &format!(" ↗ {destination}"),
+                            destination_source,
+                        ));
+                    }
+                }
             }
             Event::Text(text) | Event::Code(text) | Event::Html(text) | Event::InlineHtml(text) => {
                 graphemes.extend(source_graphemes(markdown, &sanitize(&text), range));


### PR DESCRIPTION
## Summary

- map rendered markdown link destinations back to their source ranges
- render transcript selection continuously across generated filepath suffixes
- preserve original markdown copy behavior and clear link styling inside selected cells

## Testing

- `just test` (889 tests)
- `just clippy`
- `just check-fmt`

## Dependency

Depends on #142 as the next revision in the workspace stack.

Closes #141.