### PR TITLE
feat(memory): split remote scans into ours and theirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,10 @@ criteria.
 To share memory with a team, configure an authenticated remote backend. Each person uses a distinct
 namespace and may receive either writer or read-only credentials. Tact chooses exactly one backend
 for each runtime: remote inside a configured workspace root or a linked worktree from one, and local
-outside all configured roots.
+outside all configured roots. An agent-facing remote scan makes one bounded request for the
+authenticated namespace and a second for all other visible namespaces, presenting the results as
+`ours` and `theirs`. Each candidate key identifies its author, leaving the agent to decide which
+evidence is most useful.
 
 ```toml
 [memory.remote]

--- a/bin/tact/src/tui/components/transcript/tool/memory.rs
+++ b/bin/tact/src/tui/components/transcript/tool/memory.rs
@@ -3,7 +3,7 @@ use crate::tui::{theme::Theme, transcript::ToolEntry};
 use ratatui::{style::Style, text::Line};
 use serde_json::{Map, Value};
 
-const MAX_SCAN_CANDIDATES: usize = 8;
+const MAX_SCAN_CANDIDATES_PER_GROUP: usize = 5;
 const MAX_PREVIEW_WIDTH: u16 = 240;
 
 pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
@@ -79,8 +79,7 @@ enum ResultValue<'a> {
     Failed,
     Scan {
         backend: Option<Backend>,
-        abstained: bool,
-        candidates: Vec<Candidate<'a>>,
+        candidates: ScanCandidates<'a>,
     },
     Read {
         backend: Option<Backend>,
@@ -114,13 +113,7 @@ impl<'a> ResultValue<'a> {
         match expected_operation {
             "scan" => Some(Self::Scan {
                 backend: Backend::parse(result.get("backend")),
-                abstained: result.get("abstained")?.as_bool()?,
-                candidates: result
-                    .get("candidates")?
-                    .as_array()?
-                    .iter()
-                    .map(Candidate::parse)
-                    .collect::<Option<Vec<_>>>()?,
+                candidates: ScanCandidates::parse(result)?,
             }),
             "read" => Some(Self::Read {
                 backend: Backend::parse(result.get("backend")),
@@ -143,6 +136,32 @@ impl<'a> ResultValue<'a> {
             _ => None,
         }
     }
+}
+
+struct ScanCandidates<'a> {
+    ours: Vec<Candidate<'a>>,
+    theirs: Vec<Candidate<'a>>,
+}
+
+impl<'a> ScanCandidates<'a> {
+    fn parse(result: &'a Value) -> Option<Self> {
+        Some(Self {
+            ours: parse_candidates(result.get("ours")?)?,
+            theirs: parse_candidates(result.get("theirs")?)?,
+        })
+    }
+
+    fn total(&self) -> usize {
+        self.ours.len().saturating_add(self.theirs.len())
+    }
+}
+
+fn parse_candidates(value: &Value) -> Option<Vec<Candidate<'_>>> {
+    value
+        .as_array()?
+        .iter()
+        .map(Candidate::parse)
+        .collect::<Option<Vec<_>>>()
 }
 
 #[derive(Clone)]
@@ -280,17 +299,16 @@ fn scan(
 ) -> Presentation {
     let ResultValue::Scan {
         backend,
-        abstained,
         candidates,
     } = result
     else {
         return Presentation::new("Memory scan", query);
     };
-    let outcome = if abstained {
-        "abstained".to_owned()
-    } else {
-        count_label(candidates.len(), "candidate", "candidates")
-    };
+    let outcome = format!(
+        "{} ours · {} theirs",
+        candidates.ours.len(),
+        candidates.theirs.len()
+    );
     let presentation =
         completed_presentation(backend.as_ref(), "scan", "Memory scan", query.to_owned())
             .outcome(outcome);
@@ -298,9 +316,46 @@ fn scan(
         return presentation;
     }
 
-    let shown = candidates.len().min(MAX_SCAN_CANDIDATES);
     let mut presentation = presentation;
-    for candidate in candidates.iter().take(shown) {
+    presentation = append_scan_group(presentation, "Ours", &candidates.ours, width, theme);
+    presentation = append_scan_group(presentation, "Theirs", &candidates.theirs, width, theme);
+    let shown = candidates
+        .ours
+        .len()
+        .min(MAX_SCAN_CANDIDATES_PER_GROUP)
+        .saturating_add(candidates.theirs.len().min(MAX_SCAN_CANDIDATES_PER_GROUP));
+    let total = candidates.total();
+    let footer = if shown < total {
+        format!("{shown} of {total} candidates")
+    } else {
+        count_label(total, "candidate", "candidates")
+    };
+    presentation.footer(footer)
+}
+
+fn append_scan_group<'a>(
+    mut presentation: Presentation,
+    label: &str,
+    candidates: &'a [Candidate<'a>],
+    width: u16,
+    theme: &Theme,
+) -> Presentation {
+    presentation = presentation.selectable_plain(label, width, Style::default().fg(theme.accent()));
+    append_candidates(
+        presentation,
+        candidates.iter().take(MAX_SCAN_CANDIDATES_PER_GROUP),
+        width,
+        theme,
+    )
+}
+
+fn append_candidates<'a>(
+    mut presentation: Presentation,
+    candidates: impl Iterator<Item = &'a Candidate<'a>>,
+    width: u16,
+    theme: &Theme,
+) -> Presentation {
+    for candidate in candidates {
         let label = format!(
             "{} · score {}",
             candidate.key.display(),
@@ -312,14 +367,7 @@ fn scan(
         presentation =
             presentation.selectable_plain(&preview, width, Style::default().fg(theme.text()));
     }
-    let footer = if abstained {
-        "memory scan abstained".to_owned()
-    } else if shown < candidates.len() {
-        format!("{shown} of {} candidates", candidates.len())
-    } else {
-        count_label(candidates.len(), "candidate", "candidates")
-    };
-    presentation.footer(footer)
+    presentation
 }
 
 fn read(
@@ -568,9 +616,14 @@ mod tests {
                 memory(
                     json!({"operation": "scan", "query": "Rust style", "limit": 4}),
                     ToolState::Succeeded,
-                    Some(json!({"operation": "scan", "abstained": true, "candidates": []})),
+                    Some(json!({
+                        "operation": "scan",
+                        "backend": {"source": "local", "namespace": null, "role": null},
+                        "ours": [],
+                        "theirs": []
+                    })),
                 ),
-                "Memory scan  Rust style · abstained",
+                "Memory scan · local · Rust style · 0 ours · 0 theirs",
             ),
             (
                 memory(
@@ -680,7 +733,7 @@ mod tests {
     }
 
     #[test]
-    fn completed_results_label_the_backend_even_when_empty_or_abstaining() {
+    fn completed_results_label_the_backend_even_when_empty() {
         let cases = [
             (
                 memory(
@@ -689,11 +742,11 @@ mod tests {
                     Some(json!({
                         "operation": "scan",
                         "backend": {"source": "local", "namespace": null, "role": null},
-                        "abstained": true,
-                        "candidates": []
+                        "ours": [],
+                        "theirs": []
                     })),
                 ),
-                "Memory scan · local · style · abstained",
+                "Memory scan · local · style · 0 ours · 0 theirs",
             ),
             (
                 memory(
@@ -713,6 +766,41 @@ mod tests {
             let rendered = text(&render(&tool, 100, &Theme::default()));
             assert!(rendered.contains(expected), "{rendered}");
         }
+    }
+
+    #[test]
+    fn remote_scan_presents_separately_retrieved_ours_and_theirs() {
+        let namespace_candidates = |namespace: &str| {
+            (1..=5)
+                .map(|id| {
+                    json!({
+                        "key": {"namespace": namespace, "id": id, "version": 1},
+                        "preview": format!("{namespace} guidance {id}"),
+                        "score": 1.0 / f64::from(id)
+                    })
+                })
+                .collect::<Vec<_>>()
+        };
+        let tool = memory(
+            json!({"operation": "scan", "query": "guidance"}),
+            ToolState::Succeeded,
+            Some(json!({
+                "operation": "scan",
+                "backend": {"source": "remote", "namespace": "alice", "role": "writer"},
+                "ours": namespace_candidates("alice"),
+                "theirs": namespace_candidates("bob")
+            })),
+        );
+
+        let collapsed = text(&render(&tool, 100, &Theme::default()));
+        assert!(collapsed.contains("5 ours · 5 theirs"), "{collapsed}");
+
+        let expanded = text(&render_expanded(&tool, 100, &Theme::default()));
+        assert!(expanded.contains("Ours"), "{expanded}");
+        assert!(expanded.contains("Theirs"), "{expanded}");
+        assert!(expanded.contains("alice:1@v1"), "{expanded}");
+        assert!(expanded.contains("bob:1@v1"), "{expanded}");
+        assert!(expanded.contains("10 candidates"), "{expanded}");
     }
 
     #[test]
@@ -744,19 +832,13 @@ mod tests {
     }
 
     #[test]
-    fn backendless_legacy_results_and_pending_calls_keep_generic_titles() {
-        let legacy = memory(
-            json!({"operation": "scan", "query": "style"}),
-            ToolState::Succeeded,
-            Some(json!({"operation": "scan", "abstained": false, "candidates": []})),
-        );
+    fn pending_calls_keep_generic_titles() {
         let pending = memory(
             json!({"operation": "scan", "query": "style"}),
             ToolState::Running,
             None,
         );
 
-        assert!(text(&render(&legacy, 100, &Theme::default())).contains("Memory scan  style"));
         assert!(text(&render(&pending, 100, &Theme::default())).contains("Memory scan  style"));
     }
 
@@ -824,7 +906,21 @@ mod tests {
             memory(
                 json!({"operation": "scan", "query": "style"}),
                 ToolState::Succeeded,
-                Some(json!({"operation": "scan", "candidates": "invalid"})),
+                Some(json!({
+                    "operation": "scan",
+                    "backend": {"source": "local", "namespace": null, "role": null},
+                    "candidates": []
+                })),
+            ),
+            memory(
+                json!({"operation": "scan", "query": "style"}),
+                ToolState::Succeeded,
+                Some(json!({
+                    "operation": "scan",
+                    "backend": {"source": "local", "namespace": null, "role": null},
+                    "ours": "invalid",
+                    "theirs": []
+                })),
             ),
         ];
 
@@ -864,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn expanded_scan_is_bounded_and_whitelists_candidate_fields() {
+    fn expanded_scan_groups_are_bounded_and_whitelist_candidate_fields() {
         let candidates = (0..12)
             .map(|id| {
                 json!({
@@ -878,16 +974,21 @@ mod tests {
         let tool = memory(
             json!({"operation": "scan", "query": "style"}),
             ToolState::Succeeded,
-            Some(json!({"operation": "scan", "abstained": false, "candidates": candidates})),
+            Some(json!({
+                "operation": "scan",
+                "backend": {"source": "remote", "namespace": "alice", "role": "writer"},
+                "ours": candidates,
+                "theirs": []
+            })),
         );
 
         let rendered = text(&render_expanded(&tool, 80, &Theme::default()));
 
         assert!(rendered.contains("0@v3 · score 0.875"));
-        assert!(rendered.contains("7@v3 · score 0.875"));
-        assert!(!rendered.contains("8@v3 · score"));
+        assert!(rendered.contains("4@v3 · score 0.875"));
+        assert!(!rendered.contains("5@v3 · score"));
         assert!(!rendered.contains("must not be shown"));
-        assert!(rendered.contains("8 of 12 candidates"));
+        assert!(rendered.contains("5 of 12 candidates"));
         assert!(!rendered.contains(&"x".repeat(241)));
 
         let source = render_layout(&tool, None, 80, &Theme::default(), true)
@@ -895,7 +996,7 @@ mod tests {
             .expect("scan results should be selectable");
         assert!(source.contains("0@v3 · score 0.875"));
         assert!(source.contains("preview-0"));
-        assert!(!source.contains("8@v3 · score"));
+        assert!(!source.contains("5@v3 · score"));
         assert!(!source.contains("must not be shown"));
         assert!(!source.contains(&"x".repeat(241)));
     }

--- a/crates/memory/README.md
+++ b/crates/memory/README.md
@@ -19,6 +19,11 @@ The crate exposes four integration boundaries:
 - `MemoryTool` exposes explicit scan, read, put, and delete operations to Nanocodex sessions under
   an application-provided mutation authority.
 
+Each `MemoryStore` scan request returns one bounded candidate vector selected by a
+`MemoryNamespaceFilter`. The agent-facing remote scan makes separate requests for the authenticated
+namespace and all other visible namespaces, then exposes them as `ours` and `theirs`. Candidate keys
+preserve ownership because the requests' BM25 scores are relative to different corpora.
+
 Feature flags separate the local store, remote client, server, and Nanocodex tool integrations.
 Default features enable the complete native client, local, server, and tool surface; server-only
 deployments can select `server` without native-only dependencies.

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -4,7 +4,7 @@
 ///
 /// Route paths and session negotiation derive from this single value. Increment it only when
 /// clients and servers must intentionally stop interoperating.
-pub const VERSION: u32 = 1;
+pub const VERSION: u32 = 2;
 
 mod model;
 mod retrieval;
@@ -17,14 +17,14 @@ mod tool;
 
 pub use model::{
     MemoryAccess, MemoryCandidate, MemoryImportReport, MemoryKey, MemoryLimits, MemoryRecord,
-    MemoryScan, MemorySource, normalize_identity,
+    MemorySource, normalize_identity,
 };
 pub use server::protocol::RemoteRole;
 #[cfg(feature = "local")]
 pub use store::LocalMemoryStore;
 #[cfg(all(feature = "client", feature = "local"))]
 pub use store::SelectedMemoryStore;
-pub use store::{MemoryError, MemoryStore};
+pub use store::{MemoryError, MemoryNamespaceFilter, MemoryStore};
 #[cfg(feature = "client")]
 pub use store::{RemoteClientError, RemoteMemoryClient, RemoteToken};
 #[cfg(feature = "tool")]

--- a/crates/memory/src/model.rs
+++ b/crates/memory/src/model.rs
@@ -76,26 +76,17 @@ pub struct MemoryCandidate {
     pub score: f64,
 }
 
-/// Result of a semantic memory scan.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct MemoryScan {
-    /// Whether retrieval intentionally returned no candidates.
-    pub abstained: bool,
-    /// Candidates in descending retrieval rank.
-    pub candidates: Vec<MemoryCandidate>,
-}
-
-impl MemoryScan {
+impl MemoryCandidate {
     /// Ranks an in-memory corpus with Tact's deterministic BM25 retrieval.
     ///
     /// Server backends that keep a bounded corpus in memory can use this to match local search
     /// tokenization, scoring, tie-breaking, and preview behavior.
-    pub fn rank(query: &str, memories: &[MemoryRecord], limit: usize) -> Self {
-        let candidates = crate::retrieval::rank(query, memories, limit);
-        Self {
-            abstained: candidates.is_empty(),
-            candidates,
-        }
+    pub fn rank<'a>(
+        query: &str,
+        memories: impl IntoIterator<Item = &'a MemoryRecord>,
+        limit: usize,
+    ) -> Vec<Self> {
+        crate::retrieval::rank(query, memories, limit)
     }
 }
 
@@ -110,7 +101,7 @@ pub struct MemoryLimits {
     pub total_content_bytes: usize,
     /// Maximum local SQLite database size.
     pub database_bytes: usize,
-    /// Maximum candidates returned by one scan.
+    /// Maximum candidates returned by one scan request.
     pub scan_results: usize,
     /// Maximum UTF-8 bytes in one scan query.
     pub query_bytes: usize,

--- a/crates/memory/src/retrieval.rs
+++ b/crates/memory/src/retrieval.rs
@@ -7,8 +7,12 @@ const BM25_K1: f64 = 1.2;
 const BM25_B: f64 = 0.75;
 const PREVIEW_MAX_BYTES: usize = 64;
 
-pub(super) fn rank(query: &str, memories: &[MemoryRecord], limit: usize) -> Vec<MemoryCandidate> {
-    if limit == 0 || memories.is_empty() {
+pub(super) fn rank<'a>(
+    query: &str,
+    memories: impl IntoIterator<Item = &'a MemoryRecord>,
+    limit: usize,
+) -> Vec<MemoryCandidate> {
+    if limit == 0 {
         return Vec::new();
     }
 
@@ -18,9 +22,12 @@ pub(super) fn rank(query: &str, memories: &[MemoryRecord], limit: usize) -> Vec<
     }
 
     let documents = memories
-        .iter()
+        .into_iter()
         .map(|memory| Document::new(memory, tokenize(&memory.content)))
         .collect::<Vec<_>>();
+    if documents.is_empty() {
+        return Vec::new();
+    }
     let average_document_length = documents
         .iter()
         .map(|document| document.length as f64)
@@ -192,7 +199,7 @@ fn preview(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{preview, rank, tokenize};
-    use crate::{MemoryKey, MemoryRecord};
+    use crate::{MemoryCandidate, MemoryKey, MemoryNamespaceFilter, MemoryRecord};
 
     fn memory(id: i64, content: &str) -> MemoryRecord {
         MemoryRecord {
@@ -206,6 +213,12 @@ mod tests {
             use_count: 0,
             probation_until_ms: None,
         }
+    }
+
+    fn remote_memory(namespace: &str, id: i64, content: &str) -> MemoryRecord {
+        let mut memory = memory(id, content);
+        memory.key = MemoryKey::remote(namespace.to_owned(), id, 1);
+        memory
     }
 
     #[test]
@@ -319,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn no_overlap_abstains_and_scores_tie_by_id() {
+    fn no_overlap_returns_no_candidates_and_scores_tie_by_id() {
         let memories = [memory(2, "same"), memory(1, "same")];
 
         assert!(rank("different", &memories, 5).is_empty());
@@ -330,6 +343,36 @@ mod tests {
                 .collect::<Vec<_>>(),
             [1, 2]
         );
+    }
+
+    #[test]
+    fn namespace_filters_produce_independently_ranked_scan_requests() {
+        let memories = [
+            remote_memory("alice", 1, "shared concise"),
+            remote_memory("alice", 2, "shared verbose padding words"),
+            remote_memory("bob", 1, "shared concise"),
+            remote_memory("bob", 2, "shared verbose padding words"),
+        ];
+
+        let ours = MemoryNamespaceFilter::Exact("alice".to_owned());
+        let theirs = MemoryNamespaceFilter::OtherThan("alice".to_owned());
+        let ours = MemoryCandidate::rank(
+            "shared",
+            memories.iter().filter(|memory| ours.includes(&memory.key)),
+            1,
+        );
+        let theirs = MemoryCandidate::rank(
+            "shared",
+            memories
+                .iter()
+                .filter(|memory| theirs.includes(&memory.key)),
+            1,
+        );
+
+        assert_eq!(ours.len(), 1);
+        assert_eq!(ours[0].key.namespace.as_deref(), Some("alice"));
+        assert_eq!(theirs.len(), 1);
+        assert_eq!(theirs[0].key.namespace.as_deref(), Some("bob"));
     }
 
     #[test]

--- a/crates/memory/src/server/protocol.rs
+++ b/crates/memory/src/server/protocol.rs
@@ -67,20 +67,34 @@ pub struct SessionResponse {
     pub role: RemoteRole,
 }
 
+/// Authenticated namespace scope for one scan request.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScanScope {
+    /// Every visible namespace, ranked as one corpus.
+    All,
+    /// Only the authenticated namespace.
+    Own,
+    /// Every visible namespace other than the authenticated namespace.
+    Others,
+}
+
 /// Request for semantic retrieval.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ScanRequest {
     /// Search text, bounded by [`crate::MemoryLimits::query_bytes`].
     pub query: String,
-    /// Maximum candidates requested from the server.
+    /// Namespace scope derived relative to the authenticated principal.
+    pub scope: ScanScope,
+    /// Maximum candidates requested from this scope.
     pub limit: usize,
 }
 
 /// Response to [`ScanRequest`].
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ScanResponse {
-    /// Candidates in descending rank.
+    /// Candidates from the requested scope in descending rank.
     pub candidates: Vec<MemoryCandidate>,
 }
 

--- a/crates/memory/src/server/router.rs
+++ b/crates/memory/src/server/router.rs
@@ -5,10 +5,12 @@ use super::{
     protocol::{
         self, DeleteRequest, ErrorResponse, ExportRequest, ExportResponse, ListResponse,
         PutRequest, PutResponse, ReadRequest, ReadResponse, RemoteErrorCode, RemoteRole,
-        ScanRequest, ScanResponse, SessionResponse, SyncRequest,
+        ScanRequest, ScanResponse, ScanScope, SessionResponse, SyncRequest,
     },
 };
-use crate::{MemoryError, MemoryKey, MemoryLimits, MemoryRecord, MemoryStore};
+use crate::{
+    MemoryError, MemoryKey, MemoryLimits, MemoryNamespaceFilter, MemoryRecord, MemoryStore,
+};
 use axum::{
     Json, Router,
     body::Body,
@@ -164,19 +166,21 @@ async fn scan<S: MemoryStore>(
         };
         return operation.error_response(error, counts);
     }
+    let namespaces = match request.scope {
+        ScanScope::All => MemoryNamespaceFilter::All,
+        ScanScope::Own => MemoryNamespaceFilter::Exact(principal.namespace.clone()),
+        ScanScope::Others => MemoryNamespaceFilter::OtherThan(principal.namespace.clone()),
+    };
     let store = (state.store_factory)(principal.namespace);
     match run_store(
         operation,
         counts,
-        store.scan(&request.query, request.limit),
-        |scan| OperationCounts::candidates(scan.candidates.len()),
+        store.scan(&request.query, namespaces, request.limit),
+        |candidates| OperationCounts::candidates(candidates.len()),
     )
     .await
     {
-        Ok(scan) => Json(ScanResponse {
-            candidates: scan.candidates,
-        })
-        .into_response(),
+        Ok(candidates) => Json(ScanResponse { candidates }).into_response(),
         Err(error) => error.into_response(),
     }
 }

--- a/crates/memory/src/server/tests.rs
+++ b/crates/memory/src/server/tests.rs
@@ -3,12 +3,13 @@ use super::{
     protocol::{
         self, DeleteRequest, ErrorResponse, ExportCursor, ExportRequest, ExportResponse,
         ListResponse, PutRequest, PutResponse, ReadRequest, ReadResponse, RemoteErrorCode,
-        RemoteRole, ScanRequest, ScanResponse, SessionResponse, SyncReport, SyncRequest,
+        RemoteRole, ScanRequest, ScanResponse, ScanScope, SessionResponse, SyncReport, SyncRequest,
     },
 };
 use crate::{
-    MemoryCandidate, MemoryError, MemoryKey, MemoryLimits, MemoryRecord, MemoryScan, MemoryStore,
-    RemoteClientError, RemoteMemoryClient, RemoteToken, model::normalize_identity,
+    MemoryCandidate, MemoryError, MemoryKey, MemoryLimits, MemoryNamespaceFilter, MemoryRecord,
+    MemoryStore, RemoteClientError, RemoteMemoryClient, RemoteToken, SelectedMemoryStore,
+    model::normalize_identity,
 };
 use axum::{
     Json, Router,
@@ -93,33 +94,31 @@ fn visible_records(state: &TestMemoryState) -> Vec<MemoryRecord> {
 }
 
 impl MemoryStore for TestMemoryStore {
-    async fn scan(&self, query: &str, limit: usize) -> Result<MemoryScan, MemoryError> {
+    async fn scan(
+        &self,
+        query: &str,
+        namespaces: MemoryNamespaceFilter,
+        limit: usize,
+    ) -> Result<Vec<MemoryCandidate>, MemoryError> {
         let now = now_ms();
         let query = normalize_identity(query);
         let terms = query.split_whitespace().collect::<Vec<_>>();
         let mut state = self.database.state.lock().unwrap();
         prune_expired(&mut state, now);
-        let mut seen = HashSet::new();
-        let mut candidates = visible_records(&state)
+        let records = visible_records(&state)
             .into_iter()
             .filter(|record| {
                 let content = normalize_identity(&record.content);
                 terms.iter().all(|term| content.contains(term))
-                    && seen.insert(normalize_identity(&record.content))
             })
-            .map(|record| MemoryCandidate {
-                key: record.key,
-                preview: record.content,
-                score: 1.0,
-            })
-            .take(limit.min(MemoryLimits::PRODUCTION.scan_results))
             .collect::<Vec<_>>();
-        candidates.sort_by(|left, right| {
-            left.key
-                .namespace
-                .cmp(&right.key.namespace)
-                .then_with(|| left.key.id.cmp(&right.key.id))
-        });
+        let candidates = MemoryCandidate::rank(
+            &query,
+            records
+                .iter()
+                .filter(|record| namespaces.includes(&record.key)),
+            limit.min(MemoryLimits::PRODUCTION.scan_results),
+        );
         for candidate in &candidates {
             if let Some(record) = state
                 .records
@@ -129,10 +128,7 @@ impl MemoryStore for TestMemoryStore {
                 record.scan_count = record.scan_count.saturating_add(1);
             }
         }
-        Ok(MemoryScan {
-            abstained: candidates.is_empty(),
-            candidates,
-        })
+        Ok(candidates)
     }
 
     async fn read(
@@ -444,6 +440,32 @@ async fn send<T: Serialize>(
         .unwrap()
 }
 
+async fn scan(
+    app: &Router,
+    token: &str,
+    namespace: &str,
+    query: &str,
+    scope: ScanScope,
+    limit: usize,
+) -> Vec<MemoryCandidate> {
+    json::<ScanResponse>(
+        send(
+            app,
+            protocol::SCAN_PATH,
+            token,
+            namespace,
+            &ScanRequest {
+                query: query.to_owned(),
+                scope,
+                limit,
+            },
+        )
+        .await,
+    )
+    .await
+    .candidates
+}
+
 async fn json<T: DeserializeOwned>(response: Response<Body>) -> T {
     serde_json::from_slice(&response_bytes(response).await).unwrap()
 }
@@ -598,20 +620,12 @@ async fn scan_read_and_list_return_only_caller_visible_records() {
         [&alice.key, &bob.key]
     );
 
-    let scanned = send(
-        &app,
-        protocol::SCAN_PATH,
-        ALICE_TOKEN,
-        "alice",
-        &ScanRequest {
-            query: "concurrent sqlite".to_owned(),
-            limit: 5,
-        },
-    )
-    .await;
-    let scanned = json::<ScanResponse>(scanned).await.candidates;
-    assert_eq!(scanned.len(), 1);
-    assert_eq!(scanned[0].key, bob.key);
+    let ours = scan(&app, ALICE_TOKEN, "alice", "note", ScanScope::Own, 5).await;
+    let theirs = scan(&app, ALICE_TOKEN, "alice", "note", ScanScope::Others, 5).await;
+    assert_eq!(ours.len(), 1);
+    assert_eq!(ours[0].key, alice.key);
+    assert_eq!(theirs.len(), 1);
+    assert_eq!(theirs[0].key, bob.key);
 
     let read = send(
         &app,
@@ -628,6 +642,61 @@ async fn scan_read_and_list_return_only_caller_visible_records() {
     assert_eq!(read.len(), 2);
     assert!(read.iter().any(|memory| memory.key == alice.key));
     assert!(read.iter().any(|memory| memory.key == bob.key));
+}
+
+#[tokio::test]
+async fn scan_applies_the_limit_independently_to_ours_and_theirs() {
+    let app = memory_app(vec![
+        credential("alice", RemoteRole::Writer, ALICE_TOKEN),
+        credential("bob", RemoteRole::Writer, BOB_TOKEN),
+    ]);
+    for index in 0..6 {
+        put(
+            &app,
+            "alice",
+            ALICE_TOKEN,
+            &format!("namespace candidate alice {index}"),
+        )
+        .await;
+        put(
+            &app,
+            "bob",
+            BOB_TOKEN,
+            &format!("namespace candidate bob {index}"),
+        )
+        .await;
+    }
+
+    let ours = scan(
+        &app,
+        ALICE_TOKEN,
+        "alice",
+        "namespace candidate",
+        ScanScope::Own,
+        5,
+    )
+    .await;
+    let theirs = scan(
+        &app,
+        ALICE_TOKEN,
+        "alice",
+        "namespace candidate",
+        ScanScope::Others,
+        5,
+    )
+    .await;
+
+    assert_eq!(ours.len(), 5);
+    assert!(
+        ours.iter()
+            .all(|candidate| candidate.key.namespace.as_deref() == Some("alice"))
+    );
+    assert_eq!(theirs.len(), 5);
+    assert!(
+        theirs
+            .iter()
+            .all(|candidate| candidate.key.namespace.as_deref() == Some("bob"))
+    );
 }
 
 #[tokio::test]
@@ -918,6 +987,7 @@ async fn body_and_request_bounds_are_content_free_client_errors() {
             "alice",
             &ScanRequest {
                 query: "q".repeat(MemoryLimits::PRODUCTION.query_bytes + 1),
+                scope: ScanScope::All,
                 limit: 1,
             },
         )
@@ -955,6 +1025,7 @@ async fn body_and_request_bounds_are_content_free_client_errors() {
         "alice",
         &ScanRequest {
             query: "bounded".to_owned(),
+            scope: ScanScope::All,
             limit: MemoryLimits::PRODUCTION.scan_results + 1,
         },
     )
@@ -1138,6 +1209,16 @@ async fn unsafe_scan() -> Json<ScanResponse> {
     })
 }
 
+async fn malformed_scan() -> Json<ScanResponse> {
+    Json(ScanResponse {
+        candidates: vec![MemoryCandidate {
+            key: MemoryKey::remote("alice".to_owned(), 0, 1),
+            preview: "candidate".to_owned(),
+            score: 1.0,
+        }],
+    })
+}
+
 async fn oversized_scan() -> Json<ScanResponse> {
     Json(ScanResponse {
         candidates: (1..=2)
@@ -1172,6 +1253,69 @@ async fn ascending_score_scan() -> Json<ScanResponse> {
             })
             .collect(),
     })
+}
+
+async fn misclassified_scan() -> Json<ScanResponse> {
+    Json(ScanResponse {
+        candidates: vec![MemoryCandidate {
+            key: MemoryKey::remote("bob".to_owned(), 1, 1),
+            preview: "foreign candidate".to_owned(),
+            score: 1.0,
+        }],
+    })
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ScopedScanRequest {
+    scope: ScanScope,
+    bookmark: Option<String>,
+}
+
+#[derive(Clone, Default)]
+struct ScanScopeLog {
+    requests: Arc<Mutex<Vec<ScopedScanRequest>>>,
+    fail_others: bool,
+}
+
+async fn scoped_scan(
+    axum::extract::State(log): axum::extract::State<ScanScopeLog>,
+    headers: axum::http::HeaderMap,
+    Json(request): Json<ScanRequest>,
+) -> Response<Body> {
+    let bookmark = headers
+        .get(protocol::BOOKMARK_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    log.requests.lock().unwrap().push(ScopedScanRequest {
+        scope: request.scope,
+        bookmark,
+    });
+    if log.fail_others && request.scope == ScanScope::Others {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    let namespace = match request.scope {
+        ScanScope::All | ScanScope::Own => "alice",
+        ScanScope::Others => "bob",
+    };
+    let response_bookmark = match request.scope {
+        ScanScope::All => "bookmark-all",
+        ScanScope::Own => "bookmark-own",
+        ScanScope::Others => "bookmark-others",
+    };
+    let mut response = Json(ScanResponse {
+        candidates: vec![MemoryCandidate {
+            key: MemoryKey::remote(namespace.to_owned(), 1, 1),
+            preview: format!("{namespace} candidate"),
+            score: 1.0,
+        }],
+    })
+    .into_response();
+    response.headers_mut().insert(
+        protocol::BOOKMARK_HEADER,
+        response_bookmark.parse().unwrap(),
+    );
+    response
 }
 
 async fn oversized_export() -> Json<ExportResponse> {
@@ -1379,14 +1523,44 @@ async fn client_suppresses_unsafe_scan_previews() {
     )
     .unwrap();
 
-    assert!(
-        client
-            .scan("password", 5)
-            .await
-            .unwrap()
-            .candidates
-            .is_empty()
-    );
+    let candidates = client
+        .scan(
+            "password",
+            MemoryNamespaceFilter::Exact("alice".to_owned()),
+            5,
+        )
+        .await
+        .unwrap();
+    assert!(candidates.is_empty());
+    task.abort();
+}
+
+#[tokio::test]
+async fn client_rejects_structurally_invalid_scan_candidates() {
+    let app = Router::new().route(&format!("/{}", protocol::SCAN_PATH), post(malformed_scan));
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+
+    let error = client
+        .scan(
+            "candidate",
+            MemoryNamespaceFilter::Exact("alice".to_owned()),
+            5,
+        )
+        .await
+        .unwrap_err();
+    let MemoryError::Backend { source } = error else {
+        panic!("expected backend error, got {error:?}");
+    };
+    assert!(matches!(
+        source.downcast_ref::<RemoteClientError>(),
+        Some(RemoteClientError::InvalidResponse)
+    ));
     task.abort();
 }
 
@@ -1401,7 +1575,14 @@ async fn client_rejects_oversized_scan_responses() {
     )
     .unwrap();
 
-    let error = client.scan("candidate", 1).await.unwrap_err();
+    let error = client
+        .scan(
+            "candidate",
+            MemoryNamespaceFilter::Exact("alice".to_owned()),
+            1,
+        )
+        .await
+        .unwrap_err();
     let MemoryError::Backend { source } = error else {
         panic!("expected backend error, got {error:?}");
     };
@@ -1426,7 +1607,14 @@ async fn client_rejects_ambiguous_versions_in_scan_responses() {
     )
     .unwrap();
 
-    let error = client.scan("version", 2).await.unwrap_err();
+    let error = client
+        .scan(
+            "version",
+            MemoryNamespaceFilter::Exact("alice".to_owned()),
+            2,
+        )
+        .await
+        .unwrap_err();
     let MemoryError::Backend { source } = error else {
         panic!("expected backend error, got {error:?}");
     };
@@ -1451,7 +1639,145 @@ async fn client_rejects_scan_responses_out_of_rank_order() {
     )
     .unwrap();
 
-    let error = client.scan("candidate", 2).await.unwrap_err();
+    let error = client
+        .scan(
+            "candidate",
+            MemoryNamespaceFilter::Exact("alice".to_owned()),
+            2,
+        )
+        .await
+        .unwrap_err();
+    let MemoryError::Backend { source } = error else {
+        panic!("expected backend error, got {error:?}");
+    };
+    assert!(matches!(
+        source.downcast_ref::<RemoteClientError>(),
+        Some(RemoteClientError::InvalidResponse)
+    ));
+    task.abort();
+}
+
+#[tokio::test]
+async fn selected_remote_store_scans_ours_and_theirs_with_two_requests() {
+    let log = ScanScopeLog::default();
+    let app = Router::new()
+        .route(&format!("/{}", protocol::SCAN_PATH), post(scoped_scan))
+        .with_state(log.clone());
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+    let store = SelectedMemoryStore::remote(client);
+
+    let (ours, theirs) = store.scan_groups("candidate", 2).await.unwrap();
+
+    assert_eq!(ours.len(), 1);
+    assert_eq!(ours[0].key.namespace.as_deref(), Some("alice"));
+    assert_eq!(theirs.len(), 1);
+    assert_eq!(theirs[0].key.namespace.as_deref(), Some("bob"));
+    assert_eq!(
+        *log.requests.lock().unwrap(),
+        [
+            ScopedScanRequest {
+                scope: ScanScope::Own,
+                bookmark: None,
+            },
+            ScopedScanRequest {
+                scope: ScanScope::Others,
+                bookmark: Some("bookmark-own".to_owned()),
+            },
+        ]
+    );
+    task.abort();
+}
+
+#[tokio::test]
+async fn selected_remote_store_does_not_return_a_partial_scan_group() {
+    let log = ScanScopeLog {
+        fail_others: true,
+        ..ScanScopeLog::default()
+    };
+    let app = Router::new()
+        .route(&format!("/{}", protocol::SCAN_PATH), post(scoped_scan))
+        .with_state(log.clone());
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+    let store = SelectedMemoryStore::remote(client);
+
+    assert!(store.scan_groups("candidate", 2).await.is_err());
+    assert_eq!(
+        *log.requests.lock().unwrap(),
+        [
+            ScopedScanRequest {
+                scope: ScanScope::Own,
+                bookmark: None,
+            },
+            ScopedScanRequest {
+                scope: ScanScope::Others,
+                bookmark: Some("bookmark-own".to_owned()),
+            },
+        ]
+    );
+    task.abort();
+}
+
+#[tokio::test]
+async fn client_rejects_filters_not_bound_to_its_authenticated_namespace() {
+    let log = ScanScopeLog::default();
+    let app = Router::new()
+        .route(&format!("/{}", protocol::SCAN_PATH), post(scoped_scan))
+        .with_state(log.clone());
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+
+    for namespaces in [
+        MemoryNamespaceFilter::Exact("bob".to_owned()),
+        MemoryNamespaceFilter::OtherThan("bob".to_owned()),
+    ] {
+        assert!(matches!(
+            client.scan("candidate", namespaces, 1).await,
+            Err(MemoryError::RemoteReadOnly)
+        ));
+    }
+    assert!(log.requests.lock().unwrap().is_empty());
+    task.abort();
+}
+
+#[tokio::test]
+async fn client_rejects_scan_candidates_outside_the_requested_scope() {
+    let app = Router::new().route(
+        &format!("/{}", protocol::SCAN_PATH),
+        post(misclassified_scan),
+    );
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+
+    let error = client
+        .scan(
+            "candidate",
+            MemoryNamespaceFilter::Exact("alice".to_owned()),
+            1,
+        )
+        .await
+        .unwrap_err();
     let MemoryError::Backend { source } = error else {
         panic!("expected backend error, got {error:?}");
     };
@@ -1661,14 +1987,10 @@ impl MemoryStore for AsyncStore {
     fn scan(
         &self,
         _query: &str,
+        _namespaces: MemoryNamespaceFilter,
         _limit: usize,
-    ) -> impl Future<Output = Result<MemoryScan, MemoryError>> + Send {
-        async {
-            Ok(MemoryScan {
-                abstained: true,
-                candidates: Vec::new(),
-            })
-        }
+    ) -> impl Future<Output = Result<Vec<MemoryCandidate>, MemoryError>> + Send {
+        async { Ok(Vec::new()) }
     }
 
     fn read(

--- a/crates/memory/src/store/local.rs
+++ b/crates/memory/src/store/local.rs
@@ -2,7 +2,8 @@
 
 use super::{MemoryError, MemoryStore, current_time_ms};
 use crate::{
-    MemoryImportReport, MemoryKey, MemoryLimits, MemoryRecord, MemoryScan,
+    MemoryCandidate, MemoryImportReport, MemoryKey, MemoryLimits, MemoryNamespaceFilter,
+    MemoryRecord,
     model::{StoredMemory, normalize_identity},
     secrets::contains_likely_secret,
     server::protocol::{self, ExportCursor, SyncReport},
@@ -71,21 +72,23 @@ impl LocalMemoryStore {
     async fn scan(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
         now_ms: i64,
-    ) -> Result<MemoryScan, MemoryError> {
+    ) -> Result<Vec<MemoryCandidate>, MemoryError> {
         let store = self.clone();
         let query = query.to_owned();
         let limit = limit.min(self.limits.scan_results);
-        run_local(move || store.scan_local(&query, limit, now_ms)).await
+        run_local(move || store.scan_local(&query, namespaces, limit, now_ms)).await
     }
 
     pub(crate) fn scan_local(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
         now_ms: i64,
-    ) -> Result<MemoryScan, MemoryError> {
+    ) -> Result<Vec<MemoryCandidate>, MemoryError> {
         if query.len() > self.limits.query_bytes {
             return Err(MemoryError::QueryTooLarge {
                 maximum_bytes: self.limits.query_bytes,
@@ -104,9 +107,15 @@ impl LocalMemoryStore {
             .map(MemoryRecord::from)
             .collect::<Vec<_>>();
         let limit = limit.min(self.limits.scan_results);
-        let scan = MemoryScan::rank(query, &memories, limit);
+        let candidates = MemoryCandidate::rank(
+            query,
+            memories
+                .iter()
+                .filter(|memory| namespaces.includes(&memory.key)),
+            limit,
+        );
 
-        for candidate in &scan.candidates {
+        for candidate in &candidates {
             transaction
                 .execute(
                     "UPDATE memories
@@ -118,7 +127,7 @@ impl LocalMemoryStore {
         }
         transaction.commit().map_err(sqlite_error)?;
 
-        Ok(scan)
+        Ok(candidates)
     }
 
     pub(crate) fn read_local(
@@ -692,9 +701,10 @@ impl MemoryStore for LocalMemoryStore {
     fn scan(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
-    ) -> impl Future<Output = Result<MemoryScan, MemoryError>> + Send {
-        LocalMemoryStore::scan(self, query, limit, current_time_ms())
+    ) -> impl Future<Output = Result<Vec<MemoryCandidate>, MemoryError>> + Send {
+        LocalMemoryStore::scan(self, query, namespaces, limit, current_time_ms())
     }
     fn read(
         &self,

--- a/crates/memory/src/store/mod.rs
+++ b/crates/memory/src/store/mod.rs
@@ -8,7 +8,7 @@ mod remote;
 #[cfg(all(feature = "client", feature = "local"))]
 use crate::{MemoryAccess, MemorySource, secrets::contains_likely_secret};
 use crate::{
-    MemoryKey, MemoryLimits, MemoryRecord, MemoryScan,
+    MemoryCandidate, MemoryKey, MemoryLimits, MemoryRecord,
     server::protocol::{self, ExportCursor, SyncReport},
 };
 #[cfg(feature = "local")]
@@ -22,6 +22,31 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{error::Error, future::Future};
 use thiserror::Error;
 
+/// Namespace selection applied by one memory scan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MemoryNamespaceFilter {
+    /// Includes every record visible to the store.
+    All,
+    /// Includes records from exactly one remote namespace.
+    Exact(String),
+    /// Includes remote records outside one namespace.
+    OtherThan(String),
+}
+
+impl MemoryNamespaceFilter {
+    /// Returns whether `key` belongs to this scan's namespace selection.
+    pub fn includes(&self, key: &MemoryKey) -> bool {
+        match self {
+            Self::All => true,
+            Self::Exact(namespace) => key.namespace.as_deref() == Some(namespace.as_str()),
+            Self::OtherThan(namespace) => key
+                .namespace
+                .as_deref()
+                .is_some_and(|candidate| candidate != namespace),
+        }
+    }
+}
+
 /// Ordinary operations shared by local and authenticated remote memory backends.
 ///
 /// Implementations own their namespace and storage boundary. Returned records are ordered
@@ -30,12 +55,14 @@ use thiserror::Error;
 /// Dropping a returned future requests cancellation. Implementations may finish an already-started
 /// atomic storage transaction after cancellation.
 pub trait MemoryStore: Clone + Send + Sync + 'static {
-    /// Searches visible records and records scan telemetry.
+    /// Searches records selected by `namespaces` and records telemetry for returned candidates.
+    /// `limit` bounds this request rather than any later composition of multiple scopes.
     fn scan(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
-    ) -> impl Future<Output = Result<MemoryScan, MemoryError>> + Send;
+    ) -> impl Future<Output = Result<Vec<MemoryCandidate>, MemoryError>> + Send;
 
     /// Reads unversioned IDs and versioned keys, recording use telemetry.
     fn read(
@@ -178,6 +205,41 @@ impl SelectedMemoryStore {
             }),
         }
     }
+
+    /// Returns the local group or two independently retrieved remote namespace groups.
+    ///
+    /// Remote requests run own-first so the client's shared bookmark makes the other-namespace
+    /// snapshot at least as fresh as the authenticated-namespace snapshot.
+    pub(crate) async fn scan_groups(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<(Vec<MemoryCandidate>, Vec<MemoryCandidate>), MemoryError> {
+        match self {
+            Self::Local(store) => Ok((
+                MemoryStore::scan(store, query, MemoryNamespaceFilter::All, limit).await?,
+                Vec::new(),
+            )),
+            Self::Remote(client) => {
+                let namespace = client.namespace().to_owned();
+                let ours = MemoryStore::scan(
+                    client,
+                    query,
+                    MemoryNamespaceFilter::Exact(namespace.clone()),
+                    limit,
+                )
+                .await?;
+                let theirs = MemoryStore::scan(
+                    client,
+                    query,
+                    MemoryNamespaceFilter::OtherThan(namespace),
+                    limit,
+                )
+                .await?;
+                Ok((ours, theirs))
+            }
+        }
+    }
 }
 
 #[cfg(all(feature = "client", feature = "local"))]
@@ -185,12 +247,13 @@ impl MemoryStore for SelectedMemoryStore {
     fn scan(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
-    ) -> impl Future<Output = Result<MemoryScan, MemoryError>> + Send {
+    ) -> impl Future<Output = Result<Vec<MemoryCandidate>, MemoryError>> + Send {
         async move {
             match self {
-                Self::Local(store) => MemoryStore::scan(store, query, limit).await,
-                Self::Remote(client) => MemoryStore::scan(client, query, limit).await,
+                Self::Local(store) => MemoryStore::scan(store, query, namespaces, limit).await,
+                Self::Remote(client) => MemoryStore::scan(client, query, namespaces, limit).await,
             }
         }
     }

--- a/crates/memory/src/store/remote/client.rs
+++ b/crates/memory/src/store/remote/client.rs
@@ -1,11 +1,11 @@
 use crate::{
-    MemoryCandidate, MemoryError, MemoryKey, MemoryLimits, MemoryRecord, MemoryScan, MemoryStore,
-    server::protocol,
+    MemoryCandidate, MemoryError, MemoryKey, MemoryLimits, MemoryNamespaceFilter, MemoryRecord,
+    MemoryStore, server::protocol,
 };
 use protocol::{
     DeleteRequest, ErrorResponse, ExportRequest, ExportResponse, ListResponse, PutRequest,
     PutResponse, ReadRequest, ReadResponse, RemoteErrorCode, RemoteRole, ScanRequest, ScanResponse,
-    SessionResponse, SyncReport, SyncRequest,
+    ScanScope, SessionResponse, SyncReport, SyncRequest,
 };
 use reqwest::{Client, Response, StatusCode, Url};
 use serde::{Serialize, de::DeserializeOwned};
@@ -193,6 +193,7 @@ impl RemoteMemoryClient {
     async fn scan(
         &self,
         query: &str,
+        scope: ScanScope,
         limit: usize,
     ) -> Result<Vec<MemoryCandidate>, RemoteClientError> {
         let limit = limit.min(MemoryLimits::PRODUCTION.scan_results);
@@ -204,6 +205,7 @@ impl RemoteMemoryClient {
                 protocol::SCAN_PATH,
                 &ScanRequest {
                     query: query.to_owned(),
+                    scope,
                     limit,
                 },
                 Replay::ConnectOnly,
@@ -212,26 +214,39 @@ impl RemoteMemoryClient {
         if response.candidates.len() > limit {
             return Err(RemoteClientError::InvalidResponse);
         }
+
         let mut seen = HashSet::new();
-        let mut candidates = Vec::new();
+        let mut validated = Vec::new();
         let mut previous_score = None;
         for candidate in response.candidates {
-            if !self.valid_candidate(&candidate) {
-                continue;
+            if !Self::valid_candidate(&candidate) {
+                return Err(RemoteClientError::InvalidResponse);
+            }
+            let Some(namespace) = candidate.key.namespace.clone() else {
+                return Err(RemoteClientError::InvalidResponse);
+            };
+            let owned = namespace == self.namespace();
+            let in_scope = match scope {
+                ScanScope::All => true,
+                ScanScope::Own => owned,
+                ScanScope::Others => !owned,
+            };
+            if !in_scope {
+                return Err(RemoteClientError::InvalidResponse);
             }
             if previous_score.is_some_and(|score| candidate.score > score) {
                 return Err(RemoteClientError::InvalidResponse);
             }
             previous_score = Some(candidate.score);
-            let Some(namespace) = candidate.key.namespace.clone() else {
-                continue;
-            };
             if !seen.insert((namespace, candidate.key.id)) {
                 return Err(RemoteClientError::InvalidResponse);
             }
-            candidates.push(candidate);
+            if crate::secrets::contains_likely_secret(&candidate.preview) {
+                continue;
+            }
+            validated.push(candidate);
         }
-        Ok(candidates)
+        Ok(validated)
     }
 
     async fn read(
@@ -444,13 +459,12 @@ impl RemoteMemoryClient {
             && key.version > 0
     }
 
-    fn valid_candidate(&self, candidate: &MemoryCandidate) -> bool {
+    fn valid_candidate(candidate: &MemoryCandidate) -> bool {
         Self::valid_key(&candidate.key)
             && candidate.key.namespace.is_some()
             && candidate.preview.len() <= 64
             && candidate.score.is_finite()
             && candidate.score >= 0.0
-            && !crate::secrets::contains_likely_secret(&candidate.preview)
     }
 
     fn valid_record(memory: &MemoryRecord) -> bool {
@@ -547,14 +561,23 @@ impl MemoryStore for RemoteMemoryClient {
     fn scan(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
-    ) -> impl std::future::Future<Output = Result<MemoryScan, MemoryError>> + Send {
+    ) -> impl std::future::Future<Output = Result<Vec<MemoryCandidate>, MemoryError>> + Send {
         async move {
-            let candidates = RemoteMemoryClient::scan(self, query, limit).await?;
-            Ok(MemoryScan {
-                abstained: candidates.is_empty(),
-                candidates,
-            })
+            let scope = match namespaces {
+                MemoryNamespaceFilter::All => ScanScope::All,
+                MemoryNamespaceFilter::Exact(namespace) if namespace == self.namespace() => {
+                    ScanScope::Own
+                }
+                MemoryNamespaceFilter::OtherThan(namespace) if namespace == self.namespace() => {
+                    ScanScope::Others
+                }
+                MemoryNamespaceFilter::Exact(_) | MemoryNamespaceFilter::OtherThan(_) => {
+                    return Err(RemoteClientError::NamespaceMismatch.into());
+                }
+            };
+            Ok(RemoteMemoryClient::scan(self, query, scope, limit).await?)
         }
     }
     fn read(

--- a/crates/memory/src/tests.rs
+++ b/crates/memory/src/tests.rs
@@ -23,8 +23,9 @@ impl MemoryStore {
         query: &str,
         limit: usize,
         now_ms: i64,
-    ) -> Result<super::MemoryScan, MemoryError> {
-        self.0.scan_local(query, limit, now_ms)
+    ) -> Result<Vec<super::MemoryCandidate>, MemoryError> {
+        self.0
+            .scan_local(query, super::MemoryNamespaceFilter::All, limit, now_ms)
     }
 
     fn put(
@@ -257,14 +258,13 @@ fn scan_updates_only_returned_rows() {
         .unwrap();
     let unrelated = store.put("python network", None, 0).unwrap();
 
-    let scan = store.scan("rust sqlite", 1, 1).unwrap();
+    let candidates = store.scan("rust sqlite", 1, 1).unwrap();
 
-    assert!(!scan.abstained);
-    assert_eq!(scan.candidates.len(), 1);
+    assert_eq!(candidates.len(), 1);
     let records = store.list(1).unwrap();
     let scanned = records
         .iter()
-        .find(|record| record.key.id == scan.candidates[0].key.id)
+        .find(|record| record.key.id == candidates[0].key.id)
         .unwrap();
     assert_eq!(scanned.scan_count, 1);
     assert_eq!(scanned.last_scanned_at_ms, Some(1));
@@ -275,9 +275,7 @@ fn scan_updates_only_returned_rows() {
         }
     }
 
-    let abstained = store.scan("no-overlap", 2, 2).unwrap();
-    assert!(abstained.abstained);
-    assert!(abstained.candidates.is_empty());
+    assert!(store.scan("no-overlap", 2, 2).unwrap().is_empty());
     assert_eq!(
         store
             .list(2)
@@ -296,9 +294,9 @@ fn scan_clamps_results_to_the_production_limit() {
         store.put(&format!("shared term {index}"), None, 0).unwrap();
     }
 
-    let scan = store.scan("shared", usize::MAX, 1).unwrap();
+    let candidates = store.scan("shared", usize::MAX, 1).unwrap();
 
-    assert_eq!(scan.candidates.len(), 5);
+    assert_eq!(candidates.len(), 5);
 }
 
 #[test]
@@ -404,7 +402,7 @@ fn suppresses_unsafe_legacy_rows_but_keeps_them_deletable() {
     let id = connection.last_insert_rowid();
     drop(connection);
 
-    assert!(store.scan("hunter2", 1, 0).unwrap().abstained);
+    assert!(store.scan("hunter2", 1, 0).unwrap().is_empty());
     assert!(store.read(&[id], 0).unwrap().is_empty());
     assert!(store.list(0).unwrap().is_empty());
     store.delete(MemoryKey::local(id, 1), 0).unwrap();

--- a/crates/memory/src/tool.rs
+++ b/crates/memory/src/tool.rs
@@ -1,6 +1,8 @@
 //! Explicit agent access to the global memory store.
 
-use super::{MemoryAccess, MemoryKey, MemoryRecord, MemoryStore, SelectedMemoryStore};
+use super::{
+    MemoryAccess, MemoryCandidate, MemoryKey, MemoryRecord, MemoryStore, SelectedMemoryStore,
+};
 use nanocodex::{
     Tool,
     tools::contract::{
@@ -59,8 +61,8 @@ impl<'de> Deserialize<'de> for MemoryContent {
 struct ScanOutput {
     operation: &'static str,
     backend: MemoryAccess,
-    abstained: bool,
-    candidates: Vec<ToolCandidate>,
+    ours: Vec<ToolCandidate>,
+    theirs: Vec<ToolCandidate>,
 }
 
 #[derive(Serialize)]
@@ -68,6 +70,16 @@ struct ToolCandidate {
     key: MemoryKey,
     preview: String,
     score: f64,
+}
+
+impl From<MemoryCandidate> for ToolCandidate {
+    fn from(candidate: MemoryCandidate) -> Self {
+        Self {
+            key: candidate.key,
+            preview: candidate.preview,
+            score: candidate.score,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -128,21 +140,13 @@ where
             return Err(io::Error::other("memory scan limit must be between 1 and 5").into());
         }
         let backend = self.store.access().await?;
-        let scan = self.store.scan(&query, limit).await?;
+        let (ours, theirs) = self.store.scan_groups(&query, limit).await?;
         self.searched.store(true, Ordering::Release);
         json_output(&ScanOutput {
             operation: "scan",
             backend,
-            abstained: scan.abstained,
-            candidates: scan
-                .candidates
-                .into_iter()
-                .map(|candidate| ToolCandidate {
-                    key: candidate.key,
-                    preview: candidate.preview,
-                    score: candidate.score,
-                })
-                .collect(),
+            ours: ours.into_iter().map(ToolCandidate::from).collect(),
+            theirs: theirs.into_iter().map(ToolCandidate::from).collect(),
         })
     }
 
@@ -205,7 +209,7 @@ where
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
             "memory",
-            "Explicitly searches, reads, stores, replaces, or deletes bounded memories in exactly one configured local or remote backend. Pass keys returned by scan unchanged when reading, for example {\"operation\":\"read\",\"keys\":[{\"id\":7,\"version\":1,\"namespace\":\"alice\"}]}. Remote reads include the authenticated and team namespaces. Put and delete are root-agent-only; remote mutation also requires a writer credential.",
+            "Explicitly searches, reads, stores, replaces, or deletes bounded memories in exactly one configured local or remote backend. A remote scan performs separate bounded retrievals for the authenticated namespace (ours) and other visible namespaces (theirs), so compare scores only within a group. Candidate keys identify their namespace. Pass keys returned by scan unchanged when reading, for example {\"operation\":\"read\",\"keys\":[{\"id\":7,\"version\":1,\"namespace\":\"alice\"}]}. Put and delete are root-agent-only; remote mutation also requires a writer credential.",
             memory_input_schema(),
         )
         .with_output_schema(memory_output_schema())
@@ -235,7 +239,13 @@ fn memory_input_schema() -> Value {
                 "properties": {
                     "operation": { "type": "string", "const": "scan" },
                     "query": { "type": "string", "minLength": 1, "maxLength": 512 },
-                    "limit": { "type": "integer", "minimum": 1, "maximum": 5, "default": 5 }
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "default": 5,
+                        "description": "Maximum candidates returned by each of the ours and theirs scans."
+                    }
                 },
                 "required": ["operation", "query"],
                 "additionalProperties": false
@@ -280,6 +290,7 @@ fn memory_input_schema() -> Value {
 fn memory_output_schema() -> Value {
     let record = memory_record_schema();
     let backend = memory_backend_schema();
+    let candidates = memory_candidates_schema();
     json!({
         "oneOf": [
             {
@@ -287,23 +298,10 @@ fn memory_output_schema() -> Value {
                 "properties": {
                     "operation": { "type": "string", "const": "scan" },
                     "backend": backend.clone(),
-                    "abstained": { "type": "boolean" },
-                    "candidates": {
-                        "type": "array",
-                        "maxItems": 5,
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "key": memory_key_schema(),
-                                "preview": { "type": "string", "maxLength": 64 },
-                                "score": { "type": "number" }
-                            },
-                            "required": ["key", "preview", "score"],
-                            "additionalProperties": false
-                        }
-                    }
+                    "ours": candidates.clone(),
+                    "theirs": candidates
                 },
-                "required": ["operation", "backend", "abstained", "candidates"],
+                "required": ["operation", "backend", "ours", "theirs"],
                 "additionalProperties": false
             },
             {
@@ -338,6 +336,23 @@ fn memory_output_schema() -> Value {
                 "additionalProperties": false
             }
         ]
+    })
+}
+
+fn memory_candidates_schema() -> Value {
+    json!({
+        "type": "array",
+        "maxItems": 5,
+        "items": {
+            "type": "object",
+            "properties": {
+                "key": memory_key_schema(),
+                "preview": { "type": "string", "maxLength": 64 },
+                "score": { "type": "number" }
+            },
+            "required": ["key", "preview", "score"],
+            "additionalProperties": false
+        }
     })
 }
 
@@ -455,8 +470,16 @@ mod tests {
             .iter()
             .find(|operation| operation["properties"]["operation"]["const"] == json!("scan"))
             .expect("scan output should be exposed");
-        let candidate = &scan_output["properties"]["candidates"]["items"];
-        assert_eq!(candidate["properties"]["preview"]["maxLength"], json!(64));
+        for group in ["ours", "theirs"] {
+            let candidates = &scan_output["properties"][group];
+            assert_eq!(candidates["maxItems"], json!(5));
+            assert_eq!(
+                candidates["items"]["properties"]["preview"]["maxLength"],
+                json!(64)
+            );
+        }
+        assert!(scan_output["properties"].get("abstained").is_none());
+        assert!(scan_output["properties"].get("candidates").is_none());
     }
 
     #[test]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -78,7 +78,7 @@ Local and remote modes expose the same memory operations and meanings:
 
 | Operation | Contract |
 | --- | --- |
-| `scan` | Search the selected backend and return at most five compact candidates. |
+| `scan` | Search the selected backend. Local scans populate `ours`; remote scans make separate requests returning up to five `ours` and five `theirs` candidates. |
 | `read` | Fetch complete records by exact current key. Missing or stale keys are omitted. |
 | `put` | Add one atomic conclusion, or replace a known record using its key and expected version. |
 | `delete` | Remove a known record using its key and expected version. |
@@ -95,7 +95,13 @@ The agent tool uses one exact key shape throughout. Pass scan candidate keys unc
 Root agents may mutate; child agents may only scan and read. Reader credentials make remote
 mutation unavailable regardless of agent role. Remote operations include the caller's namespace:
 an author can scan, read, and list their own remote records as well as records from other authors.
-Normalized duplicate content may exist in separate namespaces because ownership remains per author.
+Scan keeps those sources explicit: `ours` contains one response scoped to the authenticated
+namespace and `theirs` contains a second response scoped to every other visible namespace. Every key
+retains its author namespace. The requests are independently ranked and bounded, so one cannot crowd
+the other out and their corpus-relative scores are not comparable. If either request fails, the scan
+returns an error rather than a partial result or a local fallback. The agent decides which records to
+read and apply. Normalized duplicate content may exist in separate namespaces because ownership
+remains per author.
 
 The remote API is an authenticated JSON/HTTP interface. Its protocol generation is
 `tact_memory::VERSION`; routes and the session compatibility check use that same value:
@@ -103,7 +109,7 @@ The remote API is an authenticated JSON/HTTP interface. Its protocol generation 
 | Method and path | Role | Contract |
 | --- | --- | --- |
 | `GET /v{VERSION}/session` | reader | Return protocol version, authenticated namespace, and role. |
-| `POST /v{VERSION}/memories/scan` | reader | Search caller-visible records and return at most five candidates. |
+| `POST /v{VERSION}/memories/scan` | reader | Search one requested scope (`all`, `own`, or `others`) and return at most five candidates. `own` and `others` are resolved from the authenticated principal. |
 | `POST /v{VERSION}/memories/read` | reader | Resolve exact caller-visible keys. |
 | `POST /v{VERSION}/memories/list` | reader | List caller-visible records without telemetry changes. |
 | `POST /v{VERSION}/memories/put` | writer | Create a server-authored record or replace an exact current key in the writer's namespace. |
@@ -119,12 +125,12 @@ periods, hyphens, or underscores.
 Put allocates IDs, versions, timestamps, telemetry, and probation state on the server. Replacement
 checks the exact current key, increments the version, and resets server-owned state. Clients do not
 send local record metadata through ordinary put. Read omits missing or stale keys and updates read
-telemetry. Scan ranks at the store, returns no more than the requested limit or five candidates,
-and updates telemetry only for returned records. Ordinary requests do not transfer the remote
-corpus. List returns a deterministic inspection window of at most 512 visible records; production
-backends should enforce that bound in their storage query. Export preserves every namespaced record
-and uses stable bounded pages with an opaque continuation position; it does not deduplicate
-equivalent content.
+telemetry. Each scan request ranks one namespace scope at the store, returns no more than the
+requested limit or five candidates, and updates telemetry only for returned records. Ordinary
+requests do not transfer the remote corpus. List returns a deterministic inspection window of at
+most 512 visible records; production backends should enforce that bound in their storage query.
+Export preserves every namespaced record and uses stable bounded pages with an opaque continuation
+position; it does not deduplicate equivalent content.
 Stable exports must neither omit nor repeat records. A backend must define transaction or snapshot
 behavior that makes concurrent changes predictable.
 
@@ -161,7 +167,7 @@ lifecycle.
 Other backends must preserve the same semantics. SQL backends need transactional version checks,
 per-namespace uniqueness, capacity checks, and a deterministic export cursor. Cloudflare D1 or
 Durable Objects need a transactional or single-writer boundary. Database-native search is valid
-only when it reproduces visible scan behavior and the five-result bound.
+only when it reproduces visible single-scope scan behavior and the five-results-per-request bound.
 
 Remote errors are JSON objects containing only a stable code. Responses and traces must not echo
 request content, bearer tokens, database diagnostics, or credential details. Authentication,
@@ -303,11 +309,13 @@ Records carry a stable ID, monotonically increasing version, timestamps, and sep
 telemetry. A replacement and delete check the expected version so concurrent work cannot be
 silently overwritten. Remote keys add the server-authenticated author namespace; local keys do not.
 
-Retrieval uses lexical BM25 with `k1 = 1.2` and `b = 0.75`. A scan abstains when its query has no
-searchable terms or no active record shares a term. Ordinary scans return at most five cards and do
-not transfer the corpus to the caller. A short record is its own preview; a longer preview is a
-UTF-8-safe prefix of at most 64 bytes. `read` is the only operation that returns complete selected
-content and increments deliberate-read telemetry.
+Retrieval uses lexical BM25 with `k1 = 1.2` and `b = 0.75`. A scan request returns an empty candidate
+vector when its query has no searchable terms or no active record in its scope shares a term. Each
+request returns at most five cards and does not transfer its corpus to the caller. An agent-facing
+remote scan sends the authenticated-namespace request first and the other-namespaces request second,
+then preserves those responses as `ours` and `theirs`. A short record is its own preview; a longer
+preview is a UTF-8-safe prefix of at most 64 bytes. `read` is the only operation that returns complete
+selected content and increments deliberate-read telemetry.
 
 New model-authored records enter seven days of unread probation. A scan does not graduate a record;
 a successful read does. Replacement starts probation for the new version. The remote service uses
@@ -315,13 +323,13 @@ server time and server-owned telemetry.
 
 ## Bounds and transactions
 
-| Limit | v1 value |
+| Limit | v2 value |
 | --- | ---: |
 | Record content | 1 KiB |
 | Rows | 512 |
 | Total content | 256 KiB |
 | Local main database file | 4 MiB |
-| Scan results | 5 |
+| Scan results per request | 5 |
 
 Bounds apply to the global local corpus and independently to each remote writer namespace. A store
 may prune expired unread probation records before rejecting a capacity-increasing mutation, but it

--- a/examples/tact-memory-cloudflare/README.md
+++ b/examples/tact-memory-cloudflare/README.md
@@ -59,11 +59,13 @@ workspace_roots = ["/absolute/path/to/team/workspace"]
 ## Retrieval limits
 
 Tact performs exact BM25 ranking over a bounded shared corpus inside the Worker.
-`TACT_MEMORY_SCAN_MAX_RECORDS` and `TACT_MEMORY_SCAN_MAX_CONTENT_BYTES` bound the records and
-authored content loaded from D1 for one scan. The defaults permit 10,240 records and 5 MiB of
-content.
+`TACT_MEMORY_SCAN_MAX_RECORDS`, `TACT_MEMORY_SCAN_MAX_CONTENT_BYTES`, and
+`TACT_MEMORY_SCAN_MAX_RESULTS` bound the records and authored content loaded from D1 and the
+candidates returned for one scan. The defaults permit 10,240 records, 5 MiB of content, and five
+candidates. The result limit may be set from 1 through 5 and is further bounded by the request. The
+client issues an `own` request followed by an `others` request for an agent-facing remote scan.
 
-Choose limits from observed corpus size and Worker CPU usage. When the corpus exceeds either
+Choose limits from observed corpus size and Worker CPU usage. When the corpus exceeds either corpus
 bound, scans return a storage-capacity error. Export and mutation operations remain available so
 operators can reduce or migrate the corpus without editing D1 directly.
 

--- a/examples/tact-memory-cloudflare/src/config.rs
+++ b/examples/tact-memory-cloudflare/src/config.rs
@@ -1,26 +1,35 @@
 //! Non-secret deployment configuration loaded from Worker bindings.
 
 use crate::store::ScanBudget;
+use tact_memory::MemoryLimits;
 use thiserror::Error;
 use worker::Env;
 
 const SCAN_RECORDS_VARIABLE: &str = "TACT_MEMORY_SCAN_MAX_RECORDS";
 const SCAN_CONTENT_BYTES_VARIABLE: &str = "TACT_MEMORY_SCAN_MAX_CONTENT_BYTES";
+const SCAN_RESULTS_VARIABLE: &str = "TACT_MEMORY_SCAN_MAX_RESULTS";
 
-/// Failure to load a positive shared-scan resource budget.
+/// Failure to load a valid shared-scan resource budget.
 #[derive(Debug, Error)]
 pub(super) enum ConfigError {
     #[error("missing Worker variable {name}")]
     Missing { name: &'static str },
     #[error("Worker variable {name} must be a positive integer")]
     Invalid { name: &'static str },
+    #[error("Worker variable {name} must not exceed {maximum}")]
+    AboveMaximum { name: &'static str, maximum: usize },
 }
 
-/// Loads the deployment's maximum Worker-side BM25 corpus.
+/// Loads the deployment's Worker-side BM25 scan budget.
 pub(super) fn scan_budget(environment: &Env) -> Result<ScanBudget, ConfigError> {
     Ok(ScanBudget {
         records: positive_usize(environment, SCAN_RECORDS_VARIABLE)?,
         content_bytes: positive_usize(environment, SCAN_CONTENT_BYTES_VARIABLE)?,
+        results: at_most(
+            positive_usize(environment, SCAN_RESULTS_VARIABLE)?,
+            SCAN_RESULTS_VARIABLE,
+            MemoryLimits::PRODUCTION.scan_results,
+        )?,
     })
 }
 
@@ -29,9 +38,54 @@ fn positive_usize(environment: &Env, name: &'static str) -> Result<usize, Config
         .var(name)
         .map_err(|_| ConfigError::Missing { name })?
         .to_string();
+    parse_positive_usize(&value, name)
+}
+
+fn parse_positive_usize(value: &str, name: &'static str) -> Result<usize, ConfigError> {
     value
         .parse()
         .ok()
         .filter(|value| *value > 0)
         .ok_or(ConfigError::Invalid { name })
+}
+
+fn at_most(value: usize, name: &'static str, maximum: usize) -> Result<usize, ConfigError> {
+    if value > maximum {
+        return Err(ConfigError::AboveMaximum { name, maximum });
+    }
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigError, SCAN_RESULTS_VARIABLE, at_most, parse_positive_usize};
+    use tact_memory::MemoryLimits;
+
+    #[test]
+    fn positive_integer_variables_reject_zero_and_malformed_values() {
+        assert!(parse_positive_usize("1", "TEST").is_ok());
+        for value in ["0", "-1", "invalid"] {
+            assert!(matches!(
+                parse_positive_usize(value, "TEST"),
+                Err(ConfigError::Invalid { name: "TEST" })
+            ));
+        }
+    }
+
+    #[test]
+    fn scan_result_limit_cannot_exceed_the_protocol_bound() {
+        let maximum = MemoryLimits::PRODUCTION.scan_results;
+        assert_eq!(at_most(1, SCAN_RESULTS_VARIABLE, maximum).unwrap(), 1);
+        assert_eq!(
+            at_most(maximum, SCAN_RESULTS_VARIABLE, maximum).unwrap(),
+            maximum
+        );
+        assert!(matches!(
+            at_most(maximum + 1, SCAN_RESULTS_VARIABLE, maximum),
+            Err(ConfigError::AboveMaximum {
+                name: SCAN_RESULTS_VARIABLE,
+                maximum: rejected_maximum,
+            }) if rejected_maximum == maximum
+        ));
+    }
 }

--- a/examples/tact-memory-cloudflare/src/store.rs
+++ b/examples/tact-memory-cloudflare/src/store.rs
@@ -11,8 +11,8 @@ use row::{CapacityRow, CorpusRow, DecodeResult, ReplaceRow, SyncRow, VersionRow}
 use serde::Serialize;
 use std::{collections::HashSet, fmt::Display, future::Future, sync::Arc};
 use tact_memory::{
-    MemoryError, MemoryKey, MemoryLimits, MemoryRecord, MemoryScan, MemoryStore,
-    normalize_identity,
+    MemoryCandidate, MemoryError, MemoryKey, MemoryLimits, MemoryNamespaceFilter, MemoryRecord,
+    MemoryStore, normalize_identity,
     server::protocol::{self, ExportCursor, SyncReport},
 };
 use thiserror::Error;
@@ -32,6 +32,15 @@ const VISIBLE_RECORD_SQL: &str = "(memories.probation_until_ms IS NULL OR memori
 pub(crate) struct ScanBudget {
     pub(crate) records: usize,
     pub(crate) content_bytes: usize,
+    pub(crate) results: usize,
+}
+
+impl ScanBudget {
+    fn result_limit(self, requested: usize) -> usize {
+        requested
+            .min(self.results)
+            .min(MemoryLimits::PRODUCTION.scan_results)
+    }
 }
 
 /// Namespace-bound shared memory backed by Cloudflare D1.
@@ -92,8 +101,9 @@ impl MemoryStore for CloudflareMemoryStore {
     fn scan(
         &self,
         query: &str,
+        namespaces: MemoryNamespaceFilter,
         limit: usize,
-    ) -> impl Future<Output = Result<MemoryScan, MemoryError>> + Send {
+    ) -> impl Future<Output = Result<Vec<MemoryCandidate>, MemoryError>> + Send {
         let store = self.clone();
         let query = query.to_owned();
         SendFuture::new(async move {
@@ -105,19 +115,37 @@ impl MemoryStore for CloudflareMemoryStore {
             }
             let now = current_time_ms().to_string();
             let scan_budget = store.scan_budget;
+            let (namespace_sql, namespace) = match &namespaces {
+                MemoryNamespaceFilter::All => ("", None),
+                MemoryNamespaceFilter::Exact(namespace) => {
+                    (" AND memories.namespace = ?", Some(namespace.as_str()))
+                }
+                MemoryNamespaceFilter::OtherThan(namespace) => {
+                    (" AND memories.namespace != ?", Some(namespace.as_str()))
+                }
+            };
             let corpus_size_sql = format!(
-                "SELECT COUNT(*) AS record_count, COALESCE(SUM(length(CAST(content AS BLOB))), 0) AS content_bytes FROM memories WHERE {VISIBLE_RECORD_SQL}"
+                "SELECT COUNT(*) AS record_count, COALESCE(SUM(length(CAST(content AS BLOB))), 0) AS content_bytes FROM memories WHERE {VISIBLE_RECORD_SQL}{namespace_sql}"
             );
             let corpus_sql = format!(
-                "SELECT {RECORD_COLUMNS} FROM memories WHERE {VISIBLE_RECORD_SQL} AND (SELECT COUNT(*) FROM memories WHERE {VISIBLE_RECORD_SQL}) <= {} AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE {VISIBLE_RECORD_SQL}) <= {} ORDER BY namespace, id",
+                "SELECT {RECORD_COLUMNS} FROM memories WHERE {VISIBLE_RECORD_SQL}{namespace_sql} AND (SELECT COUNT(*) FROM memories WHERE {VISIBLE_RECORD_SQL}{namespace_sql}) <= {} AND (SELECT COALESCE(SUM(length(CAST(content AS BLOB))), 0) FROM memories WHERE {VISIBLE_RECORD_SQL}{namespace_sql}) <= {} ORDER BY namespace, id",
                 scan_budget.records, scan_budget.content_bytes
             );
+            let bindings = |repetitions| {
+                let mut values = Vec::new();
+                for _ in 0..repetitions {
+                    values.push(D1Type::Text(&now));
+                    if let Some(namespace) = namespace {
+                        values.push(D1Type::Text(namespace));
+                    }
+                }
+                values
+            };
+            let corpus_size_bindings = bindings(1);
+            let corpus_bindings = bindings(3);
             let statements = vec![
-                store.statement(corpus_size_sql, &[D1Type::Text(&now)])?,
-                store.statement(
-                    corpus_sql,
-                    &[D1Type::Text(&now), D1Type::Text(&now), D1Type::Text(&now)],
-                )?,
+                store.statement(corpus_size_sql, &corpus_size_bindings)?,
+                store.statement(corpus_sql, &corpus_bindings)?,
             ];
             let results = store.batch(statements).await?;
             let corpus = results[0].one::<CorpusRow>()?;
@@ -127,10 +155,16 @@ impl MemoryStore for CloudflareMemoryStore {
                 return Err(MemoryError::StorageCapacity);
             }
             let records = results[1].records()?;
-            let scan = MemoryScan::rank(&query, &records, limit.min(limits.scan_results));
-            let mut updates = Vec::with_capacity(scan.candidates.len() + 1);
+            let candidates = MemoryCandidate::rank(
+                &query,
+                records
+                    .iter()
+                    .filter(|record| namespaces.includes(&record.key)),
+                scan_budget.result_limit(limit),
+            );
+            let mut updates = Vec::with_capacity(candidates.len() + 1);
             updates.push(store.statement(PRUNE_SQL, &[D1Type::Text(&now)])?);
-            for candidate in &scan.candidates {
+            for candidate in &candidates {
                 let namespace = candidate.key.namespace.as_deref().unwrap_or_default();
                 updates.push(store.statement(
                     "UPDATE memories SET last_scanned_at_ms = CAST(? AS INTEGER), scan_count = CASE WHEN scan_count < 9223372036854775807 THEN scan_count + 1 ELSE scan_count END WHERE namespace = ? AND id = CAST(? AS INTEGER) AND version = CAST(? AS INTEGER)",
@@ -143,7 +177,7 @@ impl MemoryStore for CloudflareMemoryStore {
                 )?);
             }
             store.batch(updates).await?;
-            Ok(scan)
+            Ok(candidates)
         })
     }
 
@@ -635,8 +669,29 @@ fn current_time_ms() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::RECORD_COLUMNS;
+    use super::{RECORD_COLUMNS, ScanBudget};
     use rusqlite::{Connection, params};
+    use tact_memory::MemoryLimits;
+
+    #[test]
+    fn scan_result_limit_honors_request_deployment_and_protocol_bounds() {
+        let budget = ScanBudget {
+            records: 1,
+            content_bytes: 1,
+            results: 3,
+        };
+        assert_eq!(budget.result_limit(2), 2);
+        assert_eq!(budget.result_limit(5), 3);
+
+        let oversized = ScanBudget {
+            results: usize::MAX,
+            ..budget
+        };
+        assert_eq!(
+            oversized.result_limit(usize::MAX),
+            MemoryLimits::PRODUCTION.scan_results
+        );
+    }
 
     #[test]
     fn read_projection_is_unambiguous() {

--- a/examples/tact-memory-cloudflare/wrangler.jsonc
+++ b/examples/tact-memory-cloudflare/wrangler.jsonc
@@ -6,7 +6,8 @@
   "workers_dev": true,
   "vars": {
     "TACT_MEMORY_SCAN_MAX_RECORDS": "10240",
-    "TACT_MEMORY_SCAN_MAX_CONTENT_BYTES": "5242880"
+    "TACT_MEMORY_SCAN_MAX_CONTENT_BYTES": "5242880",
+    "TACT_MEMORY_SCAN_MAX_RESULTS": "5"
   },
   "build": {
     "command": "worker-build --release"


### PR DESCRIPTION
## Summary

Remote scans now retrieve the authenticated namespace and all other visible namespaces independently, then present both groups to the agent as ours and theirs. This prevents either source from crowding out the other while leaving the agent free to choose the strongest guidance.

- make each store scan operate on one namespace scope and return a candidate vector; an empty vector means no match
- issue own and others requests sequentially on one bookmark chain, with each response independently ranked and bounded
- derive scan scopes from the authenticated server identity and validate response ownership and ordering
- push scope filtering and a configurable per-scope result limit into the Cloudflare Worker
- render only the current grouped scan shape in the TUI and update the memory documentation

Local scans continue to use the selected local backend and populate only ours. Remote failures remain all-or-error and never fall back locally.