### PR TITLE
fix(tui): render terminal controls safely

### DIFF
--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -12,7 +12,10 @@ use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
     tui::{
         context::MODEL_WINDOW_TOKENS,
-        format::{format_turn_duration, normalize_line_endings, shorten_home},
+        format::{
+            format_turn_duration, normalize_line_endings, sanitize_terminal_text, shorten_home,
+            terminal_text_width,
+        },
         prompt::Submission,
         theme::Theme,
     },
@@ -1477,10 +1480,11 @@ fn render_draft_line(
     width: usize,
     theme: &Theme,
 ) {
+    let rendered = sanitize_terminal_text(&draft[range.clone()]);
     buffer.set_stringn(
         position.x,
         position.y,
-        &draft[range.clone()],
+        rendered,
         width,
         Style::default().fg(theme.text()),
     );
@@ -1490,7 +1494,7 @@ fn render_draft_line(
         if start >= end {
             continue;
         }
-        let offset = draft[range.start..start].width();
+        let offset = terminal_text_width(&draft[range.start..start]);
         buffer.set_stringn(
             position
                 .x
@@ -1525,8 +1529,8 @@ fn render_selection(
     let Some(text) = draft.get(start..end) else {
         return;
     };
-    let offset = prefix.width();
-    let selected_width = text.width().min(width.saturating_sub(offset));
+    let offset = terminal_text_width(prefix);
+    let selected_width = terminal_text_width(text).min(width.saturating_sub(offset));
     if selected_width == 0 {
         return;
     }
@@ -1953,6 +1957,20 @@ mod tests {
         composer.update(ComposerEvent::ReplaceDraft("edited\r\ndraft".to_owned()));
         assert_eq!(composer.draft(), "edited\ndraft");
         assert_eq!(composer.cursor(), composer.draft().len());
+    }
+
+    #[test]
+    fn pasted_controls_are_visible_without_changing_the_submission() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        let pasted = "one\ttwo\u{1b}three";
+        composer.update(ComposerEvent::Terminal(Event::Paste(pasted.to_owned())));
+
+        let terminal = render(&mut composer, 40, 5);
+        assert!(rows(&terminal)[1].contains("one    two�three"));
+        assert_eq!(terminal.backend().cursor_position(), Position::new(17, 1));
+
+        let submission = composer.take_submission().unwrap();
+        assert_eq!(submission.display_text(), pasted);
     }
 
     #[test]

--- a/bin/tact/src/tui/components/composer/layout.rs
+++ b/bin/tact/src/tui/components/composer/layout.rs
@@ -1,8 +1,8 @@
 //! Grapheme-aware soft and hard wrapping for the composer.
 
+use crate::tui::format::terminal_text_width;
 use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct VisualLine {
@@ -99,7 +99,7 @@ fn wrap_logical_line(
 
         for (offset, grapheme) in text[line_start..end].grapheme_indices(true) {
             let grapheme_start = line_start + offset;
-            let grapheme_width = grapheme.width();
+            let grapheme_width = terminal_text_width(grapheme);
             if candidate_end > line_start && used + grapheme_width > width {
                 break;
             }
@@ -132,7 +132,7 @@ fn wrap_logical_line(
         lines.push(VisualLine {
             start: line_start,
             end: line_end,
-            width: text[line_start..line_end].width(),
+            width: terminal_text_width(&text[line_start..line_end]),
         });
         line_start = line_end;
     }
@@ -141,7 +141,10 @@ fn wrap_logical_line(
 fn locate_cursor(text: &str, lines: &[VisualLine], cursor: usize) -> (usize, usize) {
     for (row, line) in lines.iter().enumerate() {
         if cursor < line.end || (line.start == line.end && cursor == line.start) {
-            return (row, text[line.start..cursor.min(line.end)].width());
+            return (
+                row,
+                terminal_text_width(&text[line.start..cursor.min(line.end)]),
+            );
         }
         if cursor == line.end {
             let next_starts_here = lines.get(row + 1).is_some_and(|next| next.start == cursor);
@@ -159,7 +162,7 @@ fn locate_cursor(text: &str, lines: &[VisualLine], cursor: usize) -> (usize, usi
 pub(super) fn byte_at_column(text: &str, line: &VisualLine, target: usize) -> usize {
     let mut column = 0;
     for (offset, grapheme) in text[line.start..line.end].grapheme_indices(true) {
-        let next = column + grapheme.width();
+        let next = column + terminal_text_width(grapheme);
         if next > target {
             return line.start + offset;
         }
@@ -172,7 +175,7 @@ pub(super) fn grapheme_at_column(text: &str, line: &VisualLine, target: usize) -
     let mut column = 0;
     for (offset, grapheme) in text[line.start..line.end].grapheme_indices(true) {
         let start = line.start + offset;
-        let next = column + grapheme.width();
+        let next = column + terminal_text_width(grapheme);
         if next > target {
             return start..start + grapheme.len();
         }

--- a/bin/tact/src/tui/components/queue.rs
+++ b/bin/tact/src/tui/components/queue.rs
@@ -4,7 +4,7 @@ use super::{
     node::{Component, ComponentUpdate, RenderRequest},
     waved_text::WavedText,
 };
-use crate::tui::{prompt::Submission, theme::Theme};
+use crate::tui::{format::sanitize_terminal_text_inline, prompt::Submission, theme::Theme};
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{
     Frame,
@@ -517,11 +517,7 @@ impl Component for MessageQueue {
 }
 
 fn truncate(text: &str, width: usize) -> Cow<'_, str> {
-    let text = if text.contains(['\n', '\r']) {
-        Cow::Owned(text.replace(['\n', '\r'], " "))
-    } else {
-        Cow::Borrowed(text)
-    };
+    let text = sanitize_terminal_text_inline(text);
     if UnicodeWidthStr::width(text.as_ref()) <= width {
         return text;
     }
@@ -614,6 +610,23 @@ mod tests {
         assert!(rows[1].contains("priority"));
         assert!(rows[3].contains("first"));
         assert!(rows[5].contains("last"));
+    }
+
+    #[test]
+    fn queued_controls_are_visible_without_changing_the_submission() {
+        let mut queue = MessageQueue::default();
+        let prompt = "one\ttwo\u{1b}three\nnext";
+        queue.push(prompt.to_owned());
+
+        let rows = rendered_rows(&mut queue, 40, 3);
+        assert!(rows[1].contains("one    two�three next"));
+
+        let update = queue.update(key(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(matches!(
+            update.effects.as_slice(),
+            [QueueEffect::Steer { prompt: submission, .. }]
+                if submission.display_text() == prompt
+        ));
     }
 
     #[test]

--- a/bin/tact/src/tui/components/subagents.rs
+++ b/bin/tact/src/tui/components/subagents.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::{
     app::config::DEFAULT_MAX_SUBAGENTS,
-    tui::{theme::Theme, transcript::TranscriptRecord},
+    tui::{format::sanitize_terminal_text_inline, theme::Theme, transcript::TranscriptRecord},
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind};
 use nanocodex::Model;
@@ -971,6 +971,7 @@ fn draw_world_string(
         return;
     }
 
+    let text = sanitize_terminal_text_inline(text);
     let mut x = screen_x;
     for grapheme in text.graphemes(true) {
         let width = i32::try_from(UnicodeWidthStr::width(grapheme)).unwrap_or(i32::MAX);
@@ -1023,6 +1024,8 @@ fn inset(area: Rect, horizontal: u16, vertical: u16) -> Rect {
 }
 
 fn truncate_with_ellipsis(text: &str, width: u16) -> String {
+    let text = sanitize_terminal_text_inline(text);
+    let text = text.as_ref();
     if UnicodeWidthStr::width(text) <= usize::from(width) {
         return text.to_owned();
     }
@@ -1252,6 +1255,23 @@ mod tests {
         assert_eq!(tree.effort, ReasoningEffort::High);
         assert_eq!(tree.active_count(), 1);
         assert!(tree.contains(AgentId::new(1)));
+    }
+
+    #[test]
+    fn tree_nodes_do_not_write_control_characters_to_terminal_cells() {
+        let mut tree = SubagentTree::new(ReasoningEffort::Medium);
+        let mut agent = descriptor();
+        agent.role = "re\u{1b}\tsearcher".to_owned();
+        tree.apply(AgentUpdate::Added(agent));
+
+        let backend = render_tree(&mut tree);
+        assert!(
+            backend
+                .buffer()
+                .content
+                .iter()
+                .all(|cell| { !cell.symbol().chars().any(char::is_control) })
+        );
     }
 
     #[test]

--- a/bin/tact/src/tui/components/transcript/markdown.rs
+++ b/bin/tact/src/tui/components/transcript/markdown.rs
@@ -1,4 +1,4 @@
-use crate::tui::theme::Theme;
+use crate::tui::{format::sanitize_terminal_text, theme::Theme};
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::{
     style::{Modifier, Style},
@@ -125,16 +125,7 @@ fn wrap_plain_with_whitespace(
 }
 
 pub(super) fn sanitize(text: &str) -> String {
-    let mut sanitized = String::with_capacity(text.len());
-    for character in text.chars() {
-        match character {
-            '\n' => sanitized.push('\n'),
-            '\t' => sanitized.push_str("    "),
-            character if character.is_control() => sanitized.push('�'),
-            character => sanitized.push(character),
-        }
-    }
-    sanitized
+    sanitize_terminal_text(text).into_owned()
 }
 
 struct Renderer<'a> {

--- a/bin/tact/src/tui/format.rs
+++ b/bin/tact/src/tui/format.rs
@@ -1,6 +1,8 @@
 //! Shared formatting for terminal-facing values.
 
 use std::{borrow::Cow, env, path::Path};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 pub(crate) fn normalize_line_endings(text: &str) -> Cow<'_, str> {
     if !text.contains('\r') {
@@ -19,6 +21,54 @@ pub(crate) fn normalize_line_endings(text: &str) -> Cow<'_, str> {
     }
     normalized.push_str(remaining);
     Cow::Owned(normalized)
+}
+
+pub(crate) fn sanitize_terminal_text(text: &str) -> Cow<'_, str> {
+    sanitize_terminal_text_with_break(text, '\n')
+}
+
+pub(crate) fn sanitize_terminal_text_inline(text: &str) -> Cow<'_, str> {
+    sanitize_terminal_text_with_break(text, ' ')
+}
+
+fn sanitize_terminal_text_with_break(text: &str, line_break: char) -> Cow<'_, str> {
+    let requires_sanitization = text.chars().any(|character| {
+        character == '\r'
+            || character == '\t'
+            || character.is_control() && character != '\n'
+            || character == '\n' && line_break != '\n'
+    });
+    if !requires_sanitization {
+        return Cow::Borrowed(text);
+    }
+
+    let mut sanitized = String::with_capacity(text.len());
+    let mut characters = text.chars().peekable();
+    while let Some(character) = characters.next() {
+        match character {
+            '\r' => {
+                if characters.peek() == Some(&'\n') {
+                    characters.next();
+                }
+                sanitized.push(line_break);
+            }
+            '\n' => sanitized.push(line_break),
+            '\t' => sanitized.push_str("    "),
+            character if character.is_control() => sanitized.push('�'),
+            character => sanitized.push(character),
+        }
+    }
+    Cow::Owned(sanitized)
+}
+
+pub(crate) fn terminal_text_width(text: &str) -> usize {
+    text.graphemes(true)
+        .map(|grapheme| match grapheme {
+            "\t" => 4,
+            grapheme if grapheme.contains(char::is_control) => 1,
+            grapheme => grapheme.width(),
+        })
+        .sum()
 }
 
 pub(crate) fn format_duration(nanoseconds: u64) -> String {
@@ -83,6 +133,7 @@ pub(crate) fn shorten_home(path: &Path) -> String {
 mod tests {
     use super::{
         duration_display_tick, format_duration, format_turn_duration, normalize_line_endings,
+        sanitize_terminal_text, sanitize_terminal_text_inline, terminal_text_width,
     };
 
     #[test]
@@ -92,6 +143,14 @@ mod tests {
             normalize_line_endings("one\r\ntwo\rthree"),
             "one\ntwo\nthree"
         );
+    }
+
+    #[test]
+    fn terminal_text_has_safe_multiline_and_inline_projections() {
+        let text = "one\r\ntwo\tthree\u{1b}";
+        assert_eq!(sanitize_terminal_text(text), "one\ntwo    three�");
+        assert_eq!(sanitize_terminal_text_inline(text), "one two    three�");
+        assert_eq!(terminal_text_width("two\tthree\u{1b}"), 13);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- project tabs and terminal controls into visible safe text without changing submitted source
- use the same display widths for composer wrapping, cursor placement, hit testing, and selection
- sanitize queued summaries and subagent graph cells before rendering

## Validation

- `just test`
- `just clippy`
- `just check-fmt`
- independent defect-first review: no findings