### PR TITLE
feat(review): add native diff search

### DIFF
--- a/web/review/app.ts
+++ b/web/review/app.ts
@@ -70,6 +70,7 @@ import {
 } from "./review-settings";
 import { overviewDocument } from "./overview";
 import { parseReviewPatch } from "./review-diff";
+import { moveSearchTarget, searchReview, type ReviewSearchMatch } from "./review-search";
 import {
   expandRange,
   moveRangeBoundary,
@@ -83,6 +84,7 @@ import {
 } from "./range-selection";
 import "./styles.css";
 
+const SEARCH_HIGHLIGHT = "tact-review-search-match";
 const TREE_STYLES = `
   [data-type="item"] {
     --tact-tree-row-bg: var(--trees-bg);
@@ -209,9 +211,36 @@ export class ReviewApp {
   private readonly workerPool: WorkerPoolManager;
   private itemVersion = 0;
   private tree?: FileTree;
+  private searchCount = 0;
+  private searchIndex = 0;
+  private searchMatch?: ReviewSearchMatch;
+  private searchPaused = true;
+  private searchSelection?: CodeViewLineSelection | null;
+  private searchExpandedItem?: string;
+  private searchReturnFocus?: HTMLElement;
   private settings = loadReviewSettings(window.localStorage, document.cookie);
   private readonly colorScheme = window.matchMedia("(prefers-color-scheme: dark)");
   private state: ReviewState;
+  private readonly handleSearchShortcut = (event: KeyboardEvent) => {
+    if (event.isComposing || this.root.querySelector("dialog[open]")) return;
+    const key = event.key.toLowerCase();
+    if ((event.metaKey || event.ctrlKey) && key === "f") {
+      const changes = this.root.querySelector<HTMLElement>("#changes-panel");
+      if (this.state.terminal.kind === "finished" || !changes?.matches(".active:not([hidden])")) return;
+      event.preventDefault();
+      this.openSearch();
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && key === "g" && this.searchIsOpen()) {
+      event.preventDefault();
+      this.moveSearch(event.shiftKey ? -1 : 1);
+      return;
+    }
+    if (event.key === "Escape" && this.searchIsOpen()) {
+      event.preventDefault();
+      this.closeSearch();
+    }
+  };
 
   constructor(
     private readonly root: HTMLElement,
@@ -324,6 +353,14 @@ export class ReviewApp {
           <iframe class="overview" title="Agent overview" sandbox="" hidden></iframe>
         </section>
         <section class="panel changes-panel active" id="changes-panel" role="tabpanel" aria-labelledby="changes-tab" data-panel="changes">
+          <div class="review-search" id="review-search" role="search" hidden>
+            <label class="sr-only" for="review-search-input">Find in changes</label>
+            <input id="review-search-input" type="search" placeholder="Find in changes" autocomplete="off" spellcheck="false" aria-describedby="review-search-count">
+            <span id="review-search-count" aria-live="polite">0 of 0</span>
+            <button class="small-icon-button search-previous" data-search-previous aria-label="Previous match" title="Previous match" disabled>${icon("chevron-down")}</button>
+            <button class="small-icon-button" data-search-next aria-label="Next match" title="Next match" disabled>${icon("chevron-down")}</button>
+            <button class="small-icon-button" data-search-close aria-label="Close search" title="Close search">${icon("close")}</button>
+          </div>
           <div class="mobile-navigation" role="tablist" aria-label="Changes navigation">
             <button class="active" role="tab" aria-selected="true" data-mobile-panel="diff">Diff</button>
             <button role="tab" aria-selected="false" tabindex="-1" data-mobile-panel="files">Files</button>
@@ -341,7 +378,7 @@ export class ReviewApp {
               </div>
             </div>
           </aside>
-          <main id="diff-view" class="diff-view" data-mobile-content="diff"></main>
+          <main id="diff-view" class="diff-view" data-mobile-content="diff" tabindex="-1"></main>
         </section>
         <footer class="review-bar">
           <label class="sr-only" for="review-summary">Overall review comment</label>
@@ -414,7 +451,9 @@ export class ReviewApp {
   cleanUp() {
     if (this.statusTimer !== undefined) window.clearInterval(this.statusTimer);
     if (this.questionPollTimer !== undefined) window.clearTimeout(this.questionPollTimer);
+    document.removeEventListener("keydown", this.handleSearchShortcut);
     this.viewer?.cleanUp();
+    CSS.highlights?.delete(SEARCH_HIGHLIGHT);
     this.tree?.cleanUp();
     this.workerPool.terminate();
   }
@@ -455,6 +494,7 @@ export class ReviewApp {
   }
 
   private installPage(page: ReviewPage) {
+    this.resetSearch();
     this.page = page;
     this.state = activatePage(this.state, page);
     const seenFiles = this.seenFiles();
@@ -776,6 +816,7 @@ export class ReviewApp {
       disableLineNumbers: !this.settings.lineNumbers,
       theme: diffTheme(this.settings),
       themeType: appearance(this.settings),
+      unsafeCSS: `::highlight(${SEARCH_HIGHLIGHT}) { color: #171717; background-color: #ffd54f; }`,
       hunkSeparators: "line-info" as const,
       expansionLineCount: 20,
       enableLineSelection: true,
@@ -785,6 +826,14 @@ export class ReviewApp {
       renderHeaderMetadata: (_file, context) => {
         if (context.item.type !== "diff") return null;
         return this.seenButton(context.item);
+      },
+      onSelectedLinesChange: (selection) => {
+        if (this.searchIsOpen()) this.searchSelection = selection;
+      },
+      onPostRender: (node, _instance, phase, context) => {
+        if (context.item.id === this.searchMatch?.itemId) {
+          this.updateSearchHighlight(phase === "unmount" ? null : node.shadowRoot);
+        }
       },
       ...commentSelectionCallbacks((selection) => this.openCommentComposer(selection)),
       renderAnnotation: (annotation: DiffLineAnnotation<AnnotationMetadata>) => this.annotationElement(annotation),
@@ -888,10 +937,201 @@ export class ReviewApp {
     item.collapsed = seen;
     item.version = ++this.itemVersion;
     this.viewer?.updateItem(item);
+    if (!seen && this.searchExpandedItem === path) this.searchExpandedItem = undefined;
     this.refreshTreeDecorations();
   }
 
+  private bindSearch() {
+    document.addEventListener("keydown", this.handleSearchShortcut);
+    const input = this.root.querySelector<HTMLInputElement>("#review-search-input");
+    input?.addEventListener("input", () => this.updateSearch());
+    input?.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" || event.isComposing) return;
+      event.preventDefault();
+      this.moveSearch(event.shiftKey ? -1 : 1);
+    });
+    this.root.querySelector("[data-search-previous]")?.addEventListener("click", () => this.moveSearch(-1));
+    this.root.querySelector("[data-search-next]")?.addEventListener("click", () => this.moveSearch(1));
+    this.root.querySelector("[data-search-close]")?.addEventListener("click", () => this.closeSearch());
+  }
+
+  private searchIsOpen() {
+    return this.root.querySelector<HTMLElement>("#review-search")?.hidden === false;
+  }
+
+  private openSearch() {
+    const panel = this.root.querySelector<HTMLElement>("#review-search");
+    const input = this.root.querySelector<HTMLInputElement>("#review-search-input");
+    if (!panel || !input) return;
+    if (panel.hidden) {
+      this.searchReturnFocus = deepActiveElement(document);
+      this.searchSelection = this.viewer?.getSelectedLines() ?? null;
+      panel.hidden = false;
+    }
+    input.focus();
+    input.select();
+  }
+
+  private closeSearch() {
+    const panel = this.root.querySelector<HTMLElement>("#review-search");
+    if (!panel || panel.hidden) return;
+    const restoreFocus = panel.contains(document.activeElement);
+    panel.hidden = true;
+    this.searchPaused = true;
+    this.updateSearchHighlight();
+    this.restoreSearchExpandedItem();
+    this.restoreSearchSelection();
+    this.searchSelection = undefined;
+    if (restoreFocus) {
+      const target = this.searchReturnFocus?.isConnected
+        ? this.searchReturnFocus
+        : this.root.querySelector<HTMLElement>("#diff-view");
+      queueMicrotask(() => target?.focus());
+    }
+    this.searchReturnFocus = undefined;
+  }
+
+  private resetSearch() {
+    this.closeSearch();
+    const input = this.root.querySelector<HTMLInputElement>("#review-search-input");
+    if (input) input.value = "";
+    this.searchCount = 0;
+    this.searchIndex = 0;
+    this.searchMatch = undefined;
+    this.searchPaused = true;
+    this.renderSearchStatus();
+  }
+
+  private updateSearch() {
+    const query = this.root.querySelector<HTMLInputElement>("#review-search-input")?.value ?? "";
+    this.restoreSearchExpandedItem();
+    this.restoreSearchSelection();
+    const result = searchReview(this.files, query);
+    this.searchCount = result.count;
+    this.searchIndex = 0;
+    this.searchMatch = result.match;
+    this.searchPaused = false;
+    this.renderSearchStatus();
+    if (result.match) this.revealSearchMatch();
+    else this.updateSearchHighlight();
+  }
+
+  private moveSearch(direction: -1 | 1) {
+    if (this.searchCount === 0) return;
+    const [index, occurrence] = moveSearchTarget(
+      this.searchMatch,
+      this.searchIndex,
+      this.searchCount,
+      direction,
+    );
+    this.searchIndex = index;
+    const query = this.root.querySelector<HTMLInputElement>("#review-search-input")?.value ?? "";
+    this.searchMatch = searchReview(this.files, query, index, occurrence).match;
+    this.searchPaused = false;
+    this.renderSearchStatus();
+    this.revealSearchMatch();
+  }
+
+  private revealSearchMatch() {
+    const match = this.searchMatch;
+    if (!match) return;
+    this.updateSearchHighlight();
+    this.root.querySelector<HTMLButtonElement>("[data-mobile-panel=diff]:not(.active)")?.click();
+    if (match.kind === "path") {
+      this.restoreSearchExpandedItem();
+      this.restoreSearchSelection();
+      this.viewer?.scrollTo({
+        type: "item",
+        id: match.itemId,
+        align: "start",
+        behavior: "smooth-auto",
+      });
+      return;
+    }
+
+    this.restoreSearchExpandedItem(match.itemId);
+    const item = this.items.find((candidate) => candidate.id === match.itemId);
+    if (item?.collapsed) {
+      item.collapsed = false;
+      item.version = ++this.itemVersion;
+      this.viewer?.updateItem(item);
+      if (this.seenFiles().has(item.id)) this.searchExpandedItem = item.id;
+    }
+    this.viewer?.setSelectedLines({
+      id: match.itemId,
+      range: {
+        start: match.lineNumber,
+        end: match.lineNumber,
+        side: match.side,
+        endSide: match.side,
+      },
+    }, { notify: false });
+    this.viewer?.scrollTo({
+      type: "line",
+      id: match.itemId,
+      lineNumber: match.lineNumber,
+      side: match.side,
+      align: "center",
+      behavior: "smooth-auto",
+    });
+  }
+
+  private updateSearchHighlight(
+    root: ShadowRoot | null | undefined = this.viewer?.getRenderedItems()
+      .find((candidate) => candidate.id === this.searchMatch?.itemId)?.element.shadowRoot,
+  ) {
+    CSS.highlights?.delete(SEARCH_HIGHLIGHT);
+    const match = this.searchMatch;
+    if (!CSS.highlights || this.searchPaused || !this.searchIsOpen() || match?.kind !== "content") return;
+    const split = root?.querySelector(`[data-${match.side}]`);
+    const lineType = match.side === "additions" ? "change-addition" : "change-deletion";
+    const line = split?.querySelector<HTMLElement>(`[data-line="${match.lineNumber}"]`)
+      ?? root?.querySelector<HTMLElement>(
+        `[data-unified] [data-line="${match.lineNumber}"]:is([data-line-type="${lineType}"], [data-line-type="context"])`,
+      );
+    const range = line ? textRange(line, match.start, match.length) : undefined;
+    if (range) CSS.highlights.set(SEARCH_HIGHLIGHT, new Highlight(range));
+  }
+
+  private restoreSearchSelection() {
+    if (this.searchSelection === undefined) return;
+    this.viewer?.setSelectedLines(this.searchSelection, { notify: false });
+  }
+
+  private clearSelectedLines() {
+    if (this.searchIsOpen()) this.searchSelection = null;
+    this.viewer?.clearSelectedLines();
+  }
+
+  private restoreSearchExpandedItem(keepItem?: string) {
+    const itemId = this.searchExpandedItem;
+    if (!itemId || itemId === keepItem) return;
+    this.searchExpandedItem = undefined;
+    const item = this.items.find((candidate) => candidate.id === itemId);
+    if (!item || !this.seenFiles().has(itemId) || item.collapsed) return;
+    item.collapsed = true;
+    item.version = ++this.itemVersion;
+    this.viewer?.updateItem(item);
+  }
+
+  private renderSearchStatus() {
+    const count = this.root.querySelector<HTMLElement>("#review-search-count");
+    const previous = this.root.querySelector<HTMLButtonElement>("[data-search-previous]");
+    const next = this.root.querySelector<HTMLButtonElement>("[data-search-next]");
+    const hasMatches = this.searchCount > 0;
+    if (previous) previous.disabled = !hasMatches;
+    if (next) next.disabled = !hasMatches;
+    if (!count) return;
+    const occurrence = this.searchMatch?.kind === "content" && this.searchMatch.occurrenceCount > 1
+      ? ` · ${this.searchMatch.occurrenceIndex + 1} of ${this.searchMatch.occurrenceCount} on line`
+      : "";
+    count.textContent = hasMatches
+      ? `${this.searchIndex + 1} of ${this.searchCount}${occurrence}`
+      : "0 of 0";
+  }
+
   private bindEvents() {
+    this.bindSearch();
     const tabs = [...this.root.querySelectorAll<HTMLButtonElement>("[data-tab]")];
     for (const [index, tab] of tabs.entries()) {
       tab.addEventListener("click", () => this.selectTab(tab.dataset.tab ?? "changes"));
@@ -1139,6 +1379,7 @@ export class ReviewApp {
   }
 
   private selectTab(name: string) {
+    if (name !== "changes") this.closeSearch();
     for (const tab of this.root.querySelectorAll<HTMLElement>("[data-tab]")) {
       const selected = tab.dataset.tab === name;
       tab.classList.toggle("active", selected);
@@ -1372,7 +1613,7 @@ export class ReviewApp {
   private closeCommentComposer() {
     const itemId = this.draft?.itemId;
     this.draft = undefined;
-    this.viewer?.clearSelectedLines();
+    this.clearSelectedLines();
     if (itemId) this.refreshItem(itemId);
     this.clearInlineError();
   }
@@ -1402,7 +1643,7 @@ export class ReviewApp {
     }
     const itemId = draft.itemId;
     this.draft = undefined;
-    this.viewer?.clearSelectedLines();
+    this.clearSelectedLines();
     this.refreshItem(itemId);
     this.refreshTreeDecorations();
     this.renderCommentList();
@@ -1570,7 +1811,7 @@ export class ReviewApp {
     }, draft.body, request, operationId);
     this.questions.push(thread);
     this.draft = undefined;
-    this.viewer?.clearSelectedLines();
+    this.clearSelectedLines();
     this.startQuestion(thread, request, operationId, page);
   }
 
@@ -2023,6 +2264,7 @@ export class ReviewApp {
       return;
     }
     this.state = finishTerminal(this.state, "submit");
+    this.closeSearch();
     const finished = this.root.querySelector<HTMLElement>("#finished");
     if (finished) finished.hidden = false;
   }
@@ -2048,6 +2290,7 @@ export class ReviewApp {
       return;
     }
     this.state = finishTerminal(this.state, "cancel");
+    this.closeSearch();
     const finished = this.root.querySelector<HTMLElement>("#finished");
     if (!finished) return;
     finished.innerHTML = "<div><span>✓</span><h2>Review cancelled</h2><p>You can return to Tact.</p></div>";
@@ -2075,6 +2318,34 @@ export class ReviewApp {
     if (!status || !status.classList.contains("error")) return;
     status.className = "terminal-status";
     status.textContent = "";
+  }
+}
+
+function deepActiveElement(root: Document | ShadowRoot): HTMLElement | undefined {
+  const active = root.activeElement;
+  if (!(active instanceof HTMLElement)) return;
+  return active.shadowRoot ? deepActiveElement(active.shadowRoot) ?? active : active;
+}
+
+function textRange(root: HTMLElement, start: number, length: number): Range | undefined {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let offset = 0;
+  let first: Text | undefined;
+  let firstOffset = 0;
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (!(node instanceof Text)) continue;
+    const end = offset + node.length;
+    if (!first && start < end) {
+      first = node;
+      firstOffset = start - offset;
+    }
+    if (first && start + length <= end) {
+      const range = document.createRange();
+      range.setStart(first, firstOffset);
+      range.setEnd(node, start + length - offset);
+      return range;
+    }
+    offset = end;
   }
 }
 

--- a/web/review/layout.test.ts
+++ b/web/review/layout.test.ts
@@ -8,6 +8,47 @@ test("the diff view owns its scrollable viewport", async () => {
   expect(diffViewRule).toMatch(/overflow:\s*auto/);
 });
 
+test("review search integrates with the virtualized review lifecycle", async () => {
+  const app = await Bun.file(new URL("app.ts", import.meta.url)).text();
+  const styles = await Bun.file(new URL("styles.css", import.meta.url)).text();
+  const shortcuts = app.slice(app.indexOf("handleSearchShortcut"), app.indexOf("constructor("));
+  const open = app.slice(
+    app.indexOf("private openSearch"),
+    app.indexOf("private closeSearch"),
+  );
+  const close = app.slice(
+    app.indexOf("private closeSearch"),
+    app.indexOf("private resetSearch"),
+  );
+  const search = app.slice(
+    app.indexOf("private bindSearch"),
+    app.indexOf("private bindEvents"),
+  );
+  const cleanup = app.slice(app.indexOf("cleanUp()"), app.indexOf("private installPage"));
+
+  expect(app).toContain('id="review-search" role="search" hidden');
+  expect(shortcuts.indexOf('dialog[open]')).toBeLessThan(shortcuts.indexOf('key === "f"'));
+  expect(search).toContain("event.isComposing");
+  expect(search).toContain("moveSearchTarget(");
+  expect(search).toContain("this.searchPaused = true");
+  expect(search).toContain("occurrenceIndex + 1");
+  expect(search).toContain("[data-mobile-panel=diff]:not(.active)");
+  expect(search).toContain("CSS.highlights.set");
+  expect(search).toContain("data-line-type");
+  expect(open).not.toContain("this.revealSearchMatch()");
+  expect(close).not.toContain("this.searchMatch = undefined");
+  expect(app).toContain("deepActiveElement(document)");
+  expect(search).toContain('this.root.querySelector<HTMLElement>("#diff-view")');
+  expect(app).toContain("context.item.id === this.searchMatch?.itemId");
+  expect(app).toContain('phase === "unmount" ? null : node.shadowRoot');
+  expect(app).toContain("onSelectedLinesChange");
+  expect(app).toContain("if (this.searchIsOpen()) this.searchSelection = null");
+  expect(app.match(/this\.viewer\?\.clearSelectedLines\(\)/g)).toHaveLength(1);
+  expect(app).toContain('document.removeEventListener("keydown", this.handleSearchShortcut)');
+  expect(cleanup.indexOf("viewer?.cleanUp()")).toBeLessThan(cleanup.indexOf("CSS.highlights?.delete"));
+  expect(styles).toMatch(/\.review-search\s*{[^}]*position:\s*absolute/s);
+});
+
 test("new changes appear before the range selector", async () => {
   const app = await Bun.file(new URL("app.ts", import.meta.url)).text();
 

--- a/web/review/review-search.test.ts
+++ b/web/review/review-search.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { parseReviewPatch } from "./review-diff";
+import { moveSearchTarget, searchReview } from "./review-search";
+
+describe("review search", () => {
+  test("handles empty queries and displayed rename paths", () => {
+    const patch = [
+      "diff --git a/src/NameName.ts b/src/new-name.ts\n",
+      "similarity index 100%\n",
+      "rename from src/NameName.ts\n",
+      "rename to src/new-name.ts\n",
+    ].join("");
+    const files = parseReviewPatch(patch, "paths", false);
+
+    expect(searchReview(files, " ")).toEqual({ count: 0 });
+    expect(matches(files, "nAmE")).toEqual([
+      { kind: "path", itemId: "src/new-name.ts" },
+    ]);
+  });
+
+  test("returns one navigable match per row with actual line numbers", () => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt\n",
+      "index 1111111..2222222 100644\n",
+      "--- a/example.txt\n",
+      "+++ b/example.txt\n",
+      "@@ -40,2 +70,3 @@\n",
+      "-needle NEEDLE needle\n",
+      "+İ Needle then nEeDlE İ\n",
+      "+İ value\n",
+      " context NEEDLE twice needle\n",
+    ].join("");
+    const files = parseReviewPatch(patch, "rows", false);
+
+    expect(matches(files, "NeEdLe").map(summary)).toEqual([
+      ["deletions", 40],
+      ["additions", 70],
+      ["additions", 72],
+    ]);
+    expect(searchReview(files, "NeEdLe").match).toMatchObject({ start: 0 });
+    expect(searchReview(files, "NeEdLe", 1).match).toMatchObject({ start: 2, length: 6 });
+    expect(searchReview(files, "NeEdLe", 2).match).toMatchObject({ start: 8 });
+    expect(searchReview(files, "i\u0307").match).toMatchObject({ start: 0, length: 1 });
+    expect(searchReview(files, "i\u0307", 0, 1).match).toMatchObject({
+      start: 21,
+      length: 1,
+      occurrenceIndex: 1,
+      occurrenceCount: 2,
+    });
+  });
+
+  test("navigates every occurrence on the active row without indexing them globally", () => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt\n",
+      "index 1111111..2222222 100644\n",
+      "--- a/example.txt\n",
+      "+++ b/example.txt\n",
+      "@@ -1,2 +1,2 @@\n",
+      "-needle NEEDLE needle\n",
+      "+needle elsewhere\n",
+      " context needle\n",
+    ].join("");
+    const files = parseReviewPatch(patch, "occurrences", false);
+    const first = searchReview(files, "needle");
+
+    expect(first.count).toBe(3);
+    expect(first.match).toMatchObject({ start: 0, occurrenceIndex: 0, occurrenceCount: 3 });
+    const second = searchReview(files, "needle", 0, 1).match;
+    expect(second).toMatchObject({
+      start: 7,
+      occurrenceIndex: 1,
+      occurrenceCount: 3,
+    });
+    const last = searchReview(files, "needle", 0, Number.MAX_SAFE_INTEGER).match;
+    expect(last).toMatchObject({ start: 14, occurrenceIndex: 2, occurrenceCount: 3 });
+    expect(moveSearchTarget(first.match, 0, first.count, 1)).toEqual([0, 1]);
+    expect(moveSearchTarget(second, 0, first.count, -1)).toEqual([0, 0]);
+    expect(moveSearchTarget(last, 0, first.count, 1)).toEqual([1, 0]);
+    expect(moveSearchTarget(searchReview(files, "needle", 1).match, 1, first.count, -1)).toEqual([
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ]);
+    expect(moveSearchTarget(first.match, 0, first.count, -1)).toEqual([
+      2,
+      Number.MAX_SAFE_INTEGER,
+    ]);
+  });
+
+  test("walks partial hunks independently of packed line indexes", () => {
+    const patch = [
+      "diff --git a/example.txt b/example.txt\n",
+      "index 1111111..2222222 100644\n",
+      "--- a/example.txt\n",
+      "+++ b/example.txt\n",
+      "@@ -10,2 +20,2 @@\n",
+      "-first needle in old file\n",
+      "+first needle in new file\n",
+      " shared first context\n",
+      "@@ -100,3 +200,4 @@\n",
+      " shared second context\n",
+      "-second needle in old file\n",
+      "+second needle in new file\n",
+      "+extra needle in new file\n",
+      " shared final context\n",
+    ].join("");
+    const [file] = parseReviewPatch(patch, "partial", false);
+
+    expect(file.isPartial).toBeTrue();
+    expect(matches([file], "needle").map(summary)).toEqual([
+      ["deletions", 10],
+      ["additions", 20],
+      ["deletions", 101],
+      ["additions", 201],
+      ["additions", 202],
+    ]);
+  });
+
+  test("excludes collapsed unchanged context from full files", () => {
+    const original = Array.from({ length: 20 }, (_, index) => `line ${index + 1}\n`);
+    original[0] = "collapsed target context\n";
+    original[6] = "displayed target context\n";
+    original[9] = "old target value\n";
+    const patch = [
+      "diff --git a/example.txt b/example.txt\n",
+      "index 1111111..2222222 100644\n",
+      "--- a/example.txt\n",
+      "+++ b/example.txt\n",
+      "@@ -1,20 +1,20 @@\n",
+      ...original.map((line, index) => index === 9 ? `-${line}+new target value\n` : ` ${line}`),
+    ].join("");
+    const [file] = parseReviewPatch(patch, "full", true);
+
+    expect(file.hunks[0].collapsedBefore).toBe(6);
+    expect(matches([file], "target").map(summary)).toEqual([
+      ["additions", 7],
+      ["deletions", 10],
+      ["additions", 10],
+    ]);
+  });
+});
+
+function matches(files: ReturnType<typeof parseReviewPatch>, query: string) {
+  const { count } = searchReview(files, query);
+  return Array.from({ length: count }, (_, index) => searchReview(files, query, index).match!);
+}
+
+function summary(match: ReturnType<typeof matches>[number]) {
+  if (match.kind === "path") return ["path"];
+  return [match.side, match.lineNumber];
+}

--- a/web/review/review-search.ts
+++ b/web/review/review-search.ts
@@ -1,0 +1,129 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+export type ReviewSearchMatch =
+  | { kind: "path"; itemId: string }
+  | {
+      kind: "content";
+      itemId: string;
+      side: "additions" | "deletions";
+      lineNumber: number;
+      start: number;
+      length: number;
+      occurrenceIndex: number;
+      occurrenceCount: number;
+    };
+
+export function searchReview(
+  files: readonly FileDiffMetadata[],
+  query: string,
+  target = 0,
+  targetOccurrence = 0,
+): { count: number; match?: ReviewSearchMatch } {
+  if (!query.trim()) return { count: 0 };
+
+  const needle = query.toLowerCase();
+  let count = 0;
+  let match: ReviewSearchMatch | undefined;
+  const isTarget = () => count++ === target;
+
+  for (const file of files) {
+    if ((file.name.toLowerCase().includes(needle)
+      || file.prevName?.toLowerCase().includes(needle)) && isTarget()) {
+      match = { kind: "path", itemId: file.name };
+    }
+
+    const recordLines = (
+      lines: readonly string[],
+      startIndex: number,
+      length: number,
+      side: "additions" | "deletions",
+      lineNumber: number,
+    ) => {
+      for (let index = 0; index < length; index++) {
+        const line = lines[startIndex + index];
+        const folded = line.toLowerCase();
+        if (!folded.includes(needle)) continue;
+        if (!isTarget()) continue;
+        const occurrence = findOccurrence(folded, needle, targetOccurrence);
+        match = {
+          kind: "content",
+          itemId: file.name,
+          side,
+          lineNumber: lineNumber + index,
+          ...sourceRange(line, occurrence.start, needle.length),
+          occurrenceIndex: occurrence.index,
+          occurrenceCount: occurrence.count,
+        };
+      }
+    };
+
+    for (const hunk of file.hunks) {
+      let deletionLine = hunk.deletionStart;
+      let additionLine = hunk.additionStart;
+
+      for (const content of hunk.hunkContent) {
+        if (content.type === "context") {
+          recordLines(file.additionLines, content.additionLineIndex, content.lines, "additions", additionLine);
+          deletionLine += content.lines;
+          additionLine += content.lines;
+          continue;
+        }
+
+        recordLines(file.deletionLines, content.deletionLineIndex, content.deletions, "deletions", deletionLine);
+        recordLines(file.additionLines, content.additionLineIndex, content.additions, "additions", additionLine);
+
+        deletionLine += content.deletions;
+        additionLine += content.additions;
+      }
+    }
+  }
+
+  return { count, match };
+}
+
+export function moveSearchTarget(
+  match: ReviewSearchMatch | undefined,
+  index: number,
+  count: number,
+  direction: -1 | 1,
+): [number, number] {
+  if (match?.kind === "content") {
+    const occurrence = match.occurrenceIndex + direction;
+    if (occurrence >= 0 && occurrence < match.occurrenceCount) return [index, occurrence];
+  }
+  return [
+    (index + direction + count) % count,
+    direction < 0 ? Number.MAX_SAFE_INTEGER : 0,
+  ];
+}
+
+function findOccurrence(text: string, needle: string, target: number) {
+  let count = 0;
+  let start = 0;
+  let selected = 0;
+  const occurrence = Math.max(0, target);
+  while ((start = text.indexOf(needle, start)) >= 0) {
+    if (count <= occurrence) selected = start;
+    count++;
+    start += needle.length;
+  }
+  return { start: selected, index: Math.min(occurrence, count - 1), count };
+}
+
+function sourceRange(text: string, start: number, length: number) {
+  let sourceOffset = 0;
+  let foldedOffset = 0;
+  let sourceStart = 0;
+  const foldedEnd = start + length;
+  for (const character of text) {
+    const sourceEnd = sourceOffset + character.length;
+    const nextFoldedOffset = foldedOffset + character.toLowerCase().length;
+    if (foldedOffset <= start && start < nextFoldedOffset) sourceStart = sourceOffset;
+    if (foldedOffset < foldedEnd && foldedEnd <= nextFoldedOffset) {
+      return { start: sourceStart, length: sourceEnd - sourceStart };
+    }
+    sourceOffset = sourceEnd;
+    foldedOffset = nextFoldedOffset;
+  }
+  return { start, length };
+}

--- a/web/review/styles.css
+++ b/web/review/styles.css
@@ -24,10 +24,10 @@
 
 * { box-sizing: border-box; }
 html, body, #app { width: 100%; height: 100%; margin: 0; overflow: hidden; }
-button, textarea, select { font: inherit; }
-button, select { color: inherit; }
+button, input, textarea, select { font: inherit; }
+button, input, select { color: inherit; }
 button:disabled { cursor: default; opacity: .55; }
-button:focus-visible, select:focus-visible, textarea:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
+button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 .mobile-navigation { display: none; }
 
@@ -170,7 +170,16 @@ button:focus-visible, select:focus-visible, textarea:focus-visible { outline: 2p
 .overview-spinner span { display: grid; place-items: center; width: 38px; height: 38px; border: 1px solid color-mix(in srgb, var(--accent-solid) 24%, var(--line)); border-radius: 50%; background: linear-gradient(145deg, color-mix(in srgb, var(--accent-solid) 14%, var(--surface)), var(--surface)); color: var(--accent); }
 .overview-spinner svg { width: 20px; height: 20px; }
 .overview-error { display: grid; place-items: center; width: 42px; height: 42px; border-radius: 13px; background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--danger); font-weight: 750; }
-.changes-panel.active { display: grid; grid-template-columns: 352px minmax(0, 1fr); width: 100%; height: 100%; min-height: 0; }
+.changes-panel.active { position: relative; display: grid; grid-template-columns: 352px minmax(0, 1fr); width: 100%; height: 100%; min-height: 0; }
+
+.review-search { position: absolute; z-index: 25; top: 10px; right: 14px; display: flex; align-items: center; gap: 4px; width: min(420px, calc(100% - 380px)); min-height: 38px; padding: 5px; border: 1px solid var(--line-strong); border-radius: 10px; background: var(--surface-raised); box-shadow: 0 12px 32px color-mix(in srgb, #000 18%, transparent); }
+.review-search[hidden] { display: none; }
+.review-search input { min-width: 0; height: 28px; flex: 1; padding: 0 8px; border: 1px solid var(--line); border-radius: 6px; outline: 0; background: var(--surface); }
+.review-search input:focus { border-color: color-mix(in srgb, var(--blue) 55%, var(--line)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--blue) 25%, transparent); }
+.review-search input:focus-visible { outline: 0; }
+.review-search > span { min-width: 58px; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, monospace; text-align: center; white-space: nowrap; }
+.review-search .small-icon-button { flex: none; }
+.review-search .search-previous svg { transform: rotate(180deg); }
 
 .sidebar { display: grid; grid-template-rows: minmax(140px, 1fr) auto; width: 100%; height: 100%; min-width: 0; min-height: 0; overflow: hidden; border-right: 1px solid var(--line); background: var(--surface); }
 .sidebar-label { display: flex; align-items: center; justify-content: space-between; padding: 0 14px; color: var(--muted); font-size: 11px; font-weight: 650; letter-spacing: .06em; text-transform: uppercase; }
@@ -381,6 +390,7 @@ button:focus-visible, select:focus-visible, textarea:focus-visible { outline: 2p
 @media (max-width: 760px) {
   :root { --review-footer-height: 132px; }
   .changes-panel.active { grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr); }
+  .review-search { top: 52px; right: 8px; width: calc(100% - 16px); }
   .mobile-navigation { display: flex; gap: 4px; padding: 6px 10px; border-bottom: 1px solid var(--line); background: var(--surface); }
   .mobile-navigation button { flex: 1; min-height: 34px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); }
   .mobile-navigation button.active { background: var(--bg); color: var(--text); font-weight: 650; }


### PR DESCRIPTION
`CodeView` only mounts files/lines that are in or around the active view, and browsers' built in Ctrl+F can't search text that is not in the DOM. This adds a native search function to the review webpage when you use Ctrl+F or Cmd+F.

<img width="1798" height="1287" alt="image" src="https://github.com/user-attachments/assets/89dbc559-6b6f-4097-9e0a-49836cde7a48" />
