### PR TITLE
fix(tui): forward copied selections through tmux

### DIFF
--- a/bin/tact/src/tui/clipboard.rs
+++ b/bin/tact/src/tui/clipboard.rs
@@ -3,13 +3,78 @@
 use arboard::Clipboard;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use png::{BitDepth, ColorType, Encoder, EncodingError};
-#[cfg(target_os = "macos")]
 use std::{
     io::{self, Write},
+    path::{Path, PathBuf},
     process::{Command, ExitStatus, Stdio},
 };
-#[cfg(target_os = "macos")]
 use thiserror::Error;
+
+pub(crate) fn copy_to_tmux(text: &str) -> Result<(), TmuxCopyError> {
+    copy_with_tmux(text, Path::new("tmux"))
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum TmuxCopyError {
+    #[error("could not launch {program}: {source}")]
+    Launch {
+        program: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("could not write to {program}: {source}")]
+    Write {
+        program: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("could not wait for {program}: {source}")]
+    Wait {
+        program: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("{program} exited with {status}")]
+    Exit {
+        program: PathBuf,
+        status: ExitStatus,
+    },
+}
+
+fn copy_with_tmux(text: &str, program: &Path) -> Result<(), TmuxCopyError> {
+    let mut child = Command::new(program)
+        .args(["load-buffer", "-w", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|source| TmuxCopyError::Launch {
+            program: program.to_path_buf(),
+            source,
+        })?;
+    let write_result = child
+        .stdin
+        .take()
+        .expect("piped tmux stdin must be available")
+        .write_all(text.as_bytes())
+        .map_err(|source| TmuxCopyError::Write {
+            program: program.to_path_buf(),
+            source,
+        });
+    let status = child.wait().map_err(|source| TmuxCopyError::Wait {
+        program: program.to_path_buf(),
+        source,
+    })?;
+    write_result?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(TmuxCopyError::Exit {
+            program: program.to_path_buf(),
+            status,
+        })
+    }
+}
 
 #[cfg(not(target_os = "macos"))]
 pub(crate) fn copy_text(text: &str) -> Result<(), arboard::Error> {
@@ -119,13 +184,40 @@ fn encode_png(width: usize, height: usize, pixels: &[u8]) -> Result<Vec<u8>, Enc
 mod tests {
     #[cfg(target_os = "macos")]
     use super::copy_with_pbcopy;
-    use super::encode_png;
+    use super::{copy_with_tmux, encode_png};
+    use std::{fs, os::unix::fs::PermissionsExt};
 
     #[test]
     fn clipboard_pixels_are_encoded_as_png() {
         let encoded = encode_png(1, 1, &[255, 0, 0, 255]).unwrap();
 
         assert_eq!(&encoded[..8], b"\x89PNG\r\n\x1a\n");
+    }
+
+    #[test]
+    fn tmux_copy_loads_buffer_from_stdin() {
+        let directory = tempfile::tempdir().unwrap();
+        let program = directory.path().join("tmux");
+        fs::write(
+            &program,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$(dirname \"$0\")/args\"\n\
+             cat > \"$(dirname \"$0\")/buffer\"\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+
+        copy_with_tmux("copy me\n", &program).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(directory.path().join("args")).unwrap(),
+            "load-buffer\n-w\n-\n"
+        );
+        assert_eq!(
+            fs::read(directory.path().join("buffer")).unwrap(),
+            b"copy me\n"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -2463,35 +2463,48 @@ fn apply_pane_effect(
     Ok(())
 }
 
-/// Copies text to tmux and through the platform's most reliable clipboard channel.
+/// Copies text through the clipboard channels available to Tact.
 ///
-/// Tmux paste buffers are loaded explicitly and forwarded to the outer terminal
-/// because tmux may ignore OSC 52 from pane applications. On Linux the terminal leads
-/// because it retains clipboard ownership after Tact exits. On macOS the native
-/// pasteboard leads because it does not depend on OSC 52 support. Each platform falls
-/// back to the other channel.
+/// On non-macOS and remote macOS sessions, Tact first tries the tmux server that
+/// directly contains it. `load-buffer -w` asks that server to forward the selection
+/// to its terminal when supported. Local macOS retains its native pasteboard-first path.
 fn copy_selection(terminal: &mut TerminalSession, text: &str) -> std::result::Result<(), String> {
-    let tmux_copy = std::env::var_os("TMUX")
-        .map(|_| clipboard::copy_to_tmux(text).map_err(|error| error.to_string()));
-    let platform_copy = copy_platform_selection(terminal, text);
+    let use_tmux = std::env::var_os("TMUX").is_some();
+    #[cfg(target_os = "macos")]
+    let use_tmux = use_tmux && is_remote_session();
 
-    copy_result(tmux_copy, platform_copy)
+    copy_selection_with(
+        use_tmux,
+        || clipboard::copy_to_tmux(text).map_err(|error| error.to_string()),
+        || copy_platform_selection(terminal, text),
+    )
 }
 
-fn copy_result(
-    tmux_copy: Option<std::result::Result<(), String>>,
-    platform_copy: std::result::Result<(), String>,
+fn copy_selection_with(
+    use_tmux: bool,
+    tmux_copy: impl FnOnce() -> std::result::Result<(), String>,
+    platform_copy: impl FnOnce() -> std::result::Result<(), String>,
 ) -> std::result::Result<(), String> {
-    match tmux_copy {
-        Some(Ok(())) => Ok(()),
-        Some(Err(tmux_error)) => platform_copy.map_err(|platform_error| {
-            format!(
-                "Could not copy selection to tmux: {tmux_error}; \
-                 platform fallback failed: {platform_error}"
-            )
-        }),
-        None => platform_copy,
+    if use_tmux {
+        match tmux_copy() {
+            Ok(()) => return Ok(()),
+            Err(tmux_error) => {
+                return platform_copy().map_err(|platform_error| {
+                    format!(
+                        "Could not copy selection to tmux: {tmux_error}; \
+                     platform fallback failed: {platform_error}"
+                    )
+                });
+            }
+        }
     }
+
+    platform_copy()
+}
+
+#[cfg(target_os = "macos")]
+fn is_remote_session() -> bool {
+    std::env::var_os("SSH_TTY").is_some() || std::env::var_os("SSH_CONNECTION").is_some()
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -2793,7 +2806,7 @@ fn request_render(request: RenderRequest, scheduler: &mut RenderScheduler) {
 mod tests {
     use super::{
         MemoryCompletion, MemoryOperation, PaneGeneration, PaneSession, PaneSettings,
-        PendingSubmission, close_pane_journal, copy_result, invalidate_memory_generations,
+        PendingSubmission, close_pane_journal, copy_selection_with, invalidate_memory_generations,
         is_image_paste, local_link_path, merge_recent_prompts, next_memory_generation, open_pane,
         run_memory_operation, send_submission, subagent_pane, validate_interactive,
     };
@@ -2813,7 +2826,7 @@ mod tests {
         },
     };
     use nanocodex::Model;
-    use std::{collections::HashMap, fs, path::Path, sync::Arc};
+    use std::{cell::Cell, collections::HashMap, fs, path::Path, sync::Arc};
     use tact_memory::{MemoryStore, SelectedMemoryStore};
     use tact_subagents::{AgentId, AgentStatus, AgentUpdate};
     use tempfile::tempdir;
@@ -2837,19 +2850,47 @@ mod tests {
     }
 
     #[test]
-    fn successful_tmux_copy_ignores_platform_failure() {
-        assert_eq!(
-            copy_result(Some(Ok(())), Err("platform failed".to_owned())),
-            Ok(())
+    fn successful_tmux_copy_skips_platform_fallback() {
+        let tmux_calls = Cell::new(0);
+        let platform_calls = Cell::new(0);
+
+        let result = copy_selection_with(
+            true,
+            || {
+                tmux_calls.set(tmux_calls.get() + 1);
+                Ok(())
+            },
+            || {
+                platform_calls.set(platform_calls.get() + 1);
+                Err("platform failed".to_owned())
+            },
         );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(tmux_calls.get(), 1);
+        assert_eq!(platform_calls.get(), 0);
     }
 
     #[test]
-    fn successful_platform_copy_falls_back_from_tmux_failure() {
-        assert_eq!(
-            copy_result(Some(Err("tmux failed".to_owned())), Ok(())),
-            Ok(())
+    fn tmux_failure_calls_platform_fallback() {
+        let tmux_calls = Cell::new(0);
+        let platform_calls = Cell::new(0);
+
+        let result = copy_selection_with(
+            true,
+            || {
+                tmux_calls.set(tmux_calls.get() + 1);
+                Err("tmux failed".to_owned())
+            },
+            || {
+                platform_calls.set(platform_calls.get() + 1);
+                Ok(())
+            },
         );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(tmux_calls.get(), 1);
+        assert_eq!(platform_calls.get(), 1);
     }
 
     #[test]

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -2463,13 +2463,42 @@ fn apply_pane_effect(
     Ok(())
 }
 
-/// Copies text through the platform's most reliable clipboard channel.
+/// Copies text to tmux and through the platform's most reliable clipboard channel.
 ///
-/// On Linux the terminal leads because it retains clipboard ownership after Tact
-/// exits. On macOS the native pasteboard leads because it does not depend on OSC 52
-/// support. Each platform falls back to the other channel.
-#[cfg(not(target_os = "macos"))]
+/// Tmux paste buffers are loaded explicitly and forwarded to the outer terminal
+/// because tmux may ignore OSC 52 from pane applications. On Linux the terminal leads
+/// because it retains clipboard ownership after Tact exits. On macOS the native
+/// pasteboard leads because it does not depend on OSC 52 support. Each platform falls
+/// back to the other channel.
 fn copy_selection(terminal: &mut TerminalSession, text: &str) -> std::result::Result<(), String> {
+    let tmux_copy = std::env::var_os("TMUX")
+        .map(|_| clipboard::copy_to_tmux(text).map_err(|error| error.to_string()));
+    let platform_copy = copy_platform_selection(terminal, text);
+
+    copy_result(tmux_copy, platform_copy)
+}
+
+fn copy_result(
+    tmux_copy: Option<std::result::Result<(), String>>,
+    platform_copy: std::result::Result<(), String>,
+) -> std::result::Result<(), String> {
+    match tmux_copy {
+        Some(Ok(())) => Ok(()),
+        Some(Err(tmux_error)) => platform_copy.map_err(|platform_error| {
+            format!(
+                "Could not copy selection to tmux: {tmux_error}; \
+                 platform fallback failed: {platform_error}"
+            )
+        }),
+        None => platform_copy,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn copy_platform_selection(
+    terminal: &mut TerminalSession,
+    text: &str,
+) -> std::result::Result<(), String> {
     match terminal.copy_to_clipboard(text) {
         Ok(()) => Ok(()),
         Err(terminal_error) => clipboard::copy_text(text).map_err(|native_error| {
@@ -2482,7 +2511,10 @@ fn copy_selection(terminal: &mut TerminalSession, text: &str) -> std::result::Re
 }
 
 #[cfg(target_os = "macos")]
-fn copy_selection(terminal: &mut TerminalSession, text: &str) -> std::result::Result<(), String> {
+fn copy_platform_selection(
+    terminal: &mut TerminalSession,
+    text: &str,
+) -> std::result::Result<(), String> {
     match clipboard::copy_text(text) {
         Ok(()) => Ok(()),
         Err(native_error) => terminal.copy_to_clipboard(text).map_err(|terminal_error| {
@@ -2761,8 +2793,8 @@ fn request_render(request: RenderRequest, scheduler: &mut RenderScheduler) {
 mod tests {
     use super::{
         MemoryCompletion, MemoryOperation, PaneGeneration, PaneSession, PaneSettings,
-        PendingSubmission, close_pane_journal, invalidate_memory_generations, is_image_paste,
-        local_link_path, merge_recent_prompts, next_memory_generation, open_pane,
+        PendingSubmission, close_pane_journal, copy_result, invalidate_memory_generations,
+        is_image_paste, local_link_path, merge_recent_prompts, next_memory_generation, open_pane,
         run_memory_operation, send_submission, subagent_pane, validate_interactive,
     };
     use crate::{
@@ -2802,6 +2834,22 @@ mod tests {
             KeyCode::Char('v'),
             KeyModifiers::NONE,
         ))));
+    }
+
+    #[test]
+    fn successful_tmux_copy_ignores_platform_failure() {
+        assert_eq!(
+            copy_result(Some(Ok(())), Err("platform failed".to_owned())),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn successful_platform_copy_falls_back_from_tmux_failure() {
+        assert_eq!(
+            copy_result(Some(Err("tmux failed".to_owned())), Ok(())),
+            Ok(())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Copying text from tact inside tmux did not reliably reach the terminal on the machine hosting the tmux client. Depending on tmux's clipboard config, OSC 52 could also be ignored without creating a tmux paste buffer.

When `$TMUX` is present, tact now pipes the selection through `tmux load-buffer -w -`. This stores the text in tmux's paste buffer and forwards it to the outer terminal clipboard. The existing platform clipboard path remains available, and behavior outside tmux is unchanged.