### PR TITLE
feat(memory): enable D1 read replication

### DIFF
--- a/crates/memory/src/server/protocol.rs
+++ b/crates/memory/src/server/protocol.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 pub const NAMESPACE_HEADER: &str = "x-tact-memory-namespace";
 /// Maximum UTF-8 bytes accepted in a namespace.
 pub const MAX_NAMESPACE_BYTES: usize = 128;
+/// Header carrying an opaque D1 session bookmark between requests.
+pub const D1_BOOKMARK_HEADER: &str = "x-d1-bookmark";
+/// Maximum UTF-8 bytes accepted in a D1 session bookmark.
+pub const MAX_D1_BOOKMARK_BYTES: usize = 4 * 1024;
 
 /// Session-negotiation route.
 pub const SESSION_PATH: &str = concatcp!("v", crate::VERSION, "/session");
@@ -35,6 +39,11 @@ pub fn is_valid_namespace(namespace: &str) -> bool {
         && namespace
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+/// Returns whether an opaque D1 session bookmark is non-empty and bounded.
+pub fn is_valid_d1_bookmark(bookmark: &str) -> bool {
+    !bookmark.is_empty() && bookmark.len() <= MAX_D1_BOOKMARK_BYTES
 }
 
 /// Authorization role returned by session negotiation.

--- a/crates/memory/src/server/protocol.rs
+++ b/crates/memory/src/server/protocol.rs
@@ -8,10 +8,10 @@ use serde::{Deserialize, Serialize};
 pub const NAMESPACE_HEADER: &str = "x-tact-memory-namespace";
 /// Maximum UTF-8 bytes accepted in a namespace.
 pub const MAX_NAMESPACE_BYTES: usize = 128;
-/// Header carrying an opaque D1 session bookmark between requests.
-pub const D1_BOOKMARK_HEADER: &str = "x-d1-bookmark";
-/// Maximum UTF-8 bytes accepted in a D1 session bookmark.
-pub const MAX_D1_BOOKMARK_BYTES: usize = 4 * 1024;
+/// Header carrying an opaque server-issued consistency token between requests.
+pub const CONSISTENCY_TOKEN_HEADER: &str = "x-tact-memory-consistency-token";
+/// Maximum UTF-8 bytes accepted in a consistency token.
+pub const MAX_CONSISTENCY_TOKEN_BYTES: usize = 4 * 1024;
 
 /// Session-negotiation route.
 pub const SESSION_PATH: &str = concatcp!("v", crate::VERSION, "/session");
@@ -41,9 +41,9 @@ pub fn is_valid_namespace(namespace: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
-/// Returns whether an opaque D1 session bookmark is non-empty and bounded.
-pub fn is_valid_d1_bookmark(bookmark: &str) -> bool {
-    !bookmark.is_empty() && bookmark.len() <= MAX_D1_BOOKMARK_BYTES
+/// Returns whether an opaque consistency token is non-empty and bounded.
+pub fn is_valid_consistency_token(token: &str) -> bool {
+    !token.is_empty() && token.len() <= MAX_CONSISTENCY_TOKEN_BYTES
 }
 
 /// Authorization role returned by session negotiation.

--- a/crates/memory/src/server/protocol.rs
+++ b/crates/memory/src/server/protocol.rs
@@ -8,10 +8,10 @@ use serde::{Deserialize, Serialize};
 pub const NAMESPACE_HEADER: &str = "x-tact-memory-namespace";
 /// Maximum UTF-8 bytes accepted in a namespace.
 pub const MAX_NAMESPACE_BYTES: usize = 128;
-/// Header carrying an opaque server-issued consistency token between requests.
-pub const CONSISTENCY_TOKEN_HEADER: &str = "x-tact-memory-consistency-token";
-/// Maximum UTF-8 bytes accepted in a consistency token.
-pub const MAX_CONSISTENCY_TOKEN_BYTES: usize = 4 * 1024;
+/// Header carrying an opaque server-issued bookmark between requests.
+pub const BOOKMARK_HEADER: &str = "x-tact-memory-bookmark";
+/// Maximum UTF-8 bytes accepted in a bookmark.
+pub const MAX_BOOKMARK_BYTES: usize = 4 * 1024;
 
 /// Session-negotiation route.
 pub const SESSION_PATH: &str = concatcp!("v", crate::VERSION, "/session");
@@ -41,9 +41,9 @@ pub fn is_valid_namespace(namespace: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
-/// Returns whether an opaque consistency token is non-empty and bounded.
-pub fn is_valid_consistency_token(token: &str) -> bool {
-    !token.is_empty() && token.len() <= MAX_CONSISTENCY_TOKEN_BYTES
+/// Returns whether an opaque bookmark is non-empty and bounded.
+pub fn is_valid_bookmark(bookmark: &str) -> bool {
+    !bookmark.is_empty() && bookmark.len() <= MAX_BOOKMARK_BYTES
 }
 
 /// Authorization role returned by session negotiation.

--- a/crates/memory/src/server/tests.rs
+++ b/crates/memory/src/server/tests.rs
@@ -1066,6 +1066,39 @@ async fn retrying_list(
     .into_response()
 }
 
+#[derive(Clone, Default)]
+struct BookmarkState {
+    requests: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+async fn bookmarked_list(
+    axum::extract::State(state): axum::extract::State<BookmarkState>,
+    headers: axum::http::HeaderMap,
+) -> Response<Body> {
+    let bookmark = headers
+        .get(protocol::D1_BOOKMARK_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    state.requests.lock().unwrap().push(bookmark.clone());
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let response_bookmark = match bookmark.as_deref() {
+        None => "bookmark-1",
+        Some("bookmark-1") => "bookmark-2",
+        Some("bookmark-2") => "bookmark-3",
+        _ => return StatusCode::CONFLICT.into_response(),
+    };
+    let mut response = Json(ListResponse {
+        memories: Vec::new(),
+    })
+    .into_response();
+    response.headers_mut().insert(
+        protocol::D1_BOOKMARK_HEADER,
+        response_bookmark.parse().unwrap(),
+    );
+    response
+}
+
 async fn unavailable_put(
     axum::extract::State(state): axum::extract::State<RetryState>,
 ) -> Response<Body> {
@@ -1235,6 +1268,36 @@ async fn client_retries_safe_operations_but_does_not_replay_put_responses() {
         })
     ));
     assert_eq!(state.put_calls.load(Ordering::SeqCst), 1);
+    task.abort();
+}
+
+#[tokio::test]
+async fn client_carries_d1_bookmarks_across_concurrent_clones() {
+    let state = BookmarkState::default();
+    let app = Router::new()
+        .route(&format!("/{}", protocol::LIST_PATH), post(bookmarked_list))
+        .with_state(state.clone());
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+    let clone = client.clone();
+
+    let (first, second) = tokio::join!(client.list(), clone.list());
+    assert!(first.unwrap().is_empty());
+    assert!(second.unwrap().is_empty());
+    assert!(client.list().await.unwrap().is_empty());
+    assert_eq!(
+        *state.requests.lock().unwrap(),
+        vec![
+            None,
+            Some("bookmark-1".to_owned()),
+            Some("bookmark-2".to_owned()),
+        ]
+    );
     task.abort();
 }
 

--- a/crates/memory/src/server/tests.rs
+++ b/crates/memory/src/server/tests.rs
@@ -1067,25 +1067,25 @@ async fn retrying_list(
 }
 
 #[derive(Clone, Default)]
-struct ConsistencyTokenState {
+struct BookmarkState {
     requests: Arc<Mutex<Vec<Option<String>>>>,
 }
 
-async fn consistent_list(
-    axum::extract::State(state): axum::extract::State<ConsistencyTokenState>,
+async fn bookmarked_list(
+    axum::extract::State(state): axum::extract::State<BookmarkState>,
     headers: axum::http::HeaderMap,
 ) -> Response<Body> {
-    let token = headers
-        .get(protocol::CONSISTENCY_TOKEN_HEADER)
+    let bookmark = headers
+        .get(protocol::BOOKMARK_HEADER)
         .and_then(|value| value.to_str().ok())
         .map(str::to_owned);
-    state.requests.lock().unwrap().push(token.clone());
+    state.requests.lock().unwrap().push(bookmark.clone());
 
     tokio::time::sleep(Duration::from_millis(50)).await;
-    let response_token = match token.as_deref() {
-        None => "token-1",
-        Some("token-1") => "token-2",
-        Some("token-2") => "token-3",
+    let response_bookmark = match bookmark.as_deref() {
+        None => "bookmark-1",
+        Some("bookmark-1") => "bookmark-2",
+        Some("bookmark-2") => "bookmark-3",
         _ => return StatusCode::CONFLICT.into_response(),
     };
     let mut response = Json(ListResponse {
@@ -1093,8 +1093,8 @@ async fn consistent_list(
     })
     .into_response();
     response.headers_mut().insert(
-        protocol::CONSISTENCY_TOKEN_HEADER,
-        response_token.parse().unwrap(),
+        protocol::BOOKMARK_HEADER,
+        response_bookmark.parse().unwrap(),
     );
     response
 }
@@ -1272,10 +1272,10 @@ async fn client_retries_safe_operations_but_does_not_replay_put_responses() {
 }
 
 #[tokio::test]
-async fn client_carries_consistency_tokens_across_concurrent_clones() {
-    let state = ConsistencyTokenState::default();
+async fn client_carries_bookmarks_across_concurrent_clones() {
+    let state = BookmarkState::default();
     let app = Router::new()
-        .route(&format!("/{}", protocol::LIST_PATH), post(consistent_list))
+        .route(&format!("/{}", protocol::LIST_PATH), post(bookmarked_list))
         .with_state(state.clone());
     let (endpoint, task) = live_server(app).await;
     let client = RemoteMemoryClient::new(
@@ -1292,7 +1292,11 @@ async fn client_carries_consistency_tokens_across_concurrent_clones() {
     assert!(client.list().await.unwrap().is_empty());
     assert_eq!(
         *state.requests.lock().unwrap(),
-        vec![None, Some("token-1".to_owned()), Some("token-2".to_owned()),]
+        vec![
+            None,
+            Some("bookmark-1".to_owned()),
+            Some("bookmark-2".to_owned()),
+        ]
     );
     task.abort();
 }

--- a/crates/memory/src/server/tests.rs
+++ b/crates/memory/src/server/tests.rs
@@ -1067,25 +1067,25 @@ async fn retrying_list(
 }
 
 #[derive(Clone, Default)]
-struct BookmarkState {
+struct ConsistencyTokenState {
     requests: Arc<Mutex<Vec<Option<String>>>>,
 }
 
-async fn bookmarked_list(
-    axum::extract::State(state): axum::extract::State<BookmarkState>,
+async fn consistent_list(
+    axum::extract::State(state): axum::extract::State<ConsistencyTokenState>,
     headers: axum::http::HeaderMap,
 ) -> Response<Body> {
-    let bookmark = headers
-        .get(protocol::D1_BOOKMARK_HEADER)
+    let token = headers
+        .get(protocol::CONSISTENCY_TOKEN_HEADER)
         .and_then(|value| value.to_str().ok())
         .map(str::to_owned);
-    state.requests.lock().unwrap().push(bookmark.clone());
+    state.requests.lock().unwrap().push(token.clone());
 
     tokio::time::sleep(Duration::from_millis(50)).await;
-    let response_bookmark = match bookmark.as_deref() {
-        None => "bookmark-1",
-        Some("bookmark-1") => "bookmark-2",
-        Some("bookmark-2") => "bookmark-3",
+    let response_token = match token.as_deref() {
+        None => "token-1",
+        Some("token-1") => "token-2",
+        Some("token-2") => "token-3",
         _ => return StatusCode::CONFLICT.into_response(),
     };
     let mut response = Json(ListResponse {
@@ -1093,8 +1093,8 @@ async fn bookmarked_list(
     })
     .into_response();
     response.headers_mut().insert(
-        protocol::D1_BOOKMARK_HEADER,
-        response_bookmark.parse().unwrap(),
+        protocol::CONSISTENCY_TOKEN_HEADER,
+        response_token.parse().unwrap(),
     );
     response
 }
@@ -1272,10 +1272,10 @@ async fn client_retries_safe_operations_but_does_not_replay_put_responses() {
 }
 
 #[tokio::test]
-async fn client_carries_d1_bookmarks_across_concurrent_clones() {
-    let state = BookmarkState::default();
+async fn client_carries_consistency_tokens_across_concurrent_clones() {
+    let state = ConsistencyTokenState::default();
     let app = Router::new()
-        .route(&format!("/{}", protocol::LIST_PATH), post(bookmarked_list))
+        .route(&format!("/{}", protocol::LIST_PATH), post(consistent_list))
         .with_state(state.clone());
     let (endpoint, task) = live_server(app).await;
     let client = RemoteMemoryClient::new(
@@ -1292,11 +1292,7 @@ async fn client_carries_d1_bookmarks_across_concurrent_clones() {
     assert!(client.list().await.unwrap().is_empty());
     assert_eq!(
         *state.requests.lock().unwrap(),
-        vec![
-            None,
-            Some("bookmark-1".to_owned()),
-            Some("bookmark-2".to_owned()),
-        ]
+        vec![None, Some("token-1".to_owned()), Some("token-2".to_owned()),]
     );
     task.abort();
 }

--- a/crates/memory/src/store/mod.rs
+++ b/crates/memory/src/store/mod.rs
@@ -44,7 +44,7 @@ pub trait MemoryStore: Clone + Send + Sync + 'static {
         keys: &[MemoryKey],
     ) -> impl Future<Output = Result<Vec<MemoryRecord>, MemoryError>> + Send;
 
-    /// Lists a deterministic visible window after pruning probation.
+    /// Lists a deterministic window that excludes expired probationary records.
     ///
     /// Implementations return at most [`MemoryLimits::records`] records so interactive inspection
     /// does not grow with the complete shared corpus. Full transfer uses paginated export instead.

--- a/crates/memory/src/store/remote/client.rs
+++ b/crates/memory/src/store/remote/client.rs
@@ -101,6 +101,9 @@ pub enum RemoteClientError {
 }
 
 /// Authenticated HTTP implementation of [`MemoryStore`].
+///
+/// Clones share any D1 bookmark returned by the server. Their requests are serialized to preserve
+/// one monotonic logical session because opaque bookmarks cannot be merged.
 #[derive(Clone)]
 pub struct RemoteMemoryClient {
     inner: Arc<RemoteClientInner>,
@@ -123,6 +126,7 @@ struct RemoteClientInner {
     token: RemoteToken,
     client: Client,
     role: tokio::sync::OnceCell<RemoteRole>,
+    d1_bookmark: tokio::sync::Mutex<Option<String>>,
 }
 
 impl RemoteMemoryClient {
@@ -160,6 +164,7 @@ impl RemoteMemoryClient {
                 token,
                 client,
                 role: tokio::sync::OnceCell::new(),
+                d1_bookmark: tokio::sync::Mutex::new(None),
             }),
         })
     }
@@ -491,6 +496,9 @@ impl RemoteMemoryClient {
         Request: Serialize + ?Sized,
         Response: DeserializeOwned,
     {
+        // D1 bookmarks are opaque, so concurrent responses cannot be merged safely. Holding this
+        // guard across the exchange makes this client and its clones one monotonic session.
+        let mut d1_bookmark = self.inner.d1_bookmark.lock().await;
         let url = self
             .inner
             .endpoint
@@ -504,10 +512,19 @@ impl RemoteMemoryClient {
             // Reqwest owns a transient, non-zeroizing header copy for the request lifetime.
             .bearer_auth(self.inner.token.expose())
             .header(protocol::NAMESPACE_HEADER, &self.inner.namespace);
+            let request = match d1_bookmark.as_deref() {
+                Some(bookmark) => request.header(protocol::D1_BOOKMARK_HEADER, bookmark),
+                None => request,
+            };
 
             match request.send().await {
                 Ok(response) if response.status().is_success() => {
-                    return decode_response(response).await;
+                    let response_bookmark = d1_bookmark_from_headers(response.headers())?;
+                    let decoded = decode_response(response).await?;
+                    if let Some(response_bookmark) = response_bookmark {
+                        *d1_bookmark = Some(response_bookmark);
+                    }
+                    return Ok(decoded);
                 }
                 Ok(response) if replay == Replay::Safe && retryable_status(response.status()) => {
                     let Some(backoff) = backoff else {
@@ -634,6 +651,29 @@ fn response_retry_delay(headers: &reqwest::header::HeaderMap, fallback: Duration
         .and_then(|value| value.parse::<u64>().ok())
         .map(|seconds| Duration::from_secs(seconds.min(2)))
         .unwrap_or(fallback)
+}
+
+fn d1_bookmark_from_headers(
+    headers: &reqwest::header::HeaderMap,
+) -> Result<Option<String>, RemoteClientError> {
+    let mut values = headers.get_all(protocol::D1_BOOKMARK_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(RemoteClientError::InvalidResponse);
+    }
+
+    let bookmark = value
+        .to_str()
+        .map_err(|_| RemoteClientError::InvalidResponse)?;
+    if bookmark.is_empty() {
+        return Ok(None);
+    }
+    if !protocol::is_valid_d1_bookmark(bookmark) {
+        return Err(RemoteClientError::InvalidResponse);
+    }
+    Ok(Some(bookmark.to_owned()))
 }
 
 async fn response_error(response: Response) -> RemoteClientError {

--- a/crates/memory/src/store/remote/client.rs
+++ b/crates/memory/src/store/remote/client.rs
@@ -101,9 +101,6 @@ pub enum RemoteClientError {
 }
 
 /// Authenticated HTTP implementation of [`MemoryStore`].
-///
-/// Clones share any bookmark returned by the server. Their requests are serialized to preserve one
-/// monotonic logical session because opaque bookmarks cannot be merged.
 #[derive(Clone)]
 pub struct RemoteMemoryClient {
     inner: Arc<RemoteClientInner>,

--- a/crates/memory/src/store/remote/client.rs
+++ b/crates/memory/src/store/remote/client.rs
@@ -102,8 +102,8 @@ pub enum RemoteClientError {
 
 /// Authenticated HTTP implementation of [`MemoryStore`].
 ///
-/// Clones share any consistency token returned by the server. Their requests are serialized to
-/// preserve one monotonic logical session because opaque tokens cannot be merged.
+/// Clones share any bookmark returned by the server. Their requests are serialized to preserve one
+/// monotonic logical session because opaque bookmarks cannot be merged.
 #[derive(Clone)]
 pub struct RemoteMemoryClient {
     inner: Arc<RemoteClientInner>,
@@ -126,7 +126,7 @@ struct RemoteClientInner {
     token: RemoteToken,
     client: Client,
     role: tokio::sync::OnceCell<RemoteRole>,
-    consistency_token: tokio::sync::Mutex<Option<String>>,
+    bookmark: tokio::sync::Mutex<Option<String>>,
 }
 
 impl RemoteMemoryClient {
@@ -164,7 +164,7 @@ impl RemoteMemoryClient {
                 token,
                 client,
                 role: tokio::sync::OnceCell::new(),
-                consistency_token: tokio::sync::Mutex::new(None),
+                bookmark: tokio::sync::Mutex::new(None),
             }),
         })
     }
@@ -496,9 +496,9 @@ impl RemoteMemoryClient {
         Request: Serialize + ?Sized,
         Response: DeserializeOwned,
     {
-        // Consistency tokens are opaque, so concurrent responses cannot be merged safely. Holding
-        // this guard across the exchange makes this client and its clones one monotonic session.
-        let mut consistency_token = self.inner.consistency_token.lock().await;
+        // Bookmarks are opaque, so concurrent responses cannot be merged safely. Holding this guard
+        // across the exchange makes this client and its clones one monotonic session.
+        let mut bookmark = self.inner.bookmark.lock().await;
         let url = self
             .inner
             .endpoint
@@ -512,17 +512,17 @@ impl RemoteMemoryClient {
             // Reqwest owns a transient, non-zeroizing header copy for the request lifetime.
             .bearer_auth(self.inner.token.expose())
             .header(protocol::NAMESPACE_HEADER, &self.inner.namespace);
-            let request = match consistency_token.as_deref() {
-                Some(token) => request.header(protocol::CONSISTENCY_TOKEN_HEADER, token),
+            let request = match bookmark.as_deref() {
+                Some(bookmark) => request.header(protocol::BOOKMARK_HEADER, bookmark),
                 None => request,
             };
 
             match request.send().await {
                 Ok(response) if response.status().is_success() => {
-                    let response_token = consistency_token_from_headers(response.headers())?;
+                    let response_bookmark = bookmark_from_headers(response.headers())?;
                     let decoded = decode_response(response).await?;
-                    if let Some(response_token) = response_token {
-                        *consistency_token = Some(response_token);
+                    if let Some(response_bookmark) = response_bookmark {
+                        *bookmark = Some(response_bookmark);
                     }
                     return Ok(decoded);
                 }
@@ -653,10 +653,10 @@ fn response_retry_delay(headers: &reqwest::header::HeaderMap, fallback: Duration
         .unwrap_or(fallback)
 }
 
-fn consistency_token_from_headers(
+fn bookmark_from_headers(
     headers: &reqwest::header::HeaderMap,
 ) -> Result<Option<String>, RemoteClientError> {
-    let mut values = headers.get_all(protocol::CONSISTENCY_TOKEN_HEADER).iter();
+    let mut values = headers.get_all(protocol::BOOKMARK_HEADER).iter();
     let Some(value) = values.next() else {
         return Ok(None);
     };
@@ -664,16 +664,16 @@ fn consistency_token_from_headers(
         return Err(RemoteClientError::InvalidResponse);
     }
 
-    let token = value
+    let bookmark = value
         .to_str()
         .map_err(|_| RemoteClientError::InvalidResponse)?;
-    if token.is_empty() {
+    if bookmark.is_empty() {
         return Ok(None);
     }
-    if !protocol::is_valid_consistency_token(token) {
+    if !protocol::is_valid_bookmark(bookmark) {
         return Err(RemoteClientError::InvalidResponse);
     }
-    Ok(Some(token.to_owned()))
+    Ok(Some(bookmark.to_owned()))
 }
 
 async fn response_error(response: Response) -> RemoteClientError {

--- a/crates/memory/src/store/remote/client.rs
+++ b/crates/memory/src/store/remote/client.rs
@@ -102,8 +102,8 @@ pub enum RemoteClientError {
 
 /// Authenticated HTTP implementation of [`MemoryStore`].
 ///
-/// Clones share any D1 bookmark returned by the server. Their requests are serialized to preserve
-/// one monotonic logical session because opaque bookmarks cannot be merged.
+/// Clones share any consistency token returned by the server. Their requests are serialized to
+/// preserve one monotonic logical session because opaque tokens cannot be merged.
 #[derive(Clone)]
 pub struct RemoteMemoryClient {
     inner: Arc<RemoteClientInner>,
@@ -126,7 +126,7 @@ struct RemoteClientInner {
     token: RemoteToken,
     client: Client,
     role: tokio::sync::OnceCell<RemoteRole>,
-    d1_bookmark: tokio::sync::Mutex<Option<String>>,
+    consistency_token: tokio::sync::Mutex<Option<String>>,
 }
 
 impl RemoteMemoryClient {
@@ -164,7 +164,7 @@ impl RemoteMemoryClient {
                 token,
                 client,
                 role: tokio::sync::OnceCell::new(),
-                d1_bookmark: tokio::sync::Mutex::new(None),
+                consistency_token: tokio::sync::Mutex::new(None),
             }),
         })
     }
@@ -496,9 +496,9 @@ impl RemoteMemoryClient {
         Request: Serialize + ?Sized,
         Response: DeserializeOwned,
     {
-        // D1 bookmarks are opaque, so concurrent responses cannot be merged safely. Holding this
-        // guard across the exchange makes this client and its clones one monotonic session.
-        let mut d1_bookmark = self.inner.d1_bookmark.lock().await;
+        // Consistency tokens are opaque, so concurrent responses cannot be merged safely. Holding
+        // this guard across the exchange makes this client and its clones one monotonic session.
+        let mut consistency_token = self.inner.consistency_token.lock().await;
         let url = self
             .inner
             .endpoint
@@ -512,17 +512,17 @@ impl RemoteMemoryClient {
             // Reqwest owns a transient, non-zeroizing header copy for the request lifetime.
             .bearer_auth(self.inner.token.expose())
             .header(protocol::NAMESPACE_HEADER, &self.inner.namespace);
-            let request = match d1_bookmark.as_deref() {
-                Some(bookmark) => request.header(protocol::D1_BOOKMARK_HEADER, bookmark),
+            let request = match consistency_token.as_deref() {
+                Some(token) => request.header(protocol::CONSISTENCY_TOKEN_HEADER, token),
                 None => request,
             };
 
             match request.send().await {
                 Ok(response) if response.status().is_success() => {
-                    let response_bookmark = d1_bookmark_from_headers(response.headers())?;
+                    let response_token = consistency_token_from_headers(response.headers())?;
                     let decoded = decode_response(response).await?;
-                    if let Some(response_bookmark) = response_bookmark {
-                        *d1_bookmark = Some(response_bookmark);
+                    if let Some(response_token) = response_token {
+                        *consistency_token = Some(response_token);
                     }
                     return Ok(decoded);
                 }
@@ -653,10 +653,10 @@ fn response_retry_delay(headers: &reqwest::header::HeaderMap, fallback: Duration
         .unwrap_or(fallback)
 }
 
-fn d1_bookmark_from_headers(
+fn consistency_token_from_headers(
     headers: &reqwest::header::HeaderMap,
 ) -> Result<Option<String>, RemoteClientError> {
-    let mut values = headers.get_all(protocol::D1_BOOKMARK_HEADER).iter();
+    let mut values = headers.get_all(protocol::CONSISTENCY_TOKEN_HEADER).iter();
     let Some(value) = values.next() else {
         return Ok(None);
     };
@@ -664,16 +664,16 @@ fn d1_bookmark_from_headers(
         return Err(RemoteClientError::InvalidResponse);
     }
 
-    let bookmark = value
+    let token = value
         .to_str()
         .map_err(|_| RemoteClientError::InvalidResponse)?;
-    if bookmark.is_empty() {
+    if token.is_empty() {
         return Ok(None);
     }
-    if !protocol::is_valid_d1_bookmark(bookmark) {
+    if !protocol::is_valid_consistency_token(token) {
         return Err(RemoteClientError::InvalidResponse);
     }
-    Ok(Some(bookmark.to_owned()))
+    Ok(Some(token.to_owned()))
 }
 
 async fn response_error(response: Response) -> RemoteClientError {

--- a/examples/tact-memory-cloudflare/README.md
+++ b/examples/tact-memory-cloudflare/README.md
@@ -69,13 +69,13 @@ operators can reduce or migrate the corpus without editing D1 directly.
 
 ## Read replication
 
-The Worker opens a first-unconstrained D1 session for a request without a bookmark. After read
-replication is enabled on the database, scan corpus queries, list, and export may be served by a
-replica. A D1-backed request without a bookmark can observe a stale snapshot, including temporarily
-missing a recent write or returning a recently deleted record. Full record reads and mutations
-update durable state and remain primary-bound. The remote client carries each returned D1 bookmark
-into its next request, so one client and its clones form a monotonic logical session across requests
-and observe their successful writes.
+The Worker opens a first-unconstrained D1 session for a request without a consistency token. After
+read replication is enabled on the database, scan corpus queries, list, and export may be served by
+a replica. A D1-backed request without a consistency token can observe a stale snapshot, including
+temporarily missing a recent write or returning a recently deleted record. Full record reads and
+mutations update durable state and remain primary-bound. The Worker exposes each D1 bookmark as an
+opaque consistency token that the remote client carries into its next request, so one client and
+its clones form a monotonic logical session across requests and observe their successful writes.
 
 ## Deployment
 

--- a/examples/tact-memory-cloudflare/README.md
+++ b/examples/tact-memory-cloudflare/README.md
@@ -67,6 +67,16 @@ Choose limits from observed corpus size and Worker CPU usage. When the corpus ex
 bound, scans return a storage-capacity error. Export and mutation operations remain available so
 operators can reduce or migrate the corpus without editing D1 directly.
 
+## Read replication
+
+The Worker opens a first-unconstrained D1 session for a request without a bookmark. After read
+replication is enabled on the database, scan corpus queries, list, and export may be served by a
+replica. A D1-backed request without a bookmark can observe a stale snapshot, including temporarily
+missing a recent write or returning a recently deleted record. Full record reads and mutations
+update durable state and remain primary-bound. The remote client carries each returned D1 bookmark
+into its next request, so one client and its clones form a monotonic logical session across requests
+and observe their successful writes.
+
 ## Deployment
 
 Create the D1 database:

--- a/examples/tact-memory-cloudflare/README.md
+++ b/examples/tact-memory-cloudflare/README.md
@@ -69,13 +69,13 @@ operators can reduce or migrate the corpus without editing D1 directly.
 
 ## Read replication
 
-The Worker opens a first-unconstrained D1 session for a request without a consistency token. After
-read replication is enabled on the database, scan corpus queries, list, and export may be served by
-a replica. A D1-backed request without a consistency token can observe a stale snapshot, including
-temporarily missing a recent write or returning a recently deleted record. Full record reads and
-mutations update durable state and remain primary-bound. The Worker exposes each D1 bookmark as an
-opaque consistency token that the remote client carries into its next request, so one client and
-its clones form a monotonic logical session across requests and observe their successful writes.
+The Worker opens a first-unconstrained D1 session for a request without a bookmark. After read
+replication is enabled on the database, scan corpus queries, list, and export may be served by a
+replica. A D1-backed request without a bookmark can observe a stale snapshot, including temporarily
+missing a recent write or returning a recently deleted record. Full record reads and mutations
+update durable state and remain primary-bound. The remote client carries each returned bookmark
+into its next request, so one client and its clones form a monotonic logical session across requests
+and observe their successful writes.
 
 ## Deployment
 

--- a/examples/tact-memory-cloudflare/src/lib.rs
+++ b/examples/tact-memory-cloudflare/src/lib.rs
@@ -39,22 +39,24 @@ pub async fn fetch(
 ) -> Result<axum::response::Response> {
     initialize_tracing();
 
-    let bookmark_headers = request.headers().get_all(protocol::D1_BOOKMARK_HEADER);
-    let mut bookmarks = bookmark_headers.iter();
-    let bookmark = match (bookmarks.next(), bookmarks.next()) {
+    let token_headers = request
+        .headers()
+        .get_all(protocol::CONSISTENCY_TOKEN_HEADER);
+    let mut tokens = token_headers.iter();
+    let consistency_token = match (tokens.next(), tokens.next()) {
         (None, None) => None,
         (Some(value), None) => match value.to_str() {
-            Ok(value) if protocol::is_valid_d1_bookmark(value) => Some(value.to_owned()),
+            Ok(value) if protocol::is_valid_consistency_token(value) => Some(value.to_owned()),
             _ => return Ok(bad_request()),
         },
         _ => return Ok(bad_request()),
     };
 
-    // A new session may begin on a stale nearby replica; a supplied bookmark resumes at least as
-    // fresh as the client's preceding response. D1 forwards mutations to the primary.
+    // A new session may begin on a stale nearby replica; a supplied consistency token resumes at
+    // least as fresh as the client's preceding response. D1 forwards mutations to the primary.
     let database = environment.d1(DATABASE_BINDING)?;
-    let session = Arc::new(match bookmark.as_deref() {
-        Some(bookmark) => database.with_session(Some(bookmark))?,
+    let session = Arc::new(match consistency_token.as_deref() {
+        Some(token) => database.with_session(Some(token))?,
         None => database.with_session_constraint(D1SessionConstraint::FirstUnconstrained)?,
     });
 
@@ -77,13 +79,13 @@ pub async fn fetch(
         .await
         .map_err(worker_error)?;
     if let Some(bookmark) = session.get_bookmark()? {
-        if !protocol::is_valid_d1_bookmark(&bookmark) {
+        if !protocol::is_valid_consistency_token(&bookmark) {
             return Err(invalid_d1_bookmark());
         }
         let value = HeaderValue::from_str(&bookmark).map_err(|_| invalid_d1_bookmark())?;
         response
             .headers_mut()
-            .insert(protocol::D1_BOOKMARK_HEADER, value);
+            .insert(protocol::CONSISTENCY_TOKEN_HEADER, value);
     }
     Ok(response)
 }

--- a/examples/tact-memory-cloudflare/src/lib.rs
+++ b/examples/tact-memory-cloudflare/src/lib.rs
@@ -8,15 +8,23 @@ mod config;
 mod store;
 
 use auth::{CREDENTIALS_SECRET, parse_credentials};
-use axum::body::Body;
+use axum::{
+    Json,
+    body::Body,
+    http::{HeaderValue, StatusCode},
+    response::IntoResponse,
+};
 use config::scan_budget;
 use std::sync::{Arc, Once};
 use store::CloudflareMemoryStore;
-use tact_memory::server::MemoryServer;
+use tact_memory::server::{
+    MemoryServer,
+    protocol::{self, ErrorResponse, RemoteErrorCode},
+};
 use tower::ServiceExt;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_web::{MakeConsoleWriter, performance_layer};
-use worker::{Context, Env, HttpRequest, Result, event};
+use worker::{Context, D1SessionConstraint, Env, HttpRequest, Result, event};
 use zeroize::Zeroizing;
 
 const DATABASE_BINDING: &str = "DB";
@@ -30,22 +38,68 @@ pub async fn fetch(
     _context: Context,
 ) -> Result<axum::response::Response> {
     initialize_tracing();
-    let database = Arc::new(environment.d1(DATABASE_BINDING)?);
+
+    let bookmark_headers = request.headers().get_all(protocol::D1_BOOKMARK_HEADER);
+    let mut bookmarks = bookmark_headers.iter();
+    let bookmark = match (bookmarks.next(), bookmarks.next()) {
+        (None, None) => None,
+        (Some(value), None) => match value.to_str() {
+            Ok(value) if protocol::is_valid_d1_bookmark(value) => Some(value.to_owned()),
+            _ => return Ok(bad_request()),
+        },
+        _ => return Ok(bad_request()),
+    };
+
+    // A new session may begin on a stale nearby replica; a supplied bookmark resumes at least as
+    // fresh as the client's preceding response. D1 forwards mutations to the primary.
+    let database = environment.d1(DATABASE_BINDING)?;
+    let session = Arc::new(match bookmark.as_deref() {
+        Some(bookmark) => database.with_session(Some(bookmark))?,
+        None => database.with_session_constraint(D1SessionConstraint::FirstUnconstrained)?,
+    });
+
     // Cloudflare owns another non-zeroizing copy behind `Secret`. This crate zeroizes only the
     // Rust string returned by the binding and every credential copy it constructs.
     let document = Zeroizing::new(environment.secret(CREDENTIALS_SECRET)?.to_string());
     let credentials = parse_credentials(document).map_err(worker_error)?;
     let scan_budget = scan_budget(&environment).map_err(worker_error)?;
+    let store_session = Arc::clone(&session);
     let server = MemoryServer::new(
-        move |namespace| CloudflareMemoryStore::new(Arc::clone(&database), namespace, scan_budget),
+        move |namespace| {
+            CloudflareMemoryStore::new(Arc::clone(&store_session), namespace, scan_budget)
+        },
         credentials,
     )
     .map_err(worker_error)?;
-    server
+    let mut response = server
         .router()
         .oneshot(request.map(Body::new))
         .await
-        .map_err(worker_error)
+        .map_err(worker_error)?;
+    if let Some(bookmark) = session.get_bookmark()? {
+        if !protocol::is_valid_d1_bookmark(&bookmark) {
+            return Err(invalid_d1_bookmark());
+        }
+        let value = HeaderValue::from_str(&bookmark).map_err(|_| invalid_d1_bookmark())?;
+        response
+            .headers_mut()
+            .insert(protocol::D1_BOOKMARK_HEADER, value);
+    }
+    Ok(response)
+}
+
+fn bad_request() -> axum::response::Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            code: RemoteErrorCode::BadRequest,
+        }),
+    )
+        .into_response()
+}
+
+fn invalid_d1_bookmark() -> worker::Error {
+    worker::Error::RustError("D1 returned an invalid session bookmark".to_owned())
 }
 
 fn initialize_tracing() {

--- a/examples/tact-memory-cloudflare/src/lib.rs
+++ b/examples/tact-memory-cloudflare/src/lib.rs
@@ -39,6 +39,7 @@ pub async fn fetch(
 ) -> Result<axum::response::Response> {
     initialize_tracing();
 
+    // A request can resume only one D1 session, so reject malformed or duplicate bookmarks.
     let bookmark_headers = request.headers().get_all(protocol::BOOKMARK_HEADER);
     let mut bookmarks = bookmark_headers.iter();
     let bookmark = match (bookmarks.next(), bookmarks.next()) {

--- a/examples/tact-memory-cloudflare/src/lib.rs
+++ b/examples/tact-memory-cloudflare/src/lib.rs
@@ -39,24 +39,22 @@ pub async fn fetch(
 ) -> Result<axum::response::Response> {
     initialize_tracing();
 
-    let token_headers = request
-        .headers()
-        .get_all(protocol::CONSISTENCY_TOKEN_HEADER);
-    let mut tokens = token_headers.iter();
-    let consistency_token = match (tokens.next(), tokens.next()) {
+    let bookmark_headers = request.headers().get_all(protocol::BOOKMARK_HEADER);
+    let mut bookmarks = bookmark_headers.iter();
+    let bookmark = match (bookmarks.next(), bookmarks.next()) {
         (None, None) => None,
         (Some(value), None) => match value.to_str() {
-            Ok(value) if protocol::is_valid_consistency_token(value) => Some(value.to_owned()),
+            Ok(value) if protocol::is_valid_bookmark(value) => Some(value.to_owned()),
             _ => return Ok(bad_request()),
         },
         _ => return Ok(bad_request()),
     };
 
-    // A new session may begin on a stale nearby replica; a supplied consistency token resumes at
-    // least as fresh as the client's preceding response. D1 forwards mutations to the primary.
+    // A new session may begin on a stale nearby replica; a supplied bookmark resumes at least as
+    // fresh as the client's preceding response. D1 forwards mutations to the primary.
     let database = environment.d1(DATABASE_BINDING)?;
-    let session = Arc::new(match consistency_token.as_deref() {
-        Some(token) => database.with_session(Some(token))?,
+    let session = Arc::new(match bookmark.as_deref() {
+        Some(bookmark) => database.with_session(Some(bookmark))?,
         None => database.with_session_constraint(D1SessionConstraint::FirstUnconstrained)?,
     });
 
@@ -79,13 +77,13 @@ pub async fn fetch(
         .await
         .map_err(worker_error)?;
     if let Some(bookmark) = session.get_bookmark()? {
-        if !protocol::is_valid_consistency_token(&bookmark) {
+        if !protocol::is_valid_bookmark(&bookmark) {
             return Err(invalid_d1_bookmark());
         }
         let value = HeaderValue::from_str(&bookmark).map_err(|_| invalid_d1_bookmark())?;
         response
             .headers_mut()
-            .insert(protocol::CONSISTENCY_TOKEN_HEADER, value);
+            .insert(protocol::BOOKMARK_HEADER, value);
     }
     Ok(response)
 }

--- a/examples/tact-memory-cloudflare/src/store.rs
+++ b/examples/tact-memory-cloudflare/src/store.rs
@@ -17,7 +17,7 @@ use tact_memory::{
 };
 use thiserror::Error;
 use worker::{
-    D1Database, Date,
+    D1DatabaseSession, Date,
     d1::{D1PreparedStatement, D1Result, D1Type},
     send::SendFuture,
 };
@@ -25,6 +25,7 @@ use worker::{
 const RECORD_COLUMNS: &str = "memories.namespace AS namespace, CAST(memories.id AS TEXT) AS id, CAST(memories.version AS TEXT) AS version, memories.content AS content, CAST(memories.created_at_ms AS TEXT) AS created_at_ms, CAST(memories.updated_at_ms AS TEXT) AS updated_at_ms, CAST(memories.last_scanned_at_ms AS TEXT) AS last_scanned_at_ms, CAST(memories.scan_count AS TEXT) AS scan_count, CAST(memories.last_used_at_ms AS TEXT) AS last_used_at_ms, CAST(memories.use_count AS TEXT) AS use_count, CAST(memories.probation_until_ms AS TEXT) AS probation_until_ms";
 const PRUNE_SQL: &str =
     "DELETE FROM memories WHERE probation_until_ms <= CAST(? AS INTEGER) AND use_count = 0";
+const VISIBLE_RECORD_SQL: &str = "(memories.probation_until_ms IS NULL OR memories.probation_until_ms > CAST(? AS INTEGER) OR memories.use_count != 0)";
 
 /// Deployment-selected bound for exact Worker-side BM25 retrieval.
 #[derive(Clone, Copy, Debug)]
@@ -36,21 +37,21 @@ pub(crate) struct ScanBudget {
 /// Namespace-bound shared memory backed by Cloudflare D1.
 #[derive(Clone, Debug)]
 pub(crate) struct CloudflareMemoryStore {
-    database: Arc<D1Database>,
+    session: Arc<D1DatabaseSession>,
     namespace: Arc<str>,
     scan_budget: ScanBudget,
 }
 
 impl CloudflareMemoryStore {
-    /// Binds `database` mutations to `namespace`; reads remain shared.
+    /// Binds a request-scoped D1 session to one writer namespace; reads remain shared.
     pub(crate) fn new(
-        database: impl Into<Arc<D1Database>>,
-        namespace: impl Into<String>,
+        session: Arc<D1DatabaseSession>,
+        namespace: String,
         scan_budget: ScanBudget,
     ) -> Self {
         Self {
-            database: database.into(),
-            namespace: Arc::from(namespace.into()),
+            session,
+            namespace: Arc::from(namespace),
             scan_budget,
         }
     }
@@ -61,7 +62,7 @@ impl CloudflareMemoryStore {
         sql: impl Into<String>,
         values: &[D1Type<'_>],
     ) -> Result<D1PreparedStatement, MemoryError> {
-        self.database
+        self.session
             .prepare(sql)
             .bind_refs(values)
             .map_err(MessageError::backend)
@@ -76,7 +77,7 @@ impl CloudflareMemoryStore {
         statements: Vec<D1PreparedStatement>,
     ) -> Result<Vec<D1Result>, MemoryError> {
         let results = self
-            .database
+            .session
             .batch(statements)
             .await
             .map_err(|error| MemoryError::unavailable(MessageError(error.to_string())))?;
@@ -102,45 +103,46 @@ impl MemoryStore for CloudflareMemoryStore {
                     maximum_bytes: limits.query_bytes,
                 });
             }
-            let now = current_time_ms();
+            let now = current_time_ms().to_string();
             let scan_budget = store.scan_budget;
+            let corpus_size_sql = format!(
+                "SELECT COUNT(*) AS record_count, COALESCE(SUM(length(CAST(content AS BLOB))), 0) AS content_bytes FROM memories WHERE {VISIBLE_RECORD_SQL}"
+            );
             let corpus_sql = format!(
-                "SELECT {RECORD_COLUMNS} FROM memories WHERE (SELECT COUNT(*) FROM memories) <= {} AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories) <= {} ORDER BY namespace, id",
+                "SELECT {RECORD_COLUMNS} FROM memories WHERE {VISIBLE_RECORD_SQL} AND (SELECT COUNT(*) FROM memories WHERE {VISIBLE_RECORD_SQL}) <= {} AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE {VISIBLE_RECORD_SQL}) <= {} ORDER BY namespace, id",
                 scan_budget.records, scan_budget.content_bytes
             );
             let statements = vec![
-                store.statement(PRUNE_SQL, &[D1Type::Text(&now.to_string())])?,
-                store.database.prepare("SELECT COUNT(*) AS record_count, COALESCE(SUM(length(CAST(content AS BLOB))), 0) AS content_bytes FROM memories"),
-                store.database.prepare(corpus_sql),
+                store.statement(corpus_size_sql, &[D1Type::Text(&now)])?,
+                store.statement(
+                    corpus_sql,
+                    &[D1Type::Text(&now), D1Type::Text(&now), D1Type::Text(&now)],
+                )?,
             ];
             let results = store.batch(statements).await?;
-            let corpus = results[1].one::<CorpusRow>()?;
+            let corpus = results[0].one::<CorpusRow>()?;
             if corpus.record_count > scan_budget.records
                 || corpus.content_bytes > scan_budget.content_bytes
             {
                 return Err(MemoryError::StorageCapacity);
             }
-            let records = results[2].records()?;
+            let records = results[1].records()?;
             let scan = MemoryScan::rank(&query, &records, limit.min(limits.scan_results));
-            if !scan.candidates.is_empty() {
-                let updates = scan
-                    .candidates
-                    .iter()
-                    .map(|candidate| {
-                        let namespace = candidate.key.namespace.as_deref().unwrap_or_default();
-                        store.statement(
-                            "UPDATE memories SET last_scanned_at_ms = CAST(? AS INTEGER), scan_count = CASE WHEN scan_count < 9223372036854775807 THEN scan_count + 1 ELSE scan_count END WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER)",
-                            &[
-                                D1Type::Text(&now.to_string()),
-                                D1Type::Text(namespace),
-                                D1Type::Text(&candidate.key.id.to_string()),
-                                D1Type::Text(&candidate.key.version.to_string()),
-                            ],
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                store.batch(updates).await?;
+            let mut updates = Vec::with_capacity(scan.candidates.len() + 1);
+            updates.push(store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?);
+            for candidate in &scan.candidates {
+                let namespace = candidate.key.namespace.as_deref().unwrap_or_default();
+                updates.push(store.statement(
+                    "UPDATE memories SET last_scanned_at_ms = CAST(? AS INTEGER), scan_count = CASE WHEN scan_count < 9223372036854775807 THEN scan_count + 1 ELSE scan_count END WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER)",
+                    &[
+                        D1Type::Text(&now),
+                        D1Type::Text(namespace),
+                        D1Type::Text(&candidate.key.id.to_string()),
+                        D1Type::Text(&candidate.key.version.to_string()),
+                    ],
+                )?);
             }
+            store.batch(updates).await?;
             Ok(scan)
         })
     }
@@ -180,16 +182,13 @@ impl MemoryStore for CloudflareMemoryStore {
         SendFuture::new(async move {
             let now = current_time_ms().to_string();
             let sql = format!(
-                "SELECT {RECORD_COLUMNS} FROM memories ORDER BY namespace, id LIMIT {}",
+                "SELECT {RECORD_COLUMNS} FROM memories WHERE {VISIBLE_RECORD_SQL} ORDER BY namespace, id LIMIT {}",
                 MemoryLimits::PRODUCTION.records
             );
             let results = store
-                .batch(vec![
-                    store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
-                    store.database.prepare(sql),
-                ])
+                .batch(vec![store.statement(sql, &[D1Type::Text(&now)])?])
                 .await?;
-            results[1].records()
+            results[0].records()
         })
     }
 
@@ -290,26 +289,24 @@ impl MemoryStore for CloudflareMemoryStore {
                 .map_or("0".to_owned(), |value| value.id.to_string());
             let bounded = limit.clamp(1, protocol::MAX_EXPORT_PAGE_RECORDS);
             let sql = format!(
-                "SELECT {RECORD_COLUMNS} FROM memories WHERE (? = 'null' OR namespace IN (SELECT value FROM json_each(?))) AND (? = '0' OR namespace > ? OR (namespace = ? AND id > CAST(? AS INTEGER))) ORDER BY namespace, id LIMIT {}",
+                "SELECT {RECORD_COLUMNS} FROM memories WHERE {VISIBLE_RECORD_SQL} AND (? = 'null' OR namespace IN (SELECT value FROM json_each(?))) AND (? = '0' OR namespace > ? OR (namespace = ? AND id > CAST(? AS INTEGER))) ORDER BY namespace, id LIMIT {}",
                 bounded + 1
             );
             let results = store
-                .batch(vec![
-                    store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?,
-                    store.statement(
-                        sql,
-                        &[
-                            D1Type::Text(&selected),
-                            D1Type::Text(&selected),
-                            D1Type::Text(has_cursor),
-                            D1Type::Text(cursor_namespace),
-                            D1Type::Text(cursor_namespace),
-                            D1Type::Text(&cursor_id),
-                        ],
-                    )?,
-                ])
+                .batch(vec![store.statement(
+                    sql,
+                    &[
+                        D1Type::Text(&now),
+                        D1Type::Text(&selected),
+                        D1Type::Text(&selected),
+                        D1Type::Text(has_cursor),
+                        D1Type::Text(cursor_namespace),
+                        D1Type::Text(cursor_namespace),
+                        D1Type::Text(&cursor_id),
+                    ],
+                )?])
                 .await?;
-            let mut records = results[1].records()?;
+            let mut records = results[0].records()?;
             let has_more = records.len() > bounded;
             records.truncate(bounded);
             let next = has_more.then(|| {


### PR DESCRIPTION
## Summary

- make scan corpus loading, list, and export replica-eligible while keeping stateful reads and mutations primary-bound
- carry bounded opaque bookmarks across requests so one remote client and its clones retain monotonic reads and read their writes; the Cloudflare Worker maps these protocol bookmarks to D1 bookmarks
- hide expired probation rows from stale replica results and prune them during primary work

The Worker uses one request-scoped D1 session, starts without a freshness constraint when no bookmark is present, and resumes from the client-provided bookmark otherwise.