### PR TITLE
refactor(memory): name transfer commands push and pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ workspace_roots = ["/path/to/team-projects"]
 Keep the configuration file private with mode `0600`: it contains the bearer token directly. Remote
 memory with a direct token currently requires Unix so Tact can verify the file permissions.
 `tact config show` and debug output redact the token. An in-scope remote error is returned to the
-caller and never falls back to local memory. Runtime operations never upload local records.
+caller and never falls back to local memory. Runtime operations never push local records.
 
-Use `tact memory upload [--dry-run]` from any directory to reconcile the complete global local
+Use `tact memory push [--dry-run]` from any directory to reconcile the complete global local
 store to the writer's personal namespace. Use `tact memory pull --all` or repeat
 `--namespace NAME` to non-destructively merge remote records into the local schema v1
 store. The [memory guide](docs/memory.md#remote-memory) includes the selection and transfer

--- a/bin/tact/src/app/cli.rs
+++ b/bin/tact/src/app/cli.rs
@@ -189,8 +189,8 @@ enum Command {
 #[derive(Debug, Subcommand)]
 enum MemoryCommand {
     /// Replace the remote personal namespace with the complete local corpus.
-    Upload {
-        /// Report the local corpus that would be uploaded without contacting the remote.
+    Push {
+        /// Report the local corpus that would be pushed without contacting the remote.
         #[arg(long)]
         dry_run: bool,
     },
@@ -498,13 +498,13 @@ impl Command {
 impl MemoryCommand {
     async fn run(self, config: &Config) -> Result<()> {
         match self {
-            Self::Upload { dry_run } => upload_memories(config, dry_run).await,
+            Self::Push { dry_run } => push_memories(config, dry_run).await,
             Self::Pull { all, namespace } => pull_memories(config, all, namespace).await,
         }
     }
 }
 
-async fn upload_memories(config: &Config, dry_run: bool) -> Result<()> {
+async fn push_memories(config: &Config, dry_run: bool) -> Result<()> {
     use crate::app::error::MemoryTransferError;
     use tact_memory::{
         MemoryStore, RemoteMemoryClient, RemoteRole, RemoteToken, SelectedMemoryStore,
@@ -523,7 +523,7 @@ async fn upload_memories(config: &Config, dry_run: bool) -> Result<()> {
         .sum::<usize>();
     if dry_run {
         println!(
-            "Would upload {} memories ({} content bytes) as the complete snapshot for namespace `{}`; remote-only rows may be deleted.",
+            "Would push {} memories ({} content bytes) as the complete snapshot for namespace `{}`; remote-only rows may be deleted.",
             memories.len(),
             content_bytes,
             remote.namespace()
@@ -532,28 +532,23 @@ async fn upload_memories(config: &Config, dry_run: bool) -> Result<()> {
     }
 
     let token =
-        RemoteToken::new(remote.bearer_token().to_owned()).map_err(MemoryTransferError::Upload)?;
+        RemoteToken::new(remote.bearer_token().to_owned()).map_err(MemoryTransferError::Push)?;
     let client = RemoteMemoryClient::new(remote.endpoint(), remote.namespace().to_owned(), token)
-        .map_err(MemoryTransferError::Upload)?;
-    if client
-        .session()
-        .await
-        .map_err(MemoryTransferError::Upload)?
-        != RemoteRole::Writer
-    {
-        return Err(MemoryTransferError::Upload(tact_memory::RemoteClientError::ReadOnly).into());
+        .map_err(MemoryTransferError::Push)?;
+    if client.session().await.map_err(MemoryTransferError::Push)? != RemoteRole::Writer {
+        return Err(MemoryTransferError::Push(tact_memory::RemoteClientError::ReadOnly).into());
     }
     let remote_store = SelectedMemoryStore::remote(client);
     for _ in 0..3 {
         let report = remote_store
             .sync(&memories)
             .await
-            .map_err(MemoryTransferError::UploadStore)?;
+            .map_err(MemoryTransferError::PushStore)?;
 
         let current = export_memories(store.clone()).await?;
         if same_replication_snapshot(&memories, &current) {
             println!(
-                "Uploaded {} memories to namespace `{}`: {} inserted, {} replaced, {} unchanged, {} deleted.",
+                "Pushed {} memories to namespace `{}`: {} inserted, {} replaced, {} unchanged, {} deleted.",
                 memories.len(),
                 remote.namespace(),
                 report.inserted,
@@ -724,8 +719,8 @@ fn read_mcp_environment(
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, McpCommand, MemoryCommand, read_mcp_environment, resume_command,
-        same_replication_snapshot, upload_memories,
+        Cli, McpCommand, MemoryCommand, push_memories, read_mcp_environment, resume_command,
+        same_replication_snapshot,
     };
     use crate::app::{
         cli::Command,
@@ -1102,8 +1097,8 @@ mod tests {
     }
 
     #[test]
-    fn memory_upload_supports_a_dry_run_and_old_sync_is_rejected() {
-        let command = Cli::try_parse_from(["tact", "memory", "upload", "--dry-run"])
+    fn memory_push_supports_a_dry_run_and_old_names_are_rejected() {
+        let command = Cli::try_parse_from(["tact", "memory", "push", "--dry-run"])
             .unwrap()
             .command
             .unwrap();
@@ -1111,10 +1106,11 @@ mod tests {
         assert!(matches!(
             &command,
             Command::Memory {
-                command: MemoryCommand::Upload { dry_run: true }
+                command: MemoryCommand::Push { dry_run: true }
             }
         ));
         assert!(command.requires_config());
+        assert!(Cli::try_parse_from(["tact", "memory", "upload"]).is_err());
         assert!(Cli::try_parse_from(["tact", "sync-memories"]).is_err());
     }
 
@@ -1156,7 +1152,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn upload_outside_workspace_roots_uses_the_async_remote_client() {
+    async fn push_outside_workspace_roots_uses_the_async_remote_client() {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let directory = tempdir().unwrap();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -1188,13 +1184,13 @@ mod tests {
         })
         .unwrap();
 
-        let result = upload_memories(&config, false).await;
+        let result = push_memories(&config, false).await;
 
         assert!(matches!(result, Err(Error::MemoryTransfer(_))));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn upload_reconciles_a_local_write_that_races_the_first_snapshot() {
+    async fn push_reconciles_a_local_write_that_races_the_first_snapshot() {
         use axum::{
             Json, Router,
             extract::State,
@@ -1288,7 +1284,7 @@ mod tests {
             .unwrap();
 
         let sync_config = config.clone();
-        let sync_task = tokio::spawn(async move { upload_memories(&sync_config, false).await });
+        let sync_task = tokio::spawn(async move { push_memories(&sync_config, false).await });
         state.first_snapshot.notified().await;
         LocalMemoryStore::new(config.memory_path())
             .put("concurrent write", None)

--- a/bin/tact/src/app/error.rs
+++ b/bin/tact/src/app/error.rs
@@ -48,16 +48,16 @@ pub(crate) enum Error {
 pub(crate) enum MemoryTransferError {
     #[error("remote memory is not configured")]
     RemoteNotConfigured,
-    #[error("failed to read the local memory snapshot for upload: {0}")]
+    #[error("failed to read the local memory snapshot for push: {0}")]
     Local(#[source] MemoryError),
     #[error(
         "local memories kept changing while the remote snapshot was synchronized; retry once writes settle"
     )]
     LocalChanged,
-    #[error("memory upload failed: {0}")]
-    Upload(#[source] RemoteClientError),
-    #[error("remote memory rejected the upload: {0}")]
-    UploadStore(#[source] MemoryError),
+    #[error("memory push failed: {0}")]
+    Push(#[source] RemoteClientError),
+    #[error("remote memory rejected the push: {0}")]
+    PushStore(#[source] MemoryError),
     #[error("memory pull failed: {0}")]
     Pull(#[source] RemoteClientError),
     #[error("remote memory rejected the pull: {0}")]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -142,7 +142,7 @@ The server wrapper owns bearer authentication, namespace and role checks, reques
 bounds, protocol errors, and operation tracing that excludes tokens and memory content. A store
 owns persistence, indexes, transactions, pagination, telemetry concurrency, capacity enforcement,
 and backend errors. It must make version-checked mutations atomic, serialize conflicting writes,
-keep upload sync atomic, and provide stable export pagination. The server-side store captures the
+keep snapshot replacement atomic, and provide stable export pagination. The server-side store captures the
 authoritative time for remote timestamps, telemetry, and probation unless a protocol operation
 explicitly preserves local snapshot identity.
 
@@ -167,7 +167,7 @@ remain distinguishable through the defined status and error mapping. The client 
 in-scope remote failures and never switches to local memory after one. Production deployments need
 HTTPS, private credentials, and storage encryption appropriate to the deployment.
 
-Runtime operations never upload local records, write through to another backend, combine backend
+Runtime operations never push local records, write through to another backend, combine backend
 results, or schedule background synchronization.
 
 ## Explicit transfer commands
@@ -176,22 +176,22 @@ Transfer commands operate on the global local store and therefore work from any 
 ignore `memory.enabled` and runtime workspace-root selection; configured remote credentials still
 govern authentication and authorization.
 
-### Upload local memory
+### Push local memory
 
 ```console
-tact memory upload --dry-run
-tact memory upload
+tact memory push --dry-run
+tact memory push
 ```
 
-Upload requires configured remote memory and a writer credential. It treats the complete live local
+Push requires configured remote memory and a writer credential. It treats the complete live local
 store as the authoritative snapshot for the writer's personal namespace. The client checks for a
 concurrently changing local snapshot for up to three reconciliation passes. The service inserts
 missing rows, replaces divergent generations or versions, preserves identical rows, and removes
 rows in that namespace that are absent locally. Other namespaces are never changed. `--dry-run`
 reports the local snapshot without contacting or modifying the service.
 
-Upload is an explicit administrative action. Runtime operations never trigger it and an outage
-does not create a queue for later upload.
+Push is an explicit administrative action. Runtime operations never trigger it and an outage does
+not create a queue for a later push.
 
 ### Pull remote memory
 
@@ -246,15 +246,15 @@ workspace_roots = ["/absolute/path/to/this/repository"]
 ```
 
 Create equivalent homes for Bob and the observer, changing namespace and token. Give Alice a local
-record while running outside the configured workspace, then upload it from any directory:
+record while running outside the configured workspace, then push it from any directory:
 
 ```console
 chmod 600 /tmp/tact-alice/config.toml
 
 TACT_HOME=/tmp/tact-alice cargo run -p tact -- \
   --workspace /tmp run 'Store a durable memory that the team uses cargo nextest in CI.'
-TACT_HOME=/tmp/tact-alice cargo run -p tact -- memory upload --dry-run
-TACT_HOME=/tmp/tact-alice cargo run -p tact -- memory upload
+TACT_HOME=/tmp/tact-alice cargo run -p tact -- memory push --dry-run
+TACT_HOME=/tmp/tact-alice cargo run -p tact -- memory push
 ```
 
 Verify that Bob uses remote memory exclusively inside the configured workspace and sees Alice's
@@ -323,7 +323,7 @@ server time and server-owned telemetry.
 Bounds apply to the global local corpus and independently to each remote writer namespace. A store
 may prune expired unread probation records before rejecting a capacity-increasing mutation, but it
 does not evict active graduated records to make room. Mutations, telemetry updates, bound checks,
-authoritative upload reconciliation, and local pull merge are transactional at their documented
+authoritative push reconciliation, and local pull merge are transactional at their documented
 scope.
 
 The local database is unencrypted. Anyone who can read the configuration directory may be able to

--- a/examples/tact-memory-cloudflare/README.md
+++ b/examples/tact-memory-cloudflare/README.md
@@ -72,7 +72,7 @@ operators can reduce or migrate the corpus without editing D1 directly.
 Create the D1 database:
 
 ```sh
-npx wrangler d1 create tact-memory
+bun x wrangler d1 create tact-memory
 ```
 
 Replace `REPLACE_WITH_D1_DATABASE_ID` in `wrangler.jsonc` with the returned database ID. Apply the


### PR DESCRIPTION
## Summary

- rename `tact memory upload` to `tact memory push` for symmetry with `tact memory pull`
- update command output, errors, tests, README guidance, and the memory guide to use push terminology
- reject the removed `memory upload` and legacy `sync-memories` command names
- use the repository-standard `bun x wrangler` invocation in the Cloudflare deployment example

## Testing

- `just test` (889 tests)
- `just clippy`
- `just check-fmt`