### PR TITLE
fix(tui): normalize carriage-return line endings

### DIFF
--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -12,7 +12,7 @@ use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
     tui::{
         context::MODEL_WINDOW_TOKENS,
-        format::{format_turn_duration, shorten_home},
+        format::{format_turn_duration, normalize_line_endings, shorten_home},
         prompt::Submission,
         theme::Theme,
     },
@@ -595,7 +595,11 @@ impl Composer {
     }
 
     pub(crate) fn replace_draft(&mut self, draft: String) {
-        self.draft = draft;
+        self.draft = if draft.contains('\r') {
+            normalize_line_endings(&draft).into_owned()
+        } else {
+            draft
+        };
         self.images.clear();
         self.next_image = 1;
         self.cursor = self.draft.len();
@@ -783,6 +787,7 @@ impl Composer {
     }
 
     fn insert(&mut self, text: &str) {
+        let text = normalize_line_endings(text);
         self.move_cursor_out_of_image();
         for image in &mut self.images {
             if image.range.start >= self.cursor {
@@ -790,7 +795,7 @@ impl Composer {
                 image.range.end += text.len();
             }
         }
-        self.draft.insert_str(self.cursor, text);
+        self.draft.insert_str(self.cursor, &text);
         self.cursor += text.len();
         self.preferred_column = None;
         self.layout = None;
@@ -1933,6 +1938,19 @@ mod tests {
         assert_eq!(composer.draft(), "one\ntwo");
 
         composer.update(ComposerEvent::ReplaceDraft("edited\ndraft".to_owned()));
+        assert_eq!(composer.draft(), "edited\ndraft");
+        assert_eq!(composer.cursor(), composer.draft().len());
+    }
+
+    #[test]
+    fn paste_and_editor_replacement_normalize_carriage_returns() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.update(ComposerEvent::Terminal(Event::Paste(
+            "one\r\ntwo\rthree".to_owned(),
+        )));
+        assert_eq!(composer.draft(), "one\ntwo\nthree");
+
+        composer.update(ComposerEvent::ReplaceDraft("edited\r\ndraft".to_owned()));
         assert_eq!(composer.draft(), "edited\ndraft");
         assert_eq!(composer.cursor(), composer.draft().len());
     }

--- a/bin/tact/src/tui/components/transcript/mod.rs
+++ b/bin/tact/src/tui/components/transcript/mod.rs
@@ -14,7 +14,9 @@ use super::{
 use crate::{
     app::config::ReasoningEffort,
     tui::{
-        format::{duration_display_tick, format_duration, format_turn_duration},
+        format::{
+            duration_display_tick, format_duration, format_turn_duration, normalize_line_endings,
+        },
         spinner::Spinner,
         theme::Theme,
         transcript::{
@@ -1806,6 +1808,7 @@ fn layout_without_links(lines: Vec<Line<'static>>) -> markdown::Layout {
 }
 
 fn render_user(text: &str, width: u16, theme: &Theme) -> markdown::Layout {
+    let text = normalize_line_endings(text);
     let color = theme.thinking_medium();
     let content_width = width.saturating_sub(2).max(1);
     let mut lines = Vec::new();
@@ -1841,7 +1844,10 @@ fn render_user(text: &str, width: u16, theme: &Theme) -> markdown::Layout {
         lines,
         selections,
         envelopes: Vec::new(),
-        selection_source: None,
+        selection_source: match text {
+            std::borrow::Cow::Borrowed(_) => None,
+            std::borrow::Cow::Owned(text) => Some(text),
+        },
     }
 }
 
@@ -1853,7 +1859,7 @@ fn line_width(text: &str) -> usize {
 mod tests {
     use super::{
         Anchor, Component, ExpandableCommand, RenderRequest, ScrollCommand, ScrollState,
-        Transcript, TranscriptEvent, unix_milliseconds,
+        Transcript, TranscriptEvent, render_user, unix_milliseconds,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -1873,6 +1879,19 @@ mod tests {
     use serde_json::{json, value::to_raw_value};
     use std::{sync::Arc, time::Duration};
     use tact_subagents::{AgentMessageUpdate, MessageSender};
+
+    #[test]
+    fn user_messages_normalize_carriage_returns() {
+        let layout = render_user("one\r\ntwo\rthree", 80, &Theme::default());
+        let rendered = layout
+            .lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+
+        assert_eq!(rendered, ["┃ one", "┃ two", "┃ three"]);
+        assert_eq!(layout.selection_source.as_deref(), Some("one\ntwo\nthree"));
+    }
 
     fn user(sequence: u64, text: impl Into<String>) -> Arc<TranscriptRecord> {
         Arc::new(

--- a/bin/tact/src/tui/format.rs
+++ b/bin/tact/src/tui/format.rs
@@ -1,6 +1,25 @@
 //! Shared formatting for terminal-facing values.
 
-use std::{env, path::Path};
+use std::{borrow::Cow, env, path::Path};
+
+pub(crate) fn normalize_line_endings(text: &str) -> Cow<'_, str> {
+    if !text.contains('\r') {
+        return Cow::Borrowed(text);
+    }
+
+    let mut normalized = String::with_capacity(text.len());
+    let mut remaining = text;
+    while let Some(index) = remaining.find('\r') {
+        normalized.push_str(&remaining[..index]);
+        normalized.push('\n');
+        remaining = &remaining[index + 1..];
+        if let Some(after_newline) = remaining.strip_prefix('\n') {
+            remaining = after_newline;
+        }
+    }
+    normalized.push_str(remaining);
+    Cow::Owned(normalized)
+}
 
 pub(crate) fn format_duration(nanoseconds: u64) -> String {
     if nanoseconds >= 1_000_000_000 {
@@ -62,7 +81,18 @@ pub(crate) fn shorten_home(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{duration_display_tick, format_duration, format_turn_duration};
+    use super::{
+        duration_display_tick, format_duration, format_turn_duration, normalize_line_endings,
+    };
+
+    #[test]
+    fn line_endings_are_normalized_without_changing_lf_text() {
+        assert_eq!(normalize_line_endings("one\ntwo"), "one\ntwo");
+        assert_eq!(
+            normalize_line_endings("one\r\ntwo\rthree"),
+            "one\ntwo\nthree"
+        );
+    }
 
     #[test]
     fn durations_round_to_the_same_tick_used_for_live_redraws() {


### PR DESCRIPTION
## Summary

- normalize CRLF and lone carriage returns before composer rendering and submission
- normalize persisted user-message line endings in the transcript feed
- preserve normalized transcript selection source and cover both paths with regressions

## Validation

- `just test` (900 passed)
- `just clippy`
- `just check-fmt`