### PR TITLE
fix(release): reuse main Rust caches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,13 +42,9 @@ jobs:
             exit 1
           fi
 
-  cache:
-    needs: validate
-    uses: ./.github/workflows/cache.yaml
-
   build:
     name: Build ${{ matrix.target }}
-    needs: cache
+    needs: validate
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -231,6 +227,10 @@ jobs:
           path: ${{ runner.temp }}/signed-release
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: build
+          save-if: false
       - name: Publish crates in dependency order
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- remove the redundant cache-building job from tagged release runs
- restore the existing read-only Rust cache in the crate publishing job
- make release binary builds depend directly on release validation

## Validation

- parsed `.github/workflows/release.yaml` successfully
- verified the release workflow has no remaining dependency on the removed cache job