### PR TITLE
feat(reflection): improve evidence attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ a later explicit request.
 
 The built-in workflow starts with the current conversation, uses `find_sessions` to discover a
 bounded set of relevant historical sessions, then uses `read_session` to inspect only the strongest
-candidates. It checks supported lessons against existing memories and active instructions, and
+candidates. Parent-session lineage helps the agent avoid counting related forks as independent
+evidence. It checks supported lessons against existing memories and active instructions, and
 recommends whether each lesson belongs in memory, always-on configuration, or nowhere. Additional
 instructions can narrow the topic or expand the workspace and task-family scope. The report states
 the coverage and uncertainty of its evidence; it does not apply its recommendations.

--- a/bin/tact/src/core/extensions/sessions.rs
+++ b/bin/tact/src/core/extensions/sessions.rs
@@ -57,6 +57,7 @@ struct FindSessionsOutput {
 #[derive(Serialize)]
 struct FoundSession {
     session_id: String,
+    parent_session_id: Option<String>,
     workspace: PathBuf,
     started_at_ms: u64,
     updated_at_ms: u64,
@@ -277,7 +278,7 @@ impl Tool for FindSessionsTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
             "find_sessions",
-            "Finds bounded recent Tact V2 sessions before using read_session. It excludes the caller's current session, optionally scopes to one exact workspace, and optionally matches ASCII-case-insensitive literal patterns against stored user prompts. Omit workspace only for cross-workspace discovery. Pass next_cursor back only when another page is needed.",
+            "Finds bounded recent Tact V2 sessions before using read_session. It excludes the caller's current session, reports parent session IDs for lineage checks, optionally scopes to one exact workspace, and optionally matches ASCII-case-insensitive literal patterns against stored user prompts. Omit workspace only for cross-workspace discovery. Pass next_cursor back only when another page is needed.",
             find_input_schema(),
         )
         .with_output_schema(find_output_schema())
@@ -359,6 +360,7 @@ fn found_session(session: StoredSession) -> FoundSession {
     }
     FoundSession {
         session_id: session.session_id,
+        parent_session_id: session.parent_session_id,
         workspace: session.workspace,
         started_at_ms: session.started_at_unix_ms,
         updated_at_ms: session.updated_at_unix_ms,
@@ -635,12 +637,16 @@ fn find_output_schema() -> Value {
                     "type": "object",
                     "properties": {
                         "session_id": { "type": "string" },
+                        "parent_session_id": {
+                            "type": ["string", "null"],
+                            "description": "The direct parent session ID for a fork or descendant, or null for a root session."
+                        },
                         "workspace": { "type": "string" },
                         "started_at_ms": { "type": "integer", "minimum": 0 },
                         "updated_at_ms": { "type": "integer", "minimum": 0 },
                         "preview": { "type": "string" }
                     },
-                    "required": ["session_id", "workspace", "started_at_ms", "updated_at_ms", "preview"],
+                    "required": ["session_id", "parent_session_id", "workspace", "started_at_ms", "updated_at_ms", "preview"],
                     "additionalProperties": false
                 }
             },
@@ -798,6 +804,10 @@ mod tests {
         assert_eq!(input["properties"]["contains_any"]["maxItems"], 16);
         assert_eq!(input["properties"]["cursor"]["additionalProperties"], false);
         assert_eq!(output["properties"]["sessions"]["maxItems"], 30);
+        assert_eq!(
+            output["properties"]["sessions"]["items"]["properties"]["parent_session_id"]["type"],
+            json!(["string", "null"])
+        );
         assert_eq!(output["additionalProperties"], json!(false));
     }
 
@@ -862,10 +872,38 @@ mod tests {
         let directory = tempdir().unwrap();
         let config_path = directory.path().join("config.toml");
         let mut storage = SessionStorage::open(&config_path).unwrap();
-        append_session(&mut storage, "current", "/work", 400, "validation needle");
-        append_session(&mut storage, "matching", "/work", 300, "Validation Needle");
-        append_session(&mut storage, "unrelated", "/work", 200, "different topic");
-        append_session(&mut storage, "other", "/other", 100, "validation needle");
+        append_session(
+            &mut storage,
+            "current",
+            None,
+            "/work",
+            400,
+            "validation needle",
+        );
+        append_session(
+            &mut storage,
+            "matching",
+            Some("root-session"),
+            "/work",
+            300,
+            "Validation Needle",
+        );
+        append_session(
+            &mut storage,
+            "unrelated",
+            None,
+            "/work",
+            200,
+            "different topic",
+        );
+        append_session(
+            &mut storage,
+            "other",
+            None,
+            "/other",
+            100,
+            "validation needle",
+        );
 
         let tool = FindSessionsTool::new(config_path);
         let output = execute_find(
@@ -881,6 +919,7 @@ mod tests {
 
         assert_eq!(output["sessions"].as_array().unwrap().len(), 1);
         assert_eq!(output["sessions"][0]["session_id"], "matching");
+        assert_eq!(output["sessions"][0]["parent_session_id"], "root-session");
         assert_eq!(output["sessions"][0]["workspace"], "/work");
         assert_eq!(output["sessions"][0]["updated_at_ms"], 300);
         assert!(output["next_cursor"].is_null());
@@ -906,6 +945,7 @@ mod tests {
             append_session(
                 &mut storage,
                 &format!("session-{index:02}"),
+                None,
                 "/work",
                 1_000_u64.saturating_sub(u64::try_from(index).unwrap()),
                 "prompt",
@@ -1230,6 +1270,7 @@ mod tests {
     fn append_session(
         storage: &mut SessionStorage,
         session_id: &str,
+        parent_session_id: Option<&str>,
         workspace: &str,
         at: u64,
         prompt: &str,
@@ -1241,7 +1282,7 @@ mod tests {
                     at.saturating_sub(1),
                     LocalEvent::SessionStarted(SessionStarted {
                         session_id: session_id.to_owned(),
-                        parent_session_id: None,
+                        parent_session_id: parent_session_id.map(str::to_owned),
                         parent_sequence: None,
                         model: "model".to_owned(),
                         effort: ReasoningEffort::Medium,

--- a/bin/tact/src/tui/storage.rs
+++ b/bin/tact/src/tui/storage.rs
@@ -61,6 +61,7 @@ pub(crate) enum StorageError {
 #[derive(Debug)]
 pub(crate) struct StoredSession {
     pub(crate) session_id: String,
+    pub(crate) parent_session_id: Option<String>,
     pub(crate) started_at_unix_ms: u64,
     pub(crate) updated_at_unix_ms: u64,
     pub(crate) model: String,
@@ -435,13 +436,13 @@ impl SessionStorage {
         let workspace = workspace.to_string_lossy();
         let statement_sql = if resumable_only {
             "SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
-                    s.workspace, s.preview, s.updated_at_ms\n\
+                    s.workspace, s.preview, s.updated_at_ms, s.parent_session_id\n\
              FROM sessions s INNER JOIN resume_states r ON r.session_id = s.session_id\n\
              WHERE s.workspace = ?1\n\
              ORDER BY s.updated_at_ms DESC, s.session_id"
         } else {
             "SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
-                    s.workspace, s.preview, s.updated_at_ms\n\
+                    s.workspace, s.preview, s.updated_at_ms, s.parent_session_id\n\
              FROM sessions s\n\
              WHERE s.workspace = ?1\n\
              ORDER BY s.updated_at_ms DESC, s.session_id"
@@ -522,7 +523,8 @@ impl SessionStorage {
         let query_sql = format!(
             "WITH candidates AS MATERIALIZED (\n\
                  SELECT s.session_id, s.started_at_ms, s.model, s.effort, s.reasoning_mode,\n\
-                        s.workspace, s.preview AS search_preview, s.updated_at_ms\n\
+                        s.workspace, s.preview AS search_preview, s.updated_at_ms,\n\
+                        s.parent_session_id\n\
                  FROM sessions s\n\
                  WHERE s.session_id != ?1\n\
                    {candidate_filters}\
@@ -530,7 +532,8 @@ impl SessionStorage {
                  LIMIT ?{limit_parameter}\n\
              )\n\
              SELECT c.session_id, c.started_at_ms, c.model, c.effort, c.reasoning_mode,\n\
-                    c.workspace, substr(c.search_preview, 1, 513), c.updated_at_ms, {matches}\n\
+                    c.workspace, substr(c.search_preview, 1, 513), c.updated_at_ms,\n\
+                    c.parent_session_id, {matches}\n\
              FROM candidates c\n\
              ORDER BY c.updated_at_ms DESC, c.session_id"
         );
@@ -540,7 +543,7 @@ impl SessionStorage {
             .map_err(|source| query(&self.path, source))?;
         let rows = statement
             .query_map(params_from_iter(parameters), |row| {
-                Ok((decode_session(row)?, row.get::<_, bool>(8)?))
+                Ok((decode_session(row)?, row.get::<_, bool>(9)?))
             })
             .map_err(|source| query(&self.path, source))?;
         let mut candidates = rows
@@ -870,6 +873,7 @@ fn decode_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredSession> {
     let reasoning_mode = row.get::<_, String>(4)?;
     Ok(StoredSession {
         session_id: row.get(0)?,
+        parent_session_id: row.get(8)?,
         started_at_unix_ms: from_sql_u64(row.get(1)?),
         updated_at_unix_ms: from_sql_u64(row.get(7)?),
         model: row.get(2)?,

--- a/bin/tact/src/tui/worker.rs
+++ b/bin/tact/src/tui/worker.rs
@@ -207,12 +207,13 @@ const REFLECTION_PROMPT: &str = concat!(
     "supplied current workspace and inspect its recent sessions. Use `contains_any` when the topic ",
     "suggests useful literal prompt patterns; omit the workspace only when the additional ",
     "instructions or evidence justify cross-workspace discovery. The tool excludes this conversation ",
-    "automatically. Pass `next_cursor` back only when another bounded page is needed. ",
+    "automatically. Use `parent_session_id` to avoid counting forks or descendants as independent ",
+    "evidence. Pass `next_cursor` back only when another bounded page is needed. ",
     "After selecting a small number of high-value session IDs, use `read_session` with exact kinds ",
-    "to read only enough context to establish what happened. A targeted `user.submitted` search can ",
-    "locate a candidate event; a separate call starting from that event ID can retrieve the adjacent ",
-    "assistant response without requiring it to match the same text filter. Stop when the evidence ",
-    "is sufficient.\n\n",
+    "to read only enough context to establish what happened. Targeted searches over both ",
+    "`user.submitted` and `user.steered` can locate candidate corrections; a separate call starting ",
+    "from a matched event ID can retrieve the adjacent assistant response without requiring it to ",
+    "match the same text filter. Stop when the evidence is sufficient.\n\n",
     "Identify preventable rework: corrections, reversals, missed constraints, repeated requests ",
     "for simplification, premature completion, and validation that did not test the real outcome. ",
     "Distinguish durable lessons from new scope, changed requirements, first-time preferences, and ",
@@ -237,11 +238,12 @@ const REFLECTION_PROMPT: &str = concat!(
 
 const REFLECTION_REPORT_ENDING: &str = concat!(
     "Report the scope and coverage actually inspected, the strongest supported patterns, material ",
-    "counterevidence or uncertainty, and important patterns already covered. End the report with ",
-    "sections named `Findings` and `Recommended actions`. Findings should state the supported ",
-    "conclusions and their scope. Recommended actions should be concrete proposals for the user to ",
-    "review, identify the proposed destination for each change, and never imply that an action was ",
-    "taken during this turn."
+    "counterevidence or uncertainty, and important patterns already covered. Do not claim exact ",
+    "frequencies unless the relevant scope was inspected exhaustively; otherwise describe recurrence ",
+    "as sampled evidence. End the report with sections named `Findings` and `Recommended actions`. ",
+    "Findings should state the supported conclusions and their scope. Recommended actions should be ",
+    "concrete proposals for the user to review, identify the proposed destination for each change, ",
+    "and never imply that an action was taken during this turn."
 );
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1114,6 +1116,9 @@ mod tests {
         assert!(text.contains("self-contained Tact reflection turn"));
         assert!(text.contains("`find_sessions`"));
         assert!(text.contains("`read_session`"));
+        assert!(text.contains("`parent_session_id`"));
+        assert!(text.contains("`user.submitted` and `user.steered`"));
+        assert!(text.contains("unless the relevant scope was inspected exhaustively"));
         assert!(text.contains(r#""workspace":"/work/current""#));
         assert!(!text.contains("sqlite3"));
         assert!(!text.contains("session_database"));


### PR DESCRIPTION
## Summary

- expose parent session IDs from find_sessions so related forks and descendants are not counted as independent recurrence
- inspect both submitted and steered user turns when locating corrections and adjacent assistant context
- require sampled recurrence language unless the inspected scope was exhaustive

## Validation

- cargo check --all-features
- just check-fmt
- just clippy
- just test (893 passed)

## Stack

- #145 — adds bounded session discovery
- #146 — this PR