### PR TITLE
feat(memory): add explicit corpus inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ recommends whether each lesson belongs in memory, always-on configuration, or no
 instructions can narrow the topic or expand the workspace and task-family scope. The report states
 the coverage and uncertainty of its evidence; it does not apply its recommendations.
 
+Ordinary reflection remains session-first and uses targeted memory scans. If the optional
+instructions explicitly request a memory-corpus audit, inspection, or cleanup review, Reflection can
+page through compact, telemetry-neutral memory inspection results and read selected full records.
+It reports exact keys and versions, backend and namespace scope, coverage, truncation, and
+uncertainty; pagination is best-effort rather than a coherent snapshot. Reflection may recommend
+replacing or deleting duplicate, stale, oversized, low-value, or retrieval-conflicting records, but
+it remains report-only and never performs those mutations.
+
 ### Review
 
 Enter `/review` while no agent work is active to open a browser-based human review tool for

--- a/bin/tact/src/tui/components/transcript/tool/memory.rs
+++ b/bin/tact/src/tui/components/transcript/tool/memory.rs
@@ -17,6 +17,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
     match operation {
         Operation::Scan { query } => scan(query, result, width, theme, expanded),
         Operation::Read { keys } => read(keys, result, width, theme, expanded),
+        Operation::Inspect { cursor } => inspect(cursor, result, width, theme, expanded),
         Operation::Put { content, replace } => {
             put(content, replace, result, width, theme, expanded)
         }
@@ -30,6 +31,9 @@ enum Operation<'a> {
     },
     Read {
         keys: Vec<MemoryKey>,
+    },
+    Inspect {
+        cursor: Option<MemoryKey>,
     },
     Put {
         content: &'a str,
@@ -50,6 +54,12 @@ impl<'a> Operation<'a> {
             "read" => Some(Self::Read {
                 keys: parse_keys(arguments.get("keys").or_else(|| arguments.get("ids"))?)?,
             }),
+            "inspect" => Some(Self::Inspect {
+                cursor: match arguments.get("cursor") {
+                    Some(cursor) => Some(MemoryKey::parse(cursor)?),
+                    None => None,
+                },
+            }),
             "put" => Some(Self::Put {
                 content: arguments.get("content")?.as_str()?,
                 replace: match arguments.get("replace") {
@@ -68,6 +78,7 @@ impl<'a> Operation<'a> {
         match self {
             Self::Scan { .. } => "scan",
             Self::Read { .. } => "read",
+            Self::Inspect { .. } => "inspect",
             Self::Put { .. } => "put",
             Self::Delete { .. } => "delete",
         }
@@ -84,6 +95,11 @@ enum ResultValue<'a> {
     Read {
         backend: Option<Backend>,
         memories: Vec<Memory<'a>>,
+    },
+    Inspect {
+        backend: Option<Backend>,
+        memories: InspectionMemories<'a>,
+        complete: bool,
     },
     Put {
         backend: Option<Backend>,
@@ -124,6 +140,17 @@ impl<'a> ResultValue<'a> {
                     .map(Memory::parse)
                     .collect::<Option<Vec<_>>>()?,
             }),
+            "inspect" => {
+                let coverage = result.get("coverage")?;
+                if coverage.get("consistency")?.as_str()? != "best_effort" {
+                    return None;
+                }
+                Some(Self::Inspect {
+                    backend: Backend::parse(result.get("backend")),
+                    memories: InspectionMemories::parse(result)?,
+                    complete: coverage.get("complete")?.as_bool()?,
+                })
+            }
             "put" => Some(Self::Put {
                 backend: Backend::parse(result.get("backend")),
                 memory: Memory::parse(result.get("memory")?)?,
@@ -280,6 +307,48 @@ struct Memory<'a> {
     fields: &'a Map<String, Value>,
 }
 
+struct InspectionMemories<'a> {
+    ours: Vec<InspectionMemory<'a>>,
+    theirs: Vec<InspectionMemory<'a>>,
+}
+
+impl<'a> InspectionMemories<'a> {
+    fn parse(result: &'a Value) -> Option<Self> {
+        Some(Self {
+            ours: parse_inspection_memories(result.get("ours")?)?,
+            theirs: parse_inspection_memories(result.get("theirs")?)?,
+        })
+    }
+
+    fn total(&self) -> usize {
+        self.ours.len().saturating_add(self.theirs.len())
+    }
+}
+
+struct InspectionMemory<'a> {
+    key: MemoryKey,
+    preview: &'a str,
+    fields: &'a Map<String, Value>,
+}
+
+impl<'a> InspectionMemory<'a> {
+    fn parse(value: &'a Value) -> Option<Self> {
+        Some(Self {
+            key: MemoryKey::parse(value)?,
+            preview: value.get("preview")?.as_str()?,
+            fields: value.as_object()?,
+        })
+    }
+}
+
+fn parse_inspection_memories(value: &Value) -> Option<Vec<InspectionMemory<'_>>> {
+    value
+        .as_array()?
+        .iter()
+        .map(InspectionMemory::parse)
+        .collect::<Option<Vec<_>>>()
+}
+
 impl<'a> Memory<'a> {
     fn parse(value: &'a Value) -> Option<Self> {
         Some(Self {
@@ -399,6 +468,67 @@ fn read(
     presentation.footer(count)
 }
 
+fn inspect(
+    cursor: Option<MemoryKey>,
+    result: ResultValue<'_>,
+    width: u16,
+    theme: &Theme,
+    expanded: bool,
+) -> Presentation {
+    let subject = cursor.as_ref().map_or_else(
+        || "first page".to_owned(),
+        |cursor| format!("after {}", cursor.display()),
+    );
+    let ResultValue::Inspect {
+        backend,
+        memories,
+        complete,
+    } = result
+    else {
+        return Presentation::new("Memory inspect", subject);
+    };
+    let count = count_label(memories.total(), "record", "records");
+    let coverage = if complete {
+        "complete"
+    } else {
+        "more available"
+    };
+    let presentation =
+        completed_presentation(backend.as_ref(), "inspect", "Memory inspect", subject)
+            .outcome(format!("{count} · {coverage}"));
+    if !expanded {
+        return presentation;
+    }
+
+    let mut presentation = presentation;
+    presentation = append_inspection_group(presentation, "Ours", &memories.ours, width, theme);
+    presentation = append_inspection_group(presentation, "Theirs", &memories.theirs, width, theme);
+    presentation.footer(format!("{count} · best-effort page"))
+}
+
+fn append_inspection_group(
+    mut presentation: Presentation,
+    label: &str,
+    memories: &[InspectionMemory<'_>],
+    width: u16,
+    theme: &Theme,
+) -> Presentation {
+    presentation = presentation.selectable_plain(label, width, Style::default().fg(theme.accent()));
+    for memory in memories {
+        let key = memory.key.display();
+        presentation =
+            presentation.selectable_plain(&key, width, Style::default().fg(theme.accent()));
+        let preview = super::truncate(memory.preview, MAX_PREVIEW_WIDTH);
+        presentation =
+            presentation.selectable_plain(&preview, width, Style::default().fg(theme.text()));
+        if let Some(metadata) = selected_metadata(memory.fields) {
+            presentation =
+                presentation.selectable_plain(&metadata, width, Style::default().fg(theme.muted()));
+        }
+    }
+    presentation
+}
+
 fn put(
     content: &str,
     replace: Option<MemoryKey>,
@@ -491,6 +621,7 @@ fn selected_metadata(fields: &Map<String, Value>) -> Option<String> {
         ("last_used_at_ms", "last used"),
         ("use_count", "uses"),
         ("probation_until_ms", "probation until"),
+        ("content_bytes", "bytes"),
     ]
     .into_iter()
     .filter_map(|(field, label)| scalar(fields.get(field)?).map(|value| format!("{label} {value}")))
@@ -601,6 +732,25 @@ mod tests {
         })
     }
 
+    fn inspection_record(namespace: Option<&str>, id: i64, preview: &str) -> Value {
+        let mut key = json!({"id": id, "version": 1});
+        if let Some(namespace) = namespace {
+            key["namespace"] = json!(namespace);
+        }
+        json!({
+            "key": key,
+            "preview": preview,
+            "content_bytes": preview.len(),
+            "created_at_ms": 10,
+            "updated_at_ms": 20,
+            "last_scanned_at_ms": null,
+            "scan_count": 2,
+            "last_used_at_ms": 30,
+            "use_count": 1,
+            "probation_until_ms": null
+        })
+    }
+
     #[test]
     fn summaries_cover_operations_states_and_results() {
         let cases = [
@@ -634,6 +784,25 @@ mod tests {
                     ),
                 ),
                 "Memory read  7@v2 · 1 memory",
+            ),
+            (
+                memory(
+                    json!({"operation": "inspect"}),
+                    ToolState::Succeeded,
+                    Some(json!({
+                        "operation": "inspect",
+                        "backend": {"source": "local", "namespace": null, "role": null},
+                        "ours": [inspection_record(None, 7, "Use early returns.")],
+                        "theirs": [],
+                        "next_cursor": null,
+                        "coverage": {
+                            "records": 1,
+                            "complete": true,
+                            "consistency": "best_effort"
+                        }
+                    })),
+                ),
+                "Memory inspect · local · first page · 1 record · complete",
             ),
             (
                 memory(
@@ -801,6 +970,40 @@ mod tests {
         assert!(expanded.contains("alice:1@v1"), "{expanded}");
         assert!(expanded.contains("bob:1@v1"), "{expanded}");
         assert!(expanded.contains("10 candidates"), "{expanded}");
+    }
+
+    #[test]
+    fn inspection_presents_attributed_groups_and_best_effort_coverage() {
+        let tool = memory(
+            json!({"operation": "inspect", "cursor": {"namespace": "alice", "id": 4}}),
+            ToolState::Succeeded,
+            Some(json!({
+                "operation": "inspect",
+                "backend": {"source": "remote", "namespace": "alice", "role": "reader"},
+                "ours": [inspection_record(Some("alice"), 5, "Our durable rule.")],
+                "theirs": [inspection_record(Some("bob"), 1, "Their related rule.")],
+                "next_cursor": {"namespace": "bob", "id": 1},
+                "coverage": {
+                    "records": 2,
+                    "complete": false,
+                    "consistency": "best_effort"
+                }
+            })),
+        );
+
+        let collapsed = text(&render(&tool, 100, &Theme::default()));
+        assert!(
+            collapsed
+                .contains("Memory inspect · remote · after alice:4 · 2 records · more available"),
+            "{collapsed}"
+        );
+        let expanded = text(&render_expanded(&tool, 100, &Theme::default()));
+        assert!(expanded.contains("Ours"), "{expanded}");
+        assert!(expanded.contains("Theirs"), "{expanded}");
+        assert!(expanded.contains("alice:5@v1"), "{expanded}");
+        assert!(expanded.contains("bob:1@v1"), "{expanded}");
+        assert!(expanded.contains("bytes 17"), "{expanded}");
+        assert!(expanded.contains("best-effort page"), "{expanded}");
     }
 
     #[test]

--- a/bin/tact/src/tui/worker.rs
+++ b/bin/tact/src/tui/worker.rs
@@ -229,6 +229,19 @@ const REFLECTION_PROMPT: &str = concat!(
     "or add one atomic memory, add a concise always-on prompt rule only when repeated retrieval ",
     "misses justify it, or make no change when the lesson is transient, searchable, or already ",
     "covered.\n\n",
+    "Ordinary reflection remains session-first and uses targeted memory retrieval. Only when the ",
+    "additional instructions explicitly ask to audit, inspect, or clean up the memory corpus, use ",
+    "the memory `inspect` operation to enumerate its fixed-size pages. Continue with each exact ",
+    "`next_cursor` issued by the preceding call until coverage is complete or a tool/output bound ",
+    "stops the audit. Treat pagination ",
+    "as best-effort under concurrent changes, not as one coherent snapshot. Compare full records with ",
+    "targeted `read` calls as needed to identify duplicates, stale or oversized records, low-value ",
+    "records, and records whose overlap may conflict during retrieval. Before recommending a change, ",
+    "run a narrow scan for the proposed conclusion and read every plausible match. Keep remote `ours` ",
+    "and `theirs` ownership distinct. Report exact keys and versions, backend and namespace scope, ",
+    "pages and records covered, truncation, secret-suppression limits, and uncertainty from concurrent ",
+    "changes or incomplete coverage. Do not inspect the corpus merely because ordinary reflection ",
+    "found a possible memory lesson.\n\n",
     "This is a read-only analysis turn. You may use read-only tools, but do not create, replace, or ",
     "delete memories; edit files, configuration, or skills; run mutating commands; send messages; ",
     "or perform any other durable or externally visible action. Proposed changes require a later, ",
@@ -1123,6 +1136,12 @@ mod tests {
         assert!(!text.contains("sqlite3"));
         assert!(!text.contains("session_database"));
         assert!(text.contains("global-memory scans"));
+        assert!(text.contains("explicitly ask to audit, inspect, or clean up"));
+        assert!(text.contains("memory `inspect` operation"));
+        assert!(text.contains("not as one coherent snapshot"));
+        assert!(text.contains("exact keys and versions"));
+        assert!(text.contains("Keep remote `ours` and `theirs` ownership distinct"));
+        assert!(text.contains("Do not inspect the corpus merely because ordinary reflection"));
         assert!(text.contains("config show"));
         assert!(text.contains("read-only analysis turn"));
         assert!(text.contains("do not create, replace, or delete memories"));

--- a/crates/memory/README.md
+++ b/crates/memory/README.md
@@ -16,8 +16,8 @@ The crate exposes four integration boundaries:
   application choose one local or remote backend for a runtime.
 - `RemoteMemoryClient` and `MemoryServer` share versioned protocol types and preserve author
   namespaces across authenticated operations.
-- `MemoryTool` exposes explicit scan, read, put, and delete operations to Nanocodex sessions under
-  an application-provided mutation authority.
+- `MemoryTool` exposes explicit scan, read, inspection, put, and delete operations to Nanocodex
+  sessions under an application-provided mutation authority.
 
 Each `MemoryStore` scan request returns one bounded candidate vector selected by a
 `MemoryNamespaceFilter`. The agent-facing remote scan makes separate requests for the authenticated

--- a/crates/memory/src/retrieval.rs
+++ b/crates/memory/src/retrieval.rs
@@ -184,7 +184,7 @@ fn split_camel_case(identifier: &str) -> Vec<&str> {
     components
 }
 
-fn preview(content: &str) -> String {
+pub(crate) fn preview(content: &str) -> String {
     if content.len() <= PREVIEW_MAX_BYTES {
         return content.to_owned();
     }

--- a/crates/memory/src/server/tests.rs
+++ b/crates/memory/src/server/tests.rs
@@ -1209,6 +1209,25 @@ async fn unsafe_scan() -> Json<ScanResponse> {
     })
 }
 
+async fn secret_then_safe_export(Json(request): Json<ExportRequest>) -> Json<ExportResponse> {
+    let mut memory = match request.cursor {
+        None => record(1, 1, "password=hunter2"),
+        Some(ExportCursor { namespace, id }) if namespace == "alice" && id == 1 => {
+            record(2, 1, "safe record after suppressed page")
+        }
+        cursor => panic!("unexpected export cursor: {cursor:?}"),
+    };
+    memory.key = MemoryKey::remote("alice".to_owned(), memory.key.id, 1);
+    let next_cursor = (memory.key.id == 1).then(|| ExportCursor {
+        namespace: "alice".to_owned(),
+        id: 1,
+    });
+    Json(ExportResponse {
+        memories: vec![memory],
+        next_cursor,
+    })
+}
+
 async fn malformed_scan() -> Json<ScanResponse> {
     Json(ScanResponse {
         candidates: vec![MemoryCandidate {
@@ -1810,6 +1829,28 @@ async fn client_enforces_the_requested_export_page_size() {
         source.downcast_ref::<RemoteClientError>(),
         Some(RemoteClientError::InvalidResponse)
     ));
+    task.abort();
+}
+
+#[tokio::test]
+async fn complete_export_advances_past_a_secret_only_filtered_page() {
+    let app = Router::new().route(
+        &format!("/{}", protocol::EXPORT_PATH),
+        post(secret_then_safe_export),
+    );
+    let (endpoint, task) = live_server(app).await;
+    let client = RemoteMemoryClient::new(
+        &endpoint,
+        "alice".to_owned(),
+        RemoteToken::new(ALICE_TOKEN.to_owned()).unwrap(),
+    )
+    .unwrap();
+
+    let memories = client.export_all(None).await.unwrap();
+
+    assert_eq!(memories.len(), 1);
+    assert_eq!(memories[0].key, MemoryKey::remote("alice".to_owned(), 2, 1));
+    assert_eq!(memories[0].content, "safe record after suppressed page");
     task.abort();
 }
 

--- a/crates/memory/src/store/mod.rs
+++ b/crates/memory/src/store/mod.rs
@@ -113,8 +113,9 @@ pub trait MemoryStore: Clone + Send + Sync + 'static {
 
     /// Collects a complete bounded export through the paginated storage contract.
     ///
-    /// The collector rejects non-progressing cursors and stops before retaining more records or
-    /// content than a local store can import.
+    /// The collector follows progressing pages even when client policy filters every record from a
+    /// page. It bounds page requests, rejects non-progressing cursors, and stops before retaining
+    /// more records or content than a local store can import.
     fn export_all(
         &self,
         namespaces: Option<&[String]>,
@@ -123,7 +124,14 @@ pub trait MemoryStore: Clone + Send + Sync + 'static {
             let mut cursor = None;
             let mut records = Vec::new();
             let mut content_bytes = 0usize;
+            let mut page_requests = 0usize;
             loop {
+                page_requests = page_requests
+                    .checked_add(1)
+                    .ok_or(MemoryError::InvalidPagination)?;
+                if page_requests > MemoryLimits::PRODUCTION.records.saturating_add(1) {
+                    return Err(MemoryError::InvalidPagination);
+                }
                 let (page, next_cursor) = self
                     .export_page(
                         namespaces,
@@ -143,10 +151,13 @@ pub trait MemoryStore: Clone + Send + Sync + 'static {
                     .ok_or(MemoryError::InvalidPagination)?;
                 if next_record_count > MemoryLimits::PRODUCTION.records
                     || content_bytes > MemoryLimits::PRODUCTION.total_content_bytes
-                    || next_cursor
-                        .as_ref()
-                        .is_some_and(|next| cursor.as_ref() == Some(next))
-                    || (page.is_empty() && next_cursor.is_some())
+                    || next_cursor.as_ref().is_some_and(|next| {
+                        next.id <= 0
+                            || cursor.as_ref().is_some_and(|cursor| {
+                                (next.namespace.as_str(), next.id)
+                                    <= (cursor.namespace.as_str(), cursor.id)
+                            })
+                    })
                 {
                     return Err(MemoryError::InvalidPagination);
                 }

--- a/crates/memory/src/store/remote/client.rs
+++ b/crates/memory/src/store/remote/client.rs
@@ -420,7 +420,7 @@ impl RemoteMemoryClient {
             let ordered = previous.as_ref().is_none_or(|previous| {
                 (namespace, memory.key.id) > (previous.namespace.as_str(), previous.id)
             });
-            if !Self::valid_record(memory) || !selected || !ordered {
+            if !Self::valid_record_structure(memory) || !selected || !ordered {
                 return Err(RemoteClientError::InvalidResponse);
             }
 
@@ -468,13 +468,17 @@ impl RemoteMemoryClient {
     }
 
     fn valid_record(memory: &MemoryRecord) -> bool {
+        Self::valid_record_structure(memory)
+            && !crate::secrets::contains_likely_secret(&memory.content)
+    }
+
+    fn valid_record_structure(memory: &MemoryRecord) -> bool {
         Self::valid_key(&memory.key)
             && memory.key.namespace.is_some()
             && !memory.content.trim().is_empty()
             && memory.content.len() <= MemoryLimits::PRODUCTION.content_bytes
             && memory.created_at_ms >= 0
             && memory.updated_at_ms >= memory.created_at_ms
-            && !crate::secrets::contains_likely_secret(&memory.content)
     }
 
     async fn get<Response>(&self, path: &str, replay: Replay) -> Result<Response, RemoteClientError>
@@ -643,7 +647,12 @@ impl MemoryStore for RemoteMemoryClient {
                 return Err(RemoteClientError::InvalidResponse.into());
             }
             Self::validate_export_page(namespaces.as_deref(), cursor.as_ref(), 0, 0, &response)?;
-            Ok((response.memories, response.next_cursor))
+            let memories = response
+                .memories
+                .into_iter()
+                .filter(Self::valid_record)
+                .collect();
+            Ok((memories, response.next_cursor))
         }
     }
 }
@@ -833,6 +842,17 @@ mod tests {
             0,
             &response(vec![memory("alpha", 1, "one")], Some(("alpha", 2))),
         )));
+    }
+
+    #[test]
+    fn export_page_validates_cursor_before_suppressing_secret_like_content() {
+        let page = response(
+            vec![memory("alpha", 1, "password=hunter2")],
+            Some(("alpha", 1)),
+        );
+
+        assert!(RemoteMemoryClient::validate_export_page(None, None, 0, 0, &page).is_ok());
+        assert!(!RemoteMemoryClient::valid_record(&page.memories[0]));
     }
 
     #[test]

--- a/crates/memory/src/tool.rs
+++ b/crates/memory/src/tool.rs
@@ -2,6 +2,7 @@
 
 use super::{
     MemoryAccess, MemoryCandidate, MemoryKey, MemoryRecord, MemoryStore, SelectedMemoryStore,
+    server::protocol::ExportCursor,
 };
 use nanocodex::{
     Tool,
@@ -12,12 +13,15 @@ use nanocodex::{
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Value, json};
 use std::{
+    future::Future,
     io,
     sync::atomic::{AtomicBool, Ordering},
 };
 use zeroize::Zeroizing;
 
 const DEFAULT_SCAN_LIMIT: usize = 5;
+const INSPECTION_PAGE_RECORDS: usize = 20;
+const INSPECTION_PAGES_PER_CALL: usize = 4;
 
 #[derive(Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
@@ -29,6 +33,10 @@ enum MemoryOperation {
     },
     Read {
         keys: Vec<MemoryKey>,
+    },
+    Inspect {
+        #[serde(default)]
+        cursor: Option<InspectionCursor>,
     },
     Put {
         content: MemoryContent,
@@ -89,6 +97,78 @@ struct ReadOutput {
     memories: Vec<MemoryRecord>,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct InspectionCursor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    namespace: Option<String>,
+    id: i64,
+}
+
+impl InspectionCursor {
+    fn into_export(self) -> ExportCursor {
+        ExportCursor {
+            namespace: self.namespace.unwrap_or_default(),
+            id: self.id,
+        }
+    }
+
+    fn from_export(cursor: ExportCursor) -> Self {
+        Self {
+            namespace: (!cursor.namespace.is_empty()).then_some(cursor.namespace),
+            id: cursor.id,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct InspectOutput {
+    operation: &'static str,
+    backend: MemoryAccess,
+    ours: Vec<InspectionRecord>,
+    theirs: Vec<InspectionRecord>,
+    next_cursor: Option<InspectionCursor>,
+    coverage: InspectionCoverage,
+}
+
+#[derive(Serialize)]
+struct InspectionCoverage {
+    records: usize,
+    complete: bool,
+    consistency: &'static str,
+}
+
+#[derive(Serialize)]
+struct InspectionRecord {
+    key: MemoryKey,
+    preview: String,
+    content_bytes: usize,
+    created_at_ms: i64,
+    updated_at_ms: i64,
+    last_scanned_at_ms: Option<i64>,
+    scan_count: u64,
+    last_used_at_ms: Option<i64>,
+    use_count: u64,
+    probation_until_ms: Option<i64>,
+}
+
+impl From<MemoryRecord> for InspectionRecord {
+    fn from(memory: MemoryRecord) -> Self {
+        Self {
+            key: memory.key,
+            preview: crate::retrieval::preview(&memory.content),
+            content_bytes: memory.content.len(),
+            created_at_ms: memory.created_at_ms,
+            updated_at_ms: memory.updated_at_ms,
+            last_scanned_at_ms: memory.last_scanned_at_ms,
+            scan_count: memory.scan_count,
+            last_used_at_ms: memory.last_used_at_ms,
+            use_count: memory.use_count,
+            probation_until_ms: memory.probation_until_ms,
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct PutOutput {
     operation: &'static str,
@@ -116,6 +196,7 @@ pub struct MemoryTool<A> {
     store: SelectedMemoryStore,
     authorizer: A,
     searched: AtomicBool,
+    inspection_cursor: tokio::sync::Mutex<Option<InspectionCursor>>,
 }
 
 impl<A> MemoryTool<A>
@@ -128,6 +209,7 @@ where
             store,
             authorizer,
             searched: AtomicBool::new(false),
+            inspection_cursor: tokio::sync::Mutex::const_new(None),
         }
     }
 
@@ -160,6 +242,72 @@ where
             operation: "read",
             backend,
             memories,
+        })
+    }
+
+    async fn inspect(&self, cursor: Option<InspectionCursor>) -> ToolResult {
+        if cursor.as_ref().is_some_and(|cursor| cursor.id <= 0) {
+            return Err(io::Error::other("memory inspection cursor is invalid").into());
+        }
+        // Hold the guard through retrieval to serialize page transitions, but do not change the
+        // issued cursor until success so an error or cancelled future leaves the page retryable.
+        let mut issued_cursor = self.inspection_cursor.lock().await;
+        if cursor
+            .as_ref()
+            .is_some_and(|cursor| issued_cursor.as_ref() != Some(cursor))
+        {
+            return Err(io::Error::other(
+                "memory inspection cursor was not issued by the preceding page",
+            )
+            .into());
+        }
+        let backend = self.store.access().await?;
+        let local = backend.namespace.is_none();
+        if cursor.as_ref().is_some_and(|cursor| {
+            local != cursor.namespace.is_none()
+                || cursor.namespace.as_deref().is_some_and(str::is_empty)
+        }) {
+            return Err(
+                io::Error::other("memory inspection cursor does not match the backend").into(),
+            );
+        }
+        let export_cursor = cursor.clone().map(InspectionCursor::into_export);
+        let (memories, next_cursor) = advance_inspection_page(export_cursor, |cursor| async move {
+            self.store
+                .export_page(None, cursor.as_ref(), INSPECTION_PAGE_RECORDS)
+                .await
+        })
+        .await?;
+
+        let namespace = backend.namespace.as_deref();
+        let records = memories.len();
+        let mut ours = Vec::new();
+        let mut theirs = Vec::new();
+        for memory in memories {
+            if crate::secrets::contains_likely_secret(&memory.content) {
+                continue;
+            }
+            let owned = namespace.is_none() || memory.key.namespace.as_deref() == namespace;
+            if owned {
+                ours.push(memory.into());
+            } else {
+                theirs.push(memory.into());
+            }
+        }
+        let complete = next_cursor.is_none();
+        let next_cursor = next_cursor.map(InspectionCursor::from_export);
+        *issued_cursor = next_cursor.clone();
+        json_output(&InspectOutput {
+            operation: "inspect",
+            backend,
+            ours,
+            theirs,
+            next_cursor,
+            coverage: InspectionCoverage {
+                records,
+                complete,
+                consistency: "best_effort",
+            },
         })
     }
 
@@ -201,6 +349,39 @@ where
     }
 }
 
+async fn advance_inspection_page<F, Fut>(
+    mut cursor: Option<ExportCursor>,
+    mut page: F,
+) -> Result<(Vec<MemoryRecord>, Option<ExportCursor>), super::MemoryError>
+where
+    F: FnMut(Option<ExportCursor>) -> Fut,
+    Fut: Future<Output = Result<(Vec<MemoryRecord>, Option<ExportCursor>), super::MemoryError>>,
+{
+    for _ in 0..INSPECTION_PAGES_PER_CALL {
+        let (memories, next_cursor) = page(cursor.clone()).await?;
+        if memories.len() > INSPECTION_PAGE_RECORDS
+            || next_cursor
+                .as_ref()
+                .is_some_and(|next| !inspection_cursor_advances(cursor.as_ref(), next))
+        {
+            return Err(super::MemoryError::InvalidPagination);
+        }
+        if !memories.is_empty() || next_cursor.is_none() {
+            return Ok((memories, next_cursor));
+        }
+        cursor = next_cursor;
+    }
+
+    Ok((Vec::new(), cursor))
+}
+
+fn inspection_cursor_advances(current: Option<&ExportCursor>, next: &ExportCursor) -> bool {
+    next.id > 0
+        && current.is_none_or(|current| {
+            (next.namespace.as_str(), next.id) > (current.namespace.as_str(), current.id)
+        })
+}
+
 #[async_trait]
 impl<A> Tool for MemoryTool<A>
 where
@@ -209,7 +390,7 @@ where
     fn definition(&self) -> ToolDefinition {
         ToolDefinition::function(
             "memory",
-            "Explicitly searches, reads, stores, replaces, or deletes bounded memories in exactly one configured local or remote backend. A remote scan performs separate bounded retrievals for the authenticated namespace (ours) and other visible namespaces (theirs), so compare scores only within a group. Candidate keys identify their namespace. Pass keys returned by scan unchanged when reading, for example {\"operation\":\"read\",\"keys\":[{\"id\":7,\"version\":1,\"namespace\":\"alice\"}]}. Put and delete are root-agent-only; remote mutation also requires a writer credential.",
+            "Explicitly searches, reads, inspects, stores, replaces, or deletes bounded memories in exactly one configured local or remote backend. Use inspect only for an explicitly requested corpus audit; it returns one telemetry-neutral, best-effort page and no snapshot guarantee. Continue only with the exact next_cursor issued by the preceding inspect call, or omit it to restart, and read selected exact keys for full content. A remote scan or inspection separates the authenticated namespace (ours) from other visible namespaces (theirs). Compare scan scores only within a group. Pass keys unchanged, for example {\"operation\":\"read\",\"keys\":[{\"id\":7,\"version\":1,\"namespace\":\"alice\"}]}. Put and delete are root-agent-only; remote mutation also requires a writer credential.",
             memory_input_schema(),
         )
         .with_output_schema(memory_output_schema())
@@ -219,6 +400,7 @@ where
         match input.decode_json::<MemoryOperation>()? {
             MemoryOperation::Scan { query, limit } => self.scan(query, limit).await,
             MemoryOperation::Read { keys } => self.read(keys).await,
+            MemoryOperation::Inspect { cursor } => self.inspect(cursor).await,
             MemoryOperation::Put { content, replace } => {
                 self.put(context.session_id(), content, replace).await
             }
@@ -262,6 +444,15 @@ fn memory_input_schema() -> Value {
                     }
                 },
                 "required": ["operation", "keys"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "operation": { "type": "string", "const": "inspect" },
+                    "cursor": inspection_cursor_schema()
+                },
+                "required": ["operation"],
                 "additionalProperties": false
             },
             {
@@ -317,6 +508,30 @@ fn memory_output_schema() -> Value {
             {
                 "type": "object",
                 "properties": {
+                    "operation": { "type": "string", "const": "inspect" },
+                    "backend": backend.clone(),
+                    "ours": inspection_records_schema(),
+                    "theirs": inspection_records_schema(),
+                    "next_cursor": {
+                        "oneOf": [inspection_cursor_schema(), { "type": "null" }]
+                    },
+                    "coverage": {
+                        "type": "object",
+                        "properties": {
+                            "records": { "type": "integer", "minimum": 0, "maximum": 20 },
+                            "complete": { "type": "boolean" },
+                            "consistency": { "type": "string", "const": "best_effort" }
+                        },
+                        "required": ["records", "complete", "consistency"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["operation", "backend", "ours", "theirs", "next_cursor", "coverage"],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
                     "operation": { "type": "string", "const": "put" },
                     "backend": backend.clone(),
                     "memory": record,
@@ -336,6 +551,47 @@ fn memory_output_schema() -> Value {
                 "additionalProperties": false
             }
         ]
+    })
+}
+
+fn inspection_cursor_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Exact continuation cursor issued by the immediately preceding inspect call on this tool. Preserve every field unchanged. Omit cursor to start or restart an audit.",
+        "properties": {
+            "namespace": { "type": "string", "minLength": 1 },
+            "id": { "type": "integer", "minimum": 1 }
+        },
+        "required": ["id"],
+        "additionalProperties": false
+    })
+}
+
+fn inspection_records_schema() -> Value {
+    json!({
+        "type": "array",
+        "maxItems": 20,
+        "items": {
+            "type": "object",
+            "properties": {
+                "key": memory_key_schema(),
+                "preview": { "type": "string", "maxLength": 64 },
+                "content_bytes": { "type": "integer", "minimum": 1, "maximum": 1024 },
+                "created_at_ms": { "type": "integer" },
+                "updated_at_ms": { "type": "integer" },
+                "last_scanned_at_ms": { "type": ["integer", "null"] },
+                "scan_count": { "type": "integer", "minimum": 0 },
+                "last_used_at_ms": { "type": ["integer", "null"] },
+                "use_count": { "type": "integer", "minimum": 0 },
+                "probation_until_ms": { "type": ["integer", "null"] }
+            },
+            "required": [
+                "key", "preview", "content_bytes", "created_at_ms", "updated_at_ms",
+                "last_scanned_at_ms", "scan_count", "last_used_at_ms", "use_count",
+                "probation_until_ms"
+            ],
+            "additionalProperties": false
+        }
     })
 }
 
@@ -407,14 +663,17 @@ fn memory_record_schema() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{MemoryOperation, MemoryTool, MutationAuthorizer};
-    use crate::{MemoryStore, SelectedMemoryStore};
+    use super::{MemoryOperation, MemoryTool, MutationAuthorizer, advance_inspection_page};
+    use crate::{
+        MemoryError, MemoryKey, MemoryRecord, MemoryStore, SelectedMemoryStore,
+        server::protocol::ExportCursor,
+    };
     use nanocodex::{
         Tool,
         tools::contract::{DEFAULT_TOOL_OUTPUT_TOKENS, ToolContext, ToolInput, async_trait},
     };
-    use serde_json::{json, value::to_raw_value};
-    use std::io;
+    use serde_json::{Value, json, value::to_raw_value};
+    use std::{cell::Cell, collections::VecDeque, fs, future::ready, io};
     use tempfile::tempdir;
 
     struct TestAuthorizer;
@@ -456,7 +715,7 @@ mod tests {
         let output_schema = definition.output_schema().unwrap().as_value();
 
         assert_eq!(definition.name(), "memory");
-        assert_eq!(schema["oneOf"].as_array().unwrap().len(), 4);
+        assert_eq!(schema["oneOf"].as_array().unwrap().len(), 5);
         assert!(
             schema["oneOf"]
                 .as_array()
@@ -480,6 +739,26 @@ mod tests {
         }
         assert!(scan_output["properties"].get("abstained").is_none());
         assert!(scan_output["properties"].get("candidates").is_none());
+
+        let inspect = schema["oneOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|operation| operation["properties"]["operation"]["const"] == json!("inspect"))
+            .expect("inspect input should be exposed");
+        assert!(inspect["properties"].get("limit").is_none());
+        assert!(inspect["properties"].get("namespaces").is_none());
+        let inspect_output = output_schema["oneOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|operation| operation["properties"]["operation"]["const"] == json!("inspect"))
+            .expect("inspect output should be exposed");
+        assert_eq!(inspect_output["properties"]["ours"]["maxItems"], json!(20));
+        assert_eq!(
+            inspect_output["properties"]["coverage"]["properties"]["consistency"]["const"],
+            json!("best_effort")
+        );
     }
 
     #[test]
@@ -642,6 +921,224 @@ mod tests {
             panic!("put reused an earlier scan");
         };
         assert_eq!(error.to_string(), "scan memory before storing a conclusion");
+    }
+
+    #[tokio::test]
+    async fn inspection_is_fixed_size_paginated_and_does_not_arm_put() {
+        let directory = tempdir().unwrap();
+        let store = SelectedMemoryStore::local(directory.path().join("memory.sqlite3"));
+        for id in 1..=21 {
+            store
+                .put(&format!("Inspection record number {id}."), None)
+                .await
+                .unwrap();
+        }
+        let tool = MemoryTool::new(store, TestAuthorizer);
+
+        let first = tool
+            .execute(input(json!({"operation": "inspect"})), context("root"))
+            .await
+            .unwrap()
+            .structured_result();
+        assert_eq!(first["ours"].as_array().unwrap().len(), 20);
+        assert_eq!(first["theirs"], json!([]));
+        assert_eq!(first["coverage"]["records"], json!(20));
+        assert_eq!(first["coverage"]["complete"], json!(false));
+        assert_eq!(first["coverage"]["consistency"], json!("best_effort"));
+        assert_eq!(first["next_cursor"], json!({"id": 20}));
+        assert!(first["ours"][0].get("content").is_none());
+        assert_eq!(first["ours"][0]["key"], json!({"id": 1, "version": 1}));
+
+        let Err(error) = tool
+            .execute(
+                input(json!({"operation": "inspect", "cursor": {"id": 19}})),
+                context("root"),
+            )
+            .await
+        else {
+            panic!("invented inspection cursor unexpectedly succeeded");
+        };
+        assert_eq!(
+            error.to_string(),
+            "memory inspection cursor was not issued by the preceding page"
+        );
+
+        let second = tool
+            .execute(
+                input(json!({"operation": "inspect", "cursor": first["next_cursor"]})),
+                context("root"),
+            )
+            .await
+            .unwrap()
+            .structured_result();
+        assert_eq!(second["ours"].as_array().unwrap().len(), 1);
+        assert_eq!(second["ours"][0]["key"], json!({"id": 21, "version": 1}));
+        assert_eq!(second["next_cursor"], Value::Null);
+        assert_eq!(second["coverage"]["complete"], json!(true));
+
+        assert!(
+            tool.execute(
+                input(json!({"operation": "inspect", "cursor": {"id": 20}})),
+                context("root"),
+            )
+            .await
+            .is_err(),
+            "consumed inspection cursor unexpectedly succeeded again"
+        );
+
+        let restarted = tool
+            .execute(input(json!({"operation": "inspect"})), context("root"))
+            .await
+            .unwrap()
+            .structured_result();
+        assert_eq!(restarted["next_cursor"], json!({"id": 20}));
+
+        let Err(error) = tool
+            .execute(
+                input(json!({
+                    "operation": "put",
+                    "content": "Inspection must not satisfy the scan-before-put gate."
+                })),
+                context("root"),
+            )
+            .await
+        else {
+            panic!("inspection unexpectedly armed a put");
+        };
+        assert_eq!(error.to_string(), "scan memory before storing a conclusion");
+    }
+
+    #[tokio::test]
+    async fn inspection_rejects_mismatched_or_non_progressing_local_cursors() {
+        let tool = MemoryTool::new(
+            SelectedMemoryStore::local(tempdir().unwrap().path().join("memory.sqlite3")),
+            TestAuthorizer,
+        );
+        for cursor in [json!({"id": 0}), json!({"namespace": "alice", "id": 1})] {
+            assert!(
+                tool.execute(
+                    input(json!({"operation": "inspect", "cursor": cursor})),
+                    context("root")
+                )
+                .await
+                .is_err()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn issued_inspection_cursor_can_retry_after_backend_failure() {
+        let directory = tempdir().unwrap();
+        let database = directory.path().join("memory.sqlite3");
+        let backup = directory.path().join("memory.backup.sqlite3");
+        let store = SelectedMemoryStore::local(&database);
+        for id in 1..=21 {
+            store
+                .put(&format!("Retryable inspection record {id}."), None)
+                .await
+                .unwrap();
+        }
+        let tool = MemoryTool::new(store, TestAuthorizer);
+        let first = tool
+            .execute(input(json!({"operation": "inspect"})), context("root"))
+            .await
+            .unwrap()
+            .structured_result();
+        let cursor = first["next_cursor"].clone();
+        assert_eq!(cursor, json!({"id": 20}));
+
+        fs::rename(&database, &backup).unwrap();
+        fs::create_dir(&database).unwrap();
+        assert!(
+            tool.execute(
+                input(json!({"operation": "inspect", "cursor": cursor.clone()})),
+                context("root"),
+            )
+            .await
+            .is_err()
+        );
+        fs::remove_dir(&database).unwrap();
+        fs::rename(&backup, &database).unwrap();
+
+        let retried = tool
+            .execute(
+                input(json!({"operation": "inspect", "cursor": cursor})),
+                context("root"),
+            )
+            .await
+            .unwrap()
+            .structured_result();
+        assert_eq!(retried["ours"].as_array().unwrap().len(), 1);
+        assert_eq!(retried["ours"][0]["key"], json!({"id": 21, "version": 1}));
+        assert_eq!(retried["next_cursor"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn inspection_advances_past_a_fully_suppressed_remote_page() {
+        let suppressed_cursor = ExportCursor {
+            namespace: "alice".to_owned(),
+            id: 1,
+        };
+        let safe = MemoryRecord {
+            key: MemoryKey::remote("alice".to_owned(), 2, 1),
+            content: "Keep safe audit guidance.".to_owned(),
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            last_scanned_at_ms: None,
+            scan_count: 0,
+            last_used_at_ms: None,
+            use_count: 0,
+            probation_until_ms: None,
+        };
+        let mut pages = VecDeque::from([
+            (Vec::new(), Some(suppressed_cursor)),
+            (vec![safe.clone()], None),
+        ]);
+
+        let (memories, next_cursor) = advance_inspection_page(None, |_| {
+            ready(Ok(pages.pop_front().expect("requested bounded page")))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(memories, vec![safe]);
+        assert_eq!(next_cursor, None);
+        assert!(pages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn inspection_rejects_a_truly_non_progressing_filtered_page() {
+        let cursor = ExportCursor {
+            namespace: "alice".to_owned(),
+            id: 1,
+        };
+        let result = advance_inspection_page(Some(cursor.clone()), |_| {
+            ready(Ok((Vec::new(), Some(cursor.clone()))))
+        })
+        .await;
+
+        assert!(matches!(result, Err(MemoryError::InvalidPagination)));
+    }
+
+    #[tokio::test]
+    async fn inspection_bounds_consecutive_fully_suppressed_pages() {
+        let calls = Cell::new(0_i64);
+        let (memories, next_cursor) = advance_inspection_page(None, |_| {
+            calls.set(calls.get() + 1);
+            ready(Ok((
+                Vec::new(),
+                Some(ExportCursor {
+                    namespace: "alice".to_owned(),
+                    id: calls.get(),
+                }),
+            )))
+        })
+        .await
+        .unwrap();
+
+        assert!(memories.is_empty());
+        assert_eq!(calls.get(), 4);
+        assert_eq!(next_cursor.unwrap().id, 4);
     }
 
     #[tokio::test]

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -80,6 +80,7 @@ Local and remote modes expose the same memory operations and meanings:
 | --- | --- |
 | `scan` | Search the selected backend. Local scans populate `ours`; remote scans make separate requests returning up to five `ours` and five `theirs` candidates. |
 | `read` | Fetch complete records by exact current key. Missing or stale keys are omitted. |
+| `inspect` | Page through compact audit cards only for an explicitly requested corpus inspection. Inspection does not change scan/read telemetry. |
 | `put` | Add one atomic conclusion, or replace a known record using its key and expected version. |
 | `delete` | Remove a known record using its key and expected version. |
 | `list` | List records without changing scan or read telemetry. |
@@ -92,7 +93,7 @@ The agent tool uses one exact key shape throughout. Pass scan candidate keys unc
 {"operation":"delete","key":{"namespace":"alice","id":7,"version":1}}
 ```
 
-Root agents may mutate; child agents may only scan and read. Reader credentials make remote
+Root agents may mutate; child agents may only scan, inspect, and read. Reader credentials make remote
 mutation unavailable regardless of agent role. Remote operations include the caller's namespace:
 an author can scan, read, and list their own remote records as well as records from other authors.
 Scan keeps those sources explicit: `ours` contains one response scoped to the authenticated
@@ -102,6 +103,17 @@ the other out and their corpus-relative scores are not comparable. If either req
 returns an error rather than a partial result or a local fallback. The agent decides which records to
 read and apply. Normalized duplicate content may exist in separate namespaces because ownership
 remains per author.
+
+Agent-facing `inspect` is a read-only audit surface, not a transfer API. It fixes each page at 20
+records and exposes no page-size or namespace-selection controls. Each compact card includes the
+exact namespaced key, a 64-byte preview, content size, timestamps, and scan/read telemetry; use
+targeted `read` calls when full content is needed. Remote pages preserve `ours` and `theirs` groups.
+Continue only with the exact cursor issued by the immediately preceding `inspect` call; invented,
+skipped, reused, or stale cursors are rejected. Omit the cursor to start or restart an audit.
+`coverage.complete` and `next_cursor` report whether
+more pages were visible. Secret-like records remain suppressed. Pagination is best-effort under
+concurrent changes and does not claim one coherent snapshot. Calling `inspect` does not satisfy the
+scan-before-put requirement.
 
 The remote API is an authenticated JSON/HTTP interface. Its protocol generation is
 `tact_memory::VERSION`; routes and the session compatibility check use that same value:


### PR DESCRIPTION
## Summary

- add a fixed-size, telemetry-neutral `inspect` operation for explicit memory-corpus audits
- return compact attributed records with exact keys and best-effort cursor pagination
- keep full content behind targeted reads and keep inspection separate from the scan-before-put gate
- teach built-in Reflection to enumerate memory only when the user explicitly requests an audit, cleanup, or inspection
- report backend scope, coverage, truncation, and uncertainty without mutating memory

Remote inspection preserves own-versus-other attribution from the selected backend and advances safely across pages emptied by secret suppression. Ordinary reflection and relevance-gated scan/read behavior remain unchanged.

## Testing

- `just check-fmt`
- `cargo check --all-features`
- `cargo test -p tact-memory` (89 tests)
- `cargo test -p tact` (762 unit tests, 15 release-pipeline tests)

## Stack

Depends on #156. Retarget to `main` after #156 merges.
