### PR TITLE
fix(memory): enable remote memory in linked worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ criteria.
 
 To share memory with a team, configure an authenticated remote backend. Each person uses a distinct
 namespace and may receive either writer or read-only credentials. Tact chooses exactly one backend
-for each runtime: remote inside a configured workspace root and local outside all configured roots.
+for each runtime: remote inside a configured workspace root or a linked worktree from one, and local
+outside all configured roots.
 
 ```toml
 [memory.remote]

--- a/bin/tact/src/app/config.rs
+++ b/bin/tact/src/app/config.rs
@@ -1129,12 +1129,13 @@ impl RemoteMemoryConfig {
         self.bearer_token.expose_secret()
     }
 
-    /// Checks the target of an already-canonical workspace against every configured root target.
+    /// Checks an already-canonical workspace against configured roots and their Git worktrees.
     pub(crate) fn matches_workspace(
         &self,
         canonical_workspace: &Path,
     ) -> std::result::Result<bool, RemoteMemoryConfigError> {
         let mut matches = false;
+        let mut canonical_roots = Vec::with_capacity(self.workspace_roots.len());
         for root in &self.workspace_roots {
             let canonical_root = root.canonicalize().map_err(|source| {
                 RemoteMemoryConfigError::ResolveWorkspaceRoot {
@@ -1147,10 +1148,65 @@ impl RemoteMemoryConfig {
                     root.clone(),
                 ));
             }
-            matches |= canonical_workspace.starts_with(canonical_root);
+            matches |= canonical_workspace.starts_with(&canonical_root);
+            canonical_roots.push(canonical_root);
         }
-        Ok(matches)
+        if matches {
+            return Ok(true);
+        }
+
+        let Some(workspace_repository) = repository_common_directory(canonical_workspace) else {
+            return Ok(false);
+        };
+        for root in canonical_roots {
+            if workspace_repository.starts_with(&root)
+                || repository_common_directory(&root).as_ref() == Some(&workspace_repository)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
+}
+
+fn repository_common_directory(path: &Path) -> Option<PathBuf> {
+    for directory in path.ancestors() {
+        let dot_git = directory.join(".git");
+        let Ok(metadata) = dot_git.symlink_metadata() else {
+            continue;
+        };
+        if metadata.is_dir() {
+            return dot_git.canonicalize().ok();
+        }
+        if !metadata.is_file() {
+            return None;
+        }
+
+        let contents = fs::read_to_string(&dot_git).ok()?;
+        let target = Path::new(contents.trim().strip_prefix("gitdir: ")?);
+        let target = if target.is_absolute() {
+            target.to_path_buf()
+        } else {
+            directory.join(target)
+        };
+        let git_directory = target.canonicalize().ok()?;
+
+        let common_directory_file = git_directory.join("commondir");
+        let registered_git_file = fs::read_to_string(git_directory.join("gitdir")).ok()?;
+        let registered_git_file = Path::new(registered_git_file.trim());
+        let registered_git_file = if registered_git_file.is_absolute() {
+            registered_git_file.to_path_buf()
+        } else {
+            git_directory.join(registered_git_file)
+        };
+        if registered_git_file.canonicalize().ok()? != dot_git.canonicalize().ok()? {
+            return None;
+        }
+
+        let contents = fs::read_to_string(common_directory_file).ok()?;
+        return git_directory.join(contents.trim()).canonicalize().ok();
+    }
+    None
 }
 
 impl SubagentsConfig {
@@ -1943,6 +1999,64 @@ mod tests {
         assert!(
             !remote
                 .matches_workspace(&allowed.join("escape").canonicalize().unwrap())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn remote_memory_scope_includes_only_registered_linked_worktrees() {
+        let directory = tempdir().unwrap();
+        let repository = directory.path().join("repository");
+        let git_directory = repository.join(".git");
+        let worktree = directory.path().join("feature-worktree");
+        let unregistered = directory.path().join("unregistered-worktree");
+        let worktree_git_directory = git_directory.join("worktrees/feature");
+        fs::create_dir_all(&worktree_git_directory).unwrap();
+        fs::create_dir(&worktree).unwrap();
+        fs::create_dir(&unregistered).unwrap();
+        fs::write(worktree_git_directory.join("commondir"), "../..\n").unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", worktree_git_directory.display()),
+        )
+        .unwrap();
+        fs::write(
+            worktree_git_directory.join("gitdir"),
+            format!("{}\n", worktree.join(".git").display()),
+        )
+        .unwrap();
+        fs::write(
+            unregistered.join(".git"),
+            format!("gitdir: {}\n", git_directory.display()),
+        )
+        .unwrap();
+        let config_path = directory.path().join("config.toml");
+        fs::write(
+            &config_path,
+            remote_memory_config(
+                "https://memory.example/v1",
+                "personal",
+                "TACT_MEMORY_TOKEN",
+                repository.to_str().unwrap(),
+            ),
+        )
+        .unwrap();
+        let config = load_config_at(config_path, directory.path()).unwrap();
+
+        assert!(
+            config
+                .memory()
+                .remote()
+                .unwrap()
+                .matches_workspace(&worktree.canonicalize().unwrap())
+                .unwrap()
+        );
+        assert!(
+            !config
+                .memory()
+                .remote()
+                .unwrap()
+                .matches_workspace(&unregistered.canonicalize().unwrap())
                 .unwrap()
         );
     }

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -16,7 +16,8 @@ enabled = true
 
 When enabled, every runtime selects exactly one backend:
 
-- inside any configured `memory.remote.workspace_roots`, it uses only the remote backend;
+- inside any configured `memory.remote.workspace_roots` or a linked worktree from one, it uses only
+  the remote backend;
 - outside all configured roots, it uses only the local backend; and
 - with memory disabled, it uses no backend.
 
@@ -25,9 +26,11 @@ to the caller. Tact never falls back to local memory for an in-scope workspace. 
 workspace on one authoritative corpus instead of silently splitting writes between stores.
 
 Relative workspace roots are resolved against the directory containing `config.toml`. Tact uses
-canonical path targets when deciding whether a workspace is in scope. The selection applies to the
-memory tool and the TUI memory browser. Configuration reload changes browser availability
-immediately; an existing agent retains the tool surface and instructions with which it started.
+canonical path targets when deciding whether a workspace is in scope. A Git worktree is also in
+scope when its repository is rooted inside a configured directory or another worktree of the same
+repository is configured. The selection applies to the memory tool and the TUI memory browser.
+Configuration reload changes browser availability immediately; an existing agent retains the tool
+surface and instructions with which it started.
 
 ## Local memory
 


### PR DESCRIPTION
## Summary

- enable remote memory for Git-linked worktrees whose repository is covered by a configured workspace root
- require Git registered worktree metadata in both directions before expanding remote-memory scope
- document worktree selection and cover registered and unregistered metadata

## Validation

- cargo nextest run -p tact remote_memory
- cargo check --all-features
- just clippy
- just check-fmt