### PR TITLE
chore(release): prepare 0.6.0

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,0 +1,49 @@
+name: Cache
+
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            warm_ci: true
+          - os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            warm_ci: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            warm_ci: true
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            warm_ci: false
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: build
+      - name: Build CI artifacts
+        if: matrix.warm_ci
+        run: cargo test --locked --workspace --all-targets --all-features --no-run
+      - name: Build release binary
+        run: cargo build --locked --release --package tact --bin tact --target ${{ matrix.target }}
+        env:
+          TACT_RELEASE_BUILD: "1"

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -40,10 +40,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: build
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build CI artifacts
-        if: matrix.warm_ci
+        if: github.ref == 'refs/heads/main' && matrix.warm_ci
         run: cargo test --locked --workspace --all-targets --all-features --no-run
       - name: Build release binary
+        if: github.ref == 'refs/heads/main'
         run: cargo build --locked --release --package tact --bin tact --target ${{ matrix.target }}
         env:
           TACT_RELEASE_BUILD: "1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cache:
+    uses: ./.github/workflows/cache.yaml
+
   review-web:
     runs-on: ubuntu-latest
     name: Review Web
@@ -33,6 +36,7 @@ jobs:
         run: bun run typecheck
 
   cargo-tests:
+    needs: cache
     runs-on: ${{ matrix.os }}
     name: Tests (${{ matrix.os }})
     timeout-minutes: 30
@@ -49,13 +53,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       - name: cargo test
         run: just test --locked
 
   cargo-build:
+    needs: cache
     runs-on: ubuntu-latest
     name: Build (${{ matrix.toolchain }})
     timeout-minutes: 20
@@ -75,7 +81,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - uses: taiki-e/install-action@just
       - name: Check standalone tact package
         run: cargo check --package tact --locked
@@ -83,6 +90,7 @@ jobs:
         run: just build --locked --all-features
 
   cargo-portability:
+    needs: cache
     runs-on: ubuntu-latest
     name: Features + WebAssembly
     timeout-minutes: 20
@@ -97,7 +105,8 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@just
       - name: Install Bun
@@ -118,6 +127,7 @@ jobs:
         run: npm run deploy:check --prefix examples/tact-memory-cloudflare
 
   cargo-lint:
+    needs: cache
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Clippy
@@ -137,11 +147,13 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - name: fmt + lint
         run: just lint
 
   cargo-doc:
+    needs: cache
     runs-on: ubuntu-latest
     name: Docs (lint + test)
     timeout-minutes: 20
@@ -155,13 +167,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - name: doclint
         run: just check-docs
       - name: doctest
         run: just test-docs
 
   cargo-build-benches:
+    needs: cache
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: Build Benchmarks
@@ -176,6 +190,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - name: build benches
         run: cargo bench --no-run --all
+
+  benchmarks:
+    needs: cache
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/codspeed.yml

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,10 +1,7 @@
 name: CodSpeed Benchmarks
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   benchmarks:
@@ -21,7 +18,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,9 +42,13 @@ jobs:
             exit 1
           fi
 
+  cache:
+    needs: validate
+    uses: ./.github/workflows/cache.yaml
+
   build:
     name: Build ${{ matrix.target }}
-    needs: validate
+    needs: cache
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -61,7 +65,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_ext: tar.gz
-          - os: macos-latest
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             archive_ext: tar.gz
     steps:
@@ -75,8 +79,8 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          key: ${{ matrix.target }}
-          cache-on-failure: true
+          shared-key: build
+          save-if: false
       - name: Build with Cargo
         run: cargo build --locked --release --package tact --bin tact --target ${{ matrix.target }}
         env:
@@ -227,9 +231,6 @@ jobs:
           path: ${{ runner.temp }}/signed-release
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          cache-on-failure: true
       - name: Publish crates in dependency order
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "arboard",
  "axum",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "tact-memory"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "axum",
  "const_format",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "tact-memory-cloudflare"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "axum",
  "rusqlite",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "tact-subagents"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bin/tact", "crates/*", "examples/tact-memory-cloudflare"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]
@@ -54,8 +54,8 @@ sha2 = "0.10.9"
 shlex = "2.0.1"
 syntect = { version = "5.3.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
 tar = "0.4.44"
-tact-memory = { version = "0.5.4", path = "crates/memory", default-features = false }
-tact-subagents = { version = "0.5.4", path = "crates/subagents" }
+tact-memory = { version = "0.6.0", path = "crates/memory", default-features = false }
+tact-subagents = { version = "0.6.0", path = "crates/subagents" }
 tempfile = "3.27.0"
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }

--- a/bin/tact/tests/release_pipeline.rs
+++ b/bin/tact/tests/release_pipeline.rs
@@ -54,6 +54,10 @@ fn harbor_context_contains_every_workspace_member() {
     );
     assert_contains(
         JUSTFILE,
+        "cp crates/memory/Cargo.toml crates/memory/README.md \"$build_context/crates/memory/\"",
+    );
+    assert_contains(
+        JUSTFILE,
         "cp crates/subagents/Cargo.toml crates/subagents/README.md \"$build_context/crates/subagents/\"",
     );
     assert_contains(

--- a/bin/tact/tests/release_pipeline.rs
+++ b/bin/tact/tests/release_pipeline.rs
@@ -1,5 +1,7 @@
 const RELEASE_WORKFLOW: &str = include_str!("../../../.github/workflows/release.yaml");
+const CACHE_WORKFLOW: &str = include_str!("../../../.github/workflows/cache.yaml");
 const CI_WORKFLOW: &str = include_str!("../../../.github/workflows/ci.yaml");
+const CODSPEED_WORKFLOW: &str = include_str!("../../../.github/workflows/codspeed.yml");
 const RELEASE_TEMPLATE: &str = include_str!("../../../.github/RELEASE_TEMPLATE.md");
 const CHANGELOG_CONFIG: &str = include_str!("../../../cliff.toml");
 const RELEASE_INSTRUCTIONS: &str = include_str!("../../../RELEASES.md");
@@ -17,6 +19,13 @@ fn assert_contains(document: &str, expected: &str) {
 
 fn workflow(document: &str) -> serde_yaml::Value {
     serde_yaml::from_str(document).expect("workflow should be valid YAML")
+}
+
+fn assert_rust_caches_restore_only(document: &str) {
+    let cache_steps = document.matches("Swatinem/rust-cache@").count();
+    assert!(cache_steps > 0);
+    assert_eq!(document.matches("shared-key: build").count(), cache_steps);
+    assert_eq!(document.matches("save-if: false").count(), cache_steps);
 }
 
 fn number_after(document: &str, marker: &str) -> u32 {
@@ -180,6 +189,84 @@ fn release_tag_must_be_on_main() {
         RELEASE_WORKFLOW,
         "git merge-base --is-ancestor \"$GITHUB_SHA\" origin/main",
     );
+}
+
+#[test]
+fn shared_cache_job_is_the_only_writer_for_ci_and_release() {
+    let release = workflow(RELEASE_WORKFLOW);
+    let steps = release["jobs"]["build"]["steps"]
+        .as_sequence()
+        .expect("release build should contain steps");
+    let cache = steps
+        .iter()
+        .find(|step| {
+            step["uses"]
+                .as_str()
+                .is_some_and(|action| action.starts_with("Swatinem/rust-cache@"))
+        })
+        .expect("release build should restore a Rust cache");
+
+    assert_eq!(cache["with"]["save-if"], false);
+    assert_eq!(cache["with"]["shared-key"], "build");
+    assert!(cache["with"]["key"].is_null());
+
+    let shared = workflow(CACHE_WORKFLOW);
+    let main_steps = shared["jobs"]["build"]["steps"]
+        .as_sequence()
+        .expect("shared cache job should contain steps");
+    let main_cache = main_steps
+        .iter()
+        .find(|step| {
+            step["uses"]
+                .as_str()
+                .is_some_and(|action| action.starts_with("Swatinem/rust-cache@"))
+        })
+        .expect("shared cache job should save a Rust cache");
+    assert_eq!(main_cache["with"]["shared-key"], "build");
+    assert!(main_cache["with"]["save-if"].is_null());
+    assert!(main_cache["with"]["key"].is_null());
+    assert_eq!(CACHE_WORKFLOW.matches("Swatinem/rust-cache@").count(), 1);
+    let matrix_pairs = |workflow: &serde_yaml::Value, job: &str| {
+        workflow["jobs"][job]["strategy"]["matrix"]["include"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .map(|entry| (entry["os"].clone(), entry["target"].clone()))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        matrix_pairs(&shared, "build"),
+        matrix_pairs(&release, "build")
+    );
+    let ci = workflow(CI_WORKFLOW);
+    assert_eq!(
+        ci["jobs"]["cache"]["uses"],
+        "./.github/workflows/cache.yaml"
+    );
+    assert_eq!(
+        release["jobs"]["cache"]["uses"],
+        "./.github/workflows/cache.yaml"
+    );
+    assert_eq!(release["jobs"]["cache"]["needs"], "validate");
+    assert_eq!(release["jobs"]["build"]["needs"], "cache");
+    for job in [
+        "cargo-tests",
+        "cargo-build",
+        "cargo-portability",
+        "cargo-lint",
+        "cargo-doc",
+        "cargo-build-benches",
+    ] {
+        assert_eq!(ci["jobs"][job]["needs"], "cache");
+    }
+    assert_eq!(ci["jobs"]["benchmarks"]["needs"], "cache");
+    assert_eq!(
+        ci["jobs"]["benchmarks"]["uses"],
+        "./.github/workflows/codspeed.yml"
+    );
+    assert_rust_caches_restore_only(CI_WORKFLOW);
+    assert_rust_caches_restore_only(CODSPEED_WORKFLOW);
+    assert_contains(RELEASE_INSTRUCTIONS, "`main` CI run");
 }
 
 #[test]

--- a/bin/tact/tests/release_pipeline.rs
+++ b/bin/tact/tests/release_pipeline.rs
@@ -192,7 +192,7 @@ fn release_tag_must_be_on_main() {
 }
 
 #[test]
-fn shared_cache_job_is_the_only_writer_for_ci_and_release() {
+fn shared_cache_reads_everywhere_and_writes_only_on_main() {
     let release = workflow(RELEASE_WORKFLOW);
     let steps = release["jobs"]["build"]["steps"]
         .as_sequence()
@@ -223,9 +223,25 @@ fn shared_cache_job_is_the_only_writer_for_ci_and_release() {
         })
         .expect("shared cache job should save a Rust cache");
     assert_eq!(main_cache["with"]["shared-key"], "build");
-    assert!(main_cache["with"]["save-if"].is_null());
+    assert_eq!(
+        main_cache["with"]["save-if"],
+        "${{ github.ref == 'refs/heads/main' }}"
+    );
     assert!(main_cache["with"]["key"].is_null());
     assert_eq!(CACHE_WORKFLOW.matches("Swatinem/rust-cache@").count(), 1);
+    let ci_artifacts = main_steps
+        .iter()
+        .find(|step| step["name"] == "Build CI artifacts")
+        .expect("shared cache job should warm CI artifacts on main");
+    assert_eq!(
+        ci_artifacts["if"],
+        "github.ref == 'refs/heads/main' && matrix.warm_ci"
+    );
+    let release_binary = main_steps
+        .iter()
+        .find(|step| step["name"] == "Build release binary")
+        .expect("shared cache job should warm release artifacts on main");
+    assert_eq!(release_binary["if"], "github.ref == 'refs/heads/main'");
     let matrix_pairs = |workflow: &serde_yaml::Value, job: &str| {
         workflow["jobs"][job]["strategy"]["matrix"]["include"]
             .as_sequence()
@@ -243,6 +259,7 @@ fn shared_cache_job_is_the_only_writer_for_ci_and_release() {
         ci["jobs"]["cache"]["uses"],
         "./.github/workflows/cache.yaml"
     );
+    assert!(ci["jobs"]["cache"]["if"].is_null());
     assert_eq!(
         release["jobs"]["cache"]["uses"],
         "./.github/workflows/cache.yaml"
@@ -258,8 +275,10 @@ fn shared_cache_job_is_the_only_writer_for_ci_and_release() {
         "cargo-build-benches",
     ] {
         assert_eq!(ci["jobs"][job]["needs"], "cache");
+        assert!(ci["jobs"][job]["if"].is_null());
     }
     assert_eq!(ci["jobs"]["benchmarks"]["needs"], "cache");
+    assert!(ci["jobs"]["benchmarks"]["if"].is_null());
     assert_eq!(
         ci["jobs"]["benchmarks"]["uses"],
         "./.github/workflows/codspeed.yml"

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 description = "Bounded local and remote memory for Tact"
+readme = "README.md"
 
 [lints]
 workspace = true

--- a/crates/memory/README.md
+++ b/crates/memory/README.md
@@ -1,0 +1,31 @@
+# tact-memory
+
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/clabby/tact/ci.yaml?style=for-the-badge&label=CI)](https://github.com/clabby/tact/actions/workflows/ci.yaml)
+[![Crates.io License](https://img.shields.io/crates/l/tact-memory?style=for-the-badge)](https://crates.io/crates/tact-memory)
+[![Crates.io MSRV](https://img.shields.io/crates/msrv/tact-memory?style=for-the-badge)](https://crates.io/crates/tact-memory)
+[![Crates.io Version](https://img.shields.io/crates/v/tact-memory?style=for-the-badge)](https://crates.io/crates/tact-memory)
+
+`tact-memory` provides bounded memory storage and retrieval for local agents and shared teams. It
+defines a common asynchronous store contract, a SQLite-backed local store, an authenticated remote
+client and server protocol, and a Nanocodex memory tool.
+
+The crate exposes four integration boundaries:
+
+- `MemoryStore` defines ordinary local and remote operations over bounded memory records.
+- `LocalMemoryStore` persists the schema-v1 local format, while `SelectedMemoryStore` lets an
+  application choose one local or remote backend for a runtime.
+- `RemoteMemoryClient` and `MemoryServer` share versioned protocol types and preserve author
+  namespaces across authenticated operations.
+- `MemoryTool` exposes explicit scan, read, put, and delete operations to Nanocodex sessions under
+  an application-provided mutation authority.
+
+Feature flags separate the local store, remote client, server, and Nanocodex tool integrations.
+Default features enable the complete native client, local, server, and tool surface; server-only
+deployments can select `server` without native-only dependencies.
+
+Implementations enforce record, query, content, and aggregate corpus bounds. Client-side storage
+boundaries reject secret-like content before mutation and suppress pre-existing unsafe records
+before use. Server backends remain storage-policy agnostic.
+
+See the [Tact memory guide](https://github.com/clabby/tact/blob/main/docs/memory.md) for backend
+selection, protocol, authentication, transfer, and deployment contracts.

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,27 +1,5 @@
-//! Bounded memory storage for local agents and shared teams.
-//!
-//! # Architecture
-//!
-//! [`MemoryStore`] is the asynchronous storage contract. [`LocalMemoryStore`] preserves Tact's
-//! schema-v1 on-disk format, [`RemoteMemoryClient`] carries the same operations over authenticated
-//! HTTP, and [`server::MemoryServer`] exposes any namespace-bound implementation through the same
-//! protocol. [`SelectedMemoryStore`] lets an application choose one local or remote backend without
-//! merging their runtime results.
-//!
-//! # Remote protocol
-//!
-//! [`server::protocol`] contains the versioned JSON types and route constants shared by clients
-//! and servers. Every compatibility check and route derives from [`VERSION`]. Remote credentials
-//! bind each writer to one author namespace; record keys retain that namespace for attribution and
-//! optimistic concurrency.
-//!
-//! # Bounds and secrets
-//!
-//! Implementations enforce record, content, query, and aggregate corpus bounds.
-//! Tact applies one shared secret-content detector at client-side storage boundaries: mutations
-//! are rejected before reaching the selected backend, and local or remote records that predate
-//! that check are suppressed before use. Server-side backends remain storage-policy agnostic.
-//! [`RemoteToken`] owns bearer credentials in zeroizing storage and redacts its debug representation.
+#![doc = include_str!("../README.md")]
+
 /// Incompatible remote-memory protocol generation.
 ///
 /// Route paths and session negotiation derive from this single value. Increment it only when

--- a/crates/subagents/README.md
+++ b/crates/subagents/README.md
@@ -1,5 +1,10 @@
 # tact-subagents
 
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/clabby/tact/ci.yaml?style=for-the-badge&label=CI)](https://github.com/clabby/tact/actions/workflows/ci.yaml)
+[![Crates.io License](https://img.shields.io/crates/l/tact-subagents?style=for-the-badge)](https://crates.io/crates/tact-subagents)
+[![Crates.io MSRV](https://img.shields.io/crates/msrv/tact-subagents?style=for-the-badge)](https://crates.io/crates/tact-subagents)
+[![Crates.io Version](https://img.shields.io/crates/v/tact-subagents?style=for-the-badge)](https://crates.io/crates/tact-subagents)
+
 `tact-subagents` provides structured child-agent orchestration for Nanocodex applications. It owns
 clean child sessions, a scoped task tree, bounded concurrent turns, directed messages, structured
 result validation, and lifecycle tools.

--- a/justfile
+++ b/justfile
@@ -105,7 +105,7 @@ build-harbor-agent platform='':
     cp bin/tact/Cargo.toml bin/tact/build.rs "$build_context/bin/tact/"
     cp -R bin/tact/src "$build_context/bin/tact/src"
     mkdir -p "$build_context/crates/memory"
-    cp crates/memory/Cargo.toml "$build_context/crates/memory/"
+    cp crates/memory/Cargo.toml crates/memory/README.md "$build_context/crates/memory/"
     cp -R crates/memory/src "$build_context/crates/memory/src"
     mkdir -p "$build_context/crates/subagents"
     cp crates/subagents/Cargo.toml crates/subagents/README.md "$build_context/crates/subagents/"


### PR DESCRIPTION
## Summary

- prepare all published crates for version 0.6.0
- add published-crate READMEs and badges
- share one architecture-aware Rust cache writer across CI, CodSpeed, and release jobs

## Validation

- just check-fmt
- just clippy --locked
- just test --locked (895 tests)
- just check-docs
- cargo check --all-features
- package-content checks for tact-memory and tact-subagents
- actionlint workflow validation