### PR TITLE
feat: report lifecycle state to Herdr

### DIFF
--- a/bin/tact/src/app/herdr.rs
+++ b/bin/tact/src/app/herdr.rs
@@ -1,0 +1,303 @@
+//! Best-effort lifecycle reporting for Tact sessions hosted by Herdr.
+
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    process::Stdio,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tokio::process::Command;
+
+const AGENT: &str = "tact";
+const SOURCE: &str = "herdr:tact";
+
+pub(crate) struct Reporter(Option<ActiveReporter>);
+
+impl Reporter {
+    pub(crate) fn from_env(session_id: &str) -> Self {
+        let Some((binary, pane_id)) = environment(
+            env::var("HERDR_ENV").ok(),
+            env::var_os("HERDR_BIN_PATH"),
+            env::var("HERDR_PANE_ID").ok(),
+        ) else {
+            return Self(None);
+        };
+        let sequence = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .saturating_mul(1_000)
+            .min(u128::from(u64::MAX)) as u64;
+        let mut reporter = ActiveReporter {
+            binary,
+            pane_id,
+            session_id: session_id.to_owned(),
+            sequence,
+        };
+        reporter.report(State::Idle);
+        Self(Some(reporter))
+    }
+
+    pub(crate) fn working(&mut self, session_id: Option<&str>) {
+        let Some(reporter) = &mut self.0 else {
+            return;
+        };
+        reporter.update_session(session_id);
+        reporter.report(State::Working);
+    }
+
+    pub(crate) fn idle(&mut self, session_id: Option<&str>) {
+        let Some(reporter) = &mut self.0 else {
+            return;
+        };
+        reporter.update_session(session_id);
+        reporter.report(State::Idle);
+    }
+}
+
+struct ActiveReporter {
+    binary: OsString,
+    pane_id: String,
+    session_id: String,
+    sequence: u64,
+}
+
+impl ActiveReporter {
+    fn update_session(&mut self, session_id: Option<&str>) {
+        if let Some(session_id) = session_id {
+            session_id.clone_into(&mut self.session_id);
+        }
+    }
+
+    fn report(&mut self, state: State) {
+        let sequence = self.next_sequence();
+        spawn(command(
+            &self.binary,
+            &self.pane_id,
+            Report::State {
+                state,
+                session_id: &self.session_id,
+            },
+            sequence,
+        ));
+    }
+
+    fn next_sequence(&mut self) -> u64 {
+        let sequence = self.sequence;
+        self.sequence = self.sequence.saturating_add(1);
+        sequence
+    }
+}
+
+impl Drop for ActiveReporter {
+    fn drop(&mut self) {
+        let sequence = self.next_sequence();
+        spawn(command(
+            &self.binary,
+            &self.pane_id,
+            Report::Release,
+            sequence,
+        ));
+    }
+}
+
+#[derive(Clone, Copy)]
+enum State {
+    Idle,
+    Working,
+}
+
+impl State {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Working => "working",
+        }
+    }
+}
+
+enum Report<'a> {
+    State { state: State, session_id: &'a str },
+    Release,
+}
+
+fn environment(
+    herdr_env: Option<String>,
+    binary: Option<OsString>,
+    pane_id: Option<String>,
+) -> Option<(OsString, String)> {
+    if herdr_env.as_deref() != Some("1") {
+        return None;
+    }
+    Some((
+        binary
+            .filter(|path| !path.is_empty())
+            .unwrap_or_else(|| "herdr".into()),
+        pane_id.filter(|pane_id| !pane_id.is_empty())?,
+    ))
+}
+
+fn command(binary: &OsStr, pane_id: &str, report: Report<'_>, sequence: u64) -> Command {
+    let mut command = Command::new(binary);
+    command.args(["pane"]);
+    match report {
+        Report::State { state, session_id } => {
+            command.args([
+                "report-agent",
+                pane_id,
+                "--source",
+                SOURCE,
+                "--agent",
+                AGENT,
+                "--state",
+                state.as_str(),
+                "--agent-session-id",
+                session_id,
+            ]);
+        }
+        Report::Release => {
+            command.args([
+                "release-agent",
+                pane_id,
+                "--source",
+                SOURCE,
+                "--agent",
+                AGENT,
+            ]);
+        }
+    }
+    command
+        .args(["--seq", &sequence.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+}
+
+fn spawn(mut command: Command) {
+    let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    let Ok(mut child) = command.spawn() else {
+        return;
+    };
+    runtime.spawn(async move {
+        drop(child.wait().await);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ActiveReporter, Report, State, command, environment};
+    use std::ffi::{OsStr, OsString};
+
+    #[test]
+    fn activates_only_inside_a_herdr_pane() {
+        assert_eq!(
+            environment(
+                Some("1".to_owned()),
+                Some("/opt/herdr".into()),
+                Some("w1:p1".to_owned()),
+            ),
+            Some(("/opt/herdr".into(), "w1:p1".to_owned()))
+        );
+        assert_eq!(
+            environment(None, Some("/opt/herdr".into()), Some("w1:p1".to_owned())),
+            None
+        );
+        assert_eq!(
+            environment(Some("1".to_owned()), None, Some("w1:p1".to_owned())),
+            Some(("herdr".into(), "w1:p1".to_owned()))
+        );
+        assert_eq!(
+            environment(Some("1".to_owned()), Some("/opt/herdr".into()), None),
+            None
+        );
+        assert_eq!(
+            environment(
+                Some("1".to_owned()),
+                Some(OsString::new()),
+                Some("w1:p1".to_owned()),
+            ),
+            Some(("herdr".into(), "w1:p1".to_owned()))
+        );
+        assert_eq!(
+            environment(
+                Some("1".to_owned()),
+                Some("/opt/herdr".into()),
+                Some(String::new()),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn reports_state_with_session_identity() {
+        let command = command(
+            OsStr::new("/opt/herdr"),
+            "w1:p1",
+            Report::State {
+                state: State::Working,
+                session_id: "session-1",
+            },
+            42,
+        );
+
+        assert_eq!(command.as_std().get_program(), "/opt/herdr");
+        assert_eq!(
+            command.as_std().get_args().collect::<Vec<_>>(),
+            [
+                "pane",
+                "report-agent",
+                "w1:p1",
+                "--source",
+                "herdr:tact",
+                "--agent",
+                "tact",
+                "--state",
+                "working",
+                "--agent-session-id",
+                "session-1",
+                "--seq",
+                "42",
+            ]
+            .map(OsString::from)
+        );
+    }
+
+    #[test]
+    fn releases_lifecycle_ownership() {
+        let command = command(OsStr::new("/opt/herdr"), "w1:p1", Report::Release, 43);
+
+        assert_eq!(command.as_std().get_program(), "/opt/herdr");
+        assert_eq!(
+            command.as_std().get_args().collect::<Vec<_>>(),
+            [
+                "pane",
+                "release-agent",
+                "w1:p1",
+                "--source",
+                "herdr:tact",
+                "--agent",
+                "tact",
+                "--seq",
+                "43",
+            ]
+            .map(OsString::from)
+        );
+    }
+
+    #[test]
+    fn refreshes_the_session_identity() {
+        let mut reporter = ActiveReporter {
+            binary: "/opt/herdr".into(),
+            pane_id: "w1:p1".to_owned(),
+            session_id: "old".to_owned(),
+            sequence: 1,
+        };
+
+        reporter.update_session(Some("new"));
+
+        assert_eq!(reporter.session_id, "new");
+    }
+}

--- a/bin/tact/src/app/mod.rs
+++ b/bin/tact/src/app/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod browser;
 mod cli;
 pub(crate) mod config;
 pub(crate) mod error;
+pub(crate) mod herdr;
 pub(crate) mod hook;
 pub(crate) mod installation;
 mod secret;

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     app::{
         config::{Config, ReasoningEffort, ReasoningMode},
         error::{Result, RuntimeError},
-        hook,
+        herdr, hook,
     },
     core::{ConfiguredAgent, extensions::Skill},
     tui::{
@@ -55,7 +55,7 @@ use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, 
 use futures_util::StreamExt;
 use nanocodex::Model;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io::{self, IsTerminal},
     path::{Path, PathBuf},
     sync::{
@@ -521,6 +521,7 @@ pub(crate) async fn run(
         subagent_control,
     } = configured;
     let main_session_id = agent.session_id().to_string();
+    let mut herdr = herdr::Reporter::from_env(&main_session_id);
     let (writer_sender, mut writer_updates) = mpsc::unbounded_channel();
     let mut panes = HashMap::new();
     panes.insert(
@@ -605,6 +606,7 @@ pub(crate) async fn run(
     let mut scheduler = RenderScheduler::new(STREAM_FRAME_INTERVAL, Instant::now());
     let mut stopping = false;
     let mut worker_stopped = false;
+    let mut herdr_turns = HashSet::new();
     let mut worker_error = None::<nanocodex::NanocodexError>;
     let mut writer_error = None::<TranscriptError>;
     let mut writers_open = 1_usize;
@@ -897,6 +899,13 @@ pub(crate) async fn run(
                         worker_error = error;
                     }
                     WorkerEvent::TurnAccepted { pane, id } => {
+                        if herdr_turns.insert((pane, id)) && herdr_turns.len() == 1 {
+                            let session_id = app
+                                .main_pane()
+                                .and_then(|pane| panes.get(&pane))
+                                .map(|runtime| runtime.session_id.as_str());
+                            herdr.working(session_id);
+                        }
                         let record = panes.get_mut(&pane).expect("worker pane must exist")
                             .journal_mut()?.append_local(LocalEvent::WorkerTurnAccepted { id })?;
                         schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
@@ -908,6 +917,13 @@ pub(crate) async fn run(
                         snapshot,
                         terminal_expected,
                     } => {
+                        if herdr_turns.remove(&(pane, id)) && herdr_turns.is_empty() {
+                            let session_id = app
+                                .main_pane()
+                                .and_then(|pane| panes.get(&pane))
+                                .map(|runtime| runtime.session_id.as_str());
+                            herdr.idle(session_id);
+                        }
                         let Some(runtime) = panes.get_mut(&pane) else {
                             continue;
                         };


### PR DESCRIPTION
## Summary

- report Tact lifecycle state when running in a Herdr pane
- include the active Tact session ID for native session restore
- invoke the inherited `HERDR_BIN_PATH` and release lifecycle ownership on exit

## Testing

- `cargo check --all-features`
- `just check-fmt`
- `just clippy`
- `just test`

Closes #157