### PR TITLE
fix(tui): allow forks during active turns

### DIFF
--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -1646,7 +1646,7 @@ impl RootNode {
     }
 
     fn can_fork(&self) -> bool {
-        self.fork_available && self.in_flight_turns == 0 && !self.transcript.component().is_active()
+        self.fork_available
     }
 
     fn open_new_session(&mut self) -> ComponentUpdate<RootEffect> {
@@ -6160,102 +6160,17 @@ mod tests {
     }
 
     #[test]
-    fn fork_waits_for_worker_and_agent_turn_state_to_agree() {
-        let mut worker_before_started = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
-        worker_before_started.in_flight_turns = 1;
-        worker_before_started.update(RootEvent::WorkerTurnFinished {
-            terminal_expected: true,
-        });
-        assert!(
-            worker_before_started
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects
-                .is_empty()
-        );
-        worker_before_started.update(RootEvent::Transcript(agent_record(
+    fn active_turn_can_fork_from_the_latest_safe_boundary() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.in_flight_turns = 1;
+        root.update(RootEvent::Transcript(agent_record(
             1,
             AgentEventKind::RunStarted,
             json!({}),
         )));
-        worker_before_started.update(RootEvent::Transcript(agent_record(
-            2,
-            AgentEventKind::RunCompleted,
-            json!({}),
-        )));
+
         assert_eq!(
-            worker_before_started
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects,
-            [RootEffect::Fork]
-        );
-
-        let mut before_started = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
-        before_started.in_flight_turns = 1;
-
-        assert!(
-            before_started
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects
-                .is_empty()
-        );
-
-        before_started.update(RootEvent::Transcript(agent_record(
-            1,
-            AgentEventKind::RunStarted,
-            json!({}),
-        )));
-        assert!(
-            before_started
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects
-                .is_empty()
-        );
-        before_started.update(RootEvent::Transcript(agent_record(
-            2,
-            AgentEventKind::RunCompleted,
-            json!({}),
-        )));
-        assert!(
-            before_started
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects
-                .is_empty()
-        );
-        before_started.update(RootEvent::WorkerTurnFinished {
-            terminal_expected: true,
-        });
-        assert_eq!(
-            before_started
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects,
-            [RootEffect::Fork]
-        );
-
-        let mut before_terminal = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
-        before_terminal.in_flight_turns = 1;
-        before_terminal.update(RootEvent::Transcript(agent_record(
-            1,
-            AgentEventKind::RunStarted,
-            json!({}),
-        )));
-        before_terminal.update(RootEvent::WorkerTurnFinished {
-            terminal_expected: true,
-        });
-
-        assert!(
-            before_terminal
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
-                .effects
-                .is_empty()
-        );
-        before_terminal.update(RootEvent::Transcript(agent_record(
-            2,
-            AgentEventKind::RunCompleted,
-            json!({}),
-        )));
-        assert_eq!(
-            before_terminal
-                .update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
+            root.update(key(KeyCode::Char('t'), KeyModifiers::CONTROL))
                 .effects,
             [RootEffect::Fork]
         );

--- a/bin/tact/src/tui/components/transcript/mod.rs
+++ b/bin/tact/src/tui/components/transcript/mod.rs
@@ -267,10 +267,6 @@ impl Transcript {
         snapshot
     }
 
-    pub(crate) const fn is_active(&self) -> bool {
-        self.model.is_active()
-    }
-
     pub(crate) const fn set_effort(&mut self, effort: ReasoningEffort) {
         self.effort = effort;
     }
@@ -1907,6 +1903,27 @@ mod tests {
         )
     }
 
+    fn fork_started(sequence: u64, parent_sequence: u64) -> Arc<TranscriptRecord> {
+        Arc::new(
+            TranscriptRecord::from_local(
+                sequence,
+                sequence,
+                LocalEvent::SessionStarted(SessionStarted {
+                    session_id: "fork".to_owned(),
+                    parent_session_id: Some("parent".to_owned()),
+                    parent_sequence: Some(parent_sequence),
+                    model: Model::Luna.to_string(),
+                    effort: ReasoningEffort::Medium,
+                    reasoning_mode: ReasoningMode::Standard,
+                    fast_mode: false,
+                    workspace: "/work".into(),
+                    application_version: "test".to_owned(),
+                }),
+            )
+            .unwrap(),
+        )
+    }
+
     fn agent(sequence: u64, kind: AgentEventKind) -> Arc<TranscriptRecord> {
         agent_with_payload(sequence, kind, json!({}))
     }
@@ -2038,24 +2055,7 @@ mod tests {
     #[test]
     fn fork_start_renders_its_parent_session_boundary() {
         let mut transcript = Transcript::new();
-        transcript.update(TranscriptEvent::Record(Arc::new(
-            TranscriptRecord::from_local(
-                1,
-                1,
-                LocalEvent::SessionStarted(SessionStarted {
-                    session_id: "fork".to_owned(),
-                    parent_session_id: Some("parent".to_owned()),
-                    parent_sequence: Some(0),
-                    model: Model::Luna.to_string(),
-                    effort: ReasoningEffort::Medium,
-                    reasoning_mode: ReasoningMode::Standard,
-                    fast_mode: false,
-                    workspace: "/work".into(),
-                    application_version: "test".to_owned(),
-                }),
-            )
-            .unwrap(),
-        )));
+        transcript.update(TranscriptEvent::Record(fork_started(1, 0)));
 
         let backend = render(&mut transcript, 40, 3);
         let output = backend
@@ -2066,6 +2066,29 @@ mod tests {
             .collect::<String>();
 
         assert!(output.contains("Forked from @@parent"));
+    }
+
+    #[test]
+    fn fork_start_discards_the_active_parent_turn() {
+        let mut transcript = Transcript::new();
+        transcript.update(TranscriptEvent::Record(user(1, "completed")));
+        transcript.update(TranscriptEvent::Record(user(2, "still running")));
+        transcript.update(TranscriptEvent::Record(agent(
+            3,
+            AgentEventKind::RunStarted,
+        )));
+        transcript.update(TranscriptEvent::Record(fork_started(4, 3)));
+
+        assert!(!transcript.model.is_active());
+        assert_eq!(transcript.model.entries().len(), 2);
+        assert!(matches!(
+            &transcript.model.entries()[0].kind,
+            EntryKind::User { text } if text == "completed"
+        ));
+        assert!(matches!(
+            &transcript.model.entries()[1].kind,
+            EntryKind::ForkedFrom { session_id } if session_id == "parent"
+        ));
     }
 
     #[test]

--- a/bin/tact/src/tui/transcript/model.rs
+++ b/bin/tact/src/tui/transcript/model.rs
@@ -229,6 +229,7 @@ impl TranscriptModel {
         let changed = match record.kind() {
             "session.started" => self.decode_local::<SessionStarted>(record).map(|payload| {
                 if let Some(session_id) = payload.parent_session_id {
+                    *self = self.fork_snapshot();
                     self.push(EntryKind::ForkedFrom { session_id });
                 }
             }),


### PR DESCRIPTION
## Summary

- enable the fork action while the current session is still working
- fork from the latest safe model boundary while excluding partial parent-turn projection state
- cover active-turn creation and persisted lineage replay with regression tests

## Validation

- `just check-fmt`
- `just clippy`
- `cargo nextest run -p tact fork` (28 tests)
- `just test` (901 tests)