### PR TITLE
chore(release): prepare 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "arboard",
  "axum",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "tact-memory"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "const_format",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "tact-memory-cloudflare"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "rusqlite",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "tact-subagents"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "futures-util",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bin/tact", "crates/*", "examples/tact-memory-cloudflare"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]
@@ -54,8 +54,8 @@ sha2 = "0.10.9"
 shlex = "2.0.1"
 syntect = { version = "5.3.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
 tar = "0.4.44"
-tact-memory = { version = "0.6.1", path = "crates/memory", default-features = false }
-tact-subagents = { version = "0.6.1", path = "crates/subagents" }
+tact-memory = { version = "0.6.2", path = "crates/memory", default-features = false }
+tact-subagents = { version = "0.6.2", path = "crates/subagents" }
 tempfile = "3.27.0"
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }


### PR DESCRIPTION
## Summary

- bump the workspace package version to 0.6.2
- update internal workspace dependency requirements and generated lockfile package versions

## Validation

- `cargo check --all-features`
- `cargo nextest run -p tact --test release_pipeline` (15 tests)