### PR TITLE
subagent completion triggers turn

### DIFF
--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -2316,8 +2316,8 @@ impl RootNode {
         let completion = match &update {
             AgentUpdate::Status {
                 id,
-                status: AgentStatus::Completed { output },
-            } => Some((*id, output.clone())),
+                status: AgentStatus::Completed { .. },
+            } => Some(*id),
             _ => None,
         };
         let root_message = match &update {
@@ -2359,7 +2359,7 @@ impl RootNode {
         if subagents_changed {
             result.render = result.render.max(RenderRequest::Immediate);
         }
-        if let Some((id, output)) = completion
+        if let Some(id) = completion
             && subagents_changed
             && self.subagents.is_direct_child(id)
             && self.in_flight_turns == 0
@@ -2370,20 +2370,20 @@ impl RootNode {
             self.in_flight_turns = 1;
             result
                 .effects
-                .push(RootEffect::ContinueSubagent(subagent_completion_prompt(
-                    id, &output,
-                )));
+                .push(RootEffect::ContinueSubagent(subagent_completion_prompt(id)));
         }
         result
     }
 }
 
-fn subagent_completion_prompt(id: AgentId, output: &serde_json::Value) -> Submission {
+fn subagent_completion_prompt(id: AgentId) -> Submission {
     Submission::text(format!(
-        "A subagent completed after the previous turn ended. Continue the current task using its \
-         result. Integrate or verify it as appropriate, perform any remaining work, and then \
-         respond to the user. Do not merely repeat the raw result.\n\n\
-         <subagent_completion agent_id=\"{id}\">\n{output}\n</subagent_completion>"
+        "A subagent completed after the previous turn ended. Continue the current task by \
+         inspecting its structured result. In code mode, include completed agents when calling \
+         list_agents, find agent {id}, and expose only the result fields needed for the next step. \
+         Integrate or verify them as appropriate, perform any remaining work, and then respond to \
+         the user. Do not merely repeat the raw result.\n\n\
+         <subagent_completion agent_id=\"{id}\" />"
     ))
 }
 
@@ -3521,8 +3521,9 @@ mod tests {
         assert!(matches!(
             update.effects.as_slice(),
             [RootEffect::ContinueSubagent(prompt)]
-                if prompt.display_text().contains("queue is sound")
+                if prompt.display_text().contains("list_agents")
                     && prompt.display_text().contains("agent_id=\"1\"")
+                    && !prompt.display_text().contains("queue is sound")
         ));
         assert_eq!(root.in_flight_turns, 1);
     }

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -52,7 +52,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tact_memory::{MemoryAccess, MemoryKey, MemoryRecord, MemorySource};
-use tact_subagents::{AgentUpdate, MessageSender};
+use tact_subagents::{AgentId, AgentStatus, AgentUpdate, MessageSender};
 
 const KEY_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(2);
 const SELECTION_SCROLL_INTERVAL: Duration = Duration::from_millis(60);
@@ -231,6 +231,7 @@ pub(crate) enum RootEffect {
     Submit(Submission),
     Reflect(Submission),
     RunShell(String),
+    ContinueSubagent(Submission),
     OpenDraftEditor,
     OpenQueueEditor {
         id: QueueId,
@@ -2312,6 +2313,13 @@ impl RootNode {
 
     fn apply_subagent_update(&mut self, update: AgentUpdate) -> ComponentUpdate<RootEffect> {
         let previous_active = self.subagents.active_count();
+        let completion = match &update {
+            AgentUpdate::Status {
+                id,
+                status: AgentStatus::Completed { output },
+            } => Some((*id, output.clone())),
+            _ => None,
+        };
         let root_message = match &update {
             AgentUpdate::Message(update)
                 if update.thread.messages.iter().any(|message| {
@@ -2351,8 +2359,32 @@ impl RootNode {
         if subagents_changed {
             result.render = result.render.max(RenderRequest::Immediate);
         }
+        if let Some((id, output)) = completion
+            && subagents_changed
+            && self.subagents.is_direct_child(id)
+            && self.in_flight_turns == 0
+            && self.blocking_task.is_none()
+            && self.interactive
+        {
+            self.thread = ThreadState::Started;
+            self.in_flight_turns = 1;
+            result
+                .effects
+                .push(RootEffect::ContinueSubagent(subagent_completion_prompt(
+                    id, &output,
+                )));
+        }
         result
     }
+}
+
+fn subagent_completion_prompt(id: AgentId, output: &serde_json::Value) -> Submission {
+    Submission::text(format!(
+        "A subagent completed after the previous turn ended. Continue the current task using its \
+         result. Integrate or verify it as appropriate, perform any remaining work, and then \
+         respond to the user. Do not merely repeat the raw result.\n\n\
+         <subagent_completion agent_id=\"{id}\">\n{output}\n</subagent_completion>"
+    ))
 }
 
 impl Component for RootNode {
@@ -3463,6 +3495,87 @@ mod tests {
             .collect::<String>();
 
         assert!(!rendered.contains("subagents"));
+    }
+
+    #[test]
+    fn completed_direct_subagent_starts_a_continuation_when_idle() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(super::RootEvent::Subagent(AgentUpdate::Added(
+            AgentDescriptor {
+                id: AgentId::new(1),
+                session_id: "child".to_owned(),
+                model: Model::Sol,
+                role: "worker".to_owned(),
+                task: "inspect the queue".to_owned(),
+                parent: None,
+            },
+        )));
+
+        let update = root.update(super::RootEvent::Subagent(AgentUpdate::Status {
+            id: AgentId::new(1),
+            status: AgentStatus::Completed {
+                output: json!({ "report": "queue is sound" }),
+            },
+        }));
+
+        assert!(matches!(
+            update.effects.as_slice(),
+            [RootEffect::ContinueSubagent(prompt)]
+                if prompt.display_text().contains("queue is sound")
+                    && prompt.display_text().contains("agent_id=\"1\"")
+        ));
+        assert_eq!(root.in_flight_turns, 1);
+    }
+
+    #[test]
+    fn completed_subagent_does_not_start_a_competing_active_turn() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.in_flight_turns = 1;
+        root.update(super::RootEvent::Subagent(AgentUpdate::Added(
+            AgentDescriptor {
+                id: AgentId::new(1),
+                session_id: "child".to_owned(),
+                model: Model::Sol,
+                role: "worker".to_owned(),
+                task: "inspect the queue".to_owned(),
+                parent: None,
+            },
+        )));
+
+        let update = root.update(super::RootEvent::Subagent(AgentUpdate::Status {
+            id: AgentId::new(1),
+            status: AgentStatus::Completed {
+                output: json!({ "report": "queue is sound" }),
+            },
+        }));
+
+        assert!(update.effects.is_empty());
+        assert_eq!(root.in_flight_turns, 1);
+    }
+
+    #[test]
+    fn completed_nested_subagent_does_not_bypass_its_parent() {
+        let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.update(super::RootEvent::Subagent(AgentUpdate::Added(
+            AgentDescriptor {
+                id: AgentId::new(2),
+                session_id: "grandchild".to_owned(),
+                model: Model::Sol,
+                role: "worker".to_owned(),
+                task: "inspect the queue".to_owned(),
+                parent: Some(AgentId::new(1)),
+            },
+        )));
+
+        let update = root.update(super::RootEvent::Subagent(AgentUpdate::Status {
+            id: AgentId::new(2),
+            status: AgentStatus::Completed {
+                output: json!({ "report": "queue is sound" }),
+            },
+        }));
+
+        assert!(update.effects.is_empty());
+        assert_eq!(root.in_flight_turns, 0);
     }
 
     #[test]

--- a/bin/tact/src/tui/components/subagents.rs
+++ b/bin/tact/src/tui/components/subagents.rs
@@ -167,6 +167,9 @@ impl SubagentTree {
                 let Some(node) = self.node_mut(id) else {
                     return false;
                 };
+                if node.status == status {
+                    return false;
+                }
                 node.status = status;
                 true
             }
@@ -219,6 +222,11 @@ impl SubagentTree {
 
     pub(super) fn contains(&self, id: AgentId) -> bool {
         self.nodes.iter().any(|node| node.descriptor.id == id)
+    }
+
+    pub(super) fn is_direct_child(&self, id: AgentId) -> bool {
+        self.node(id)
+            .is_some_and(|node| node.descriptor.parent.is_none())
     }
 
     pub(super) fn animation_deadline(&self) -> Option<Instant> {

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -802,13 +802,10 @@ pub(crate) async fn run(
             }
             Some(event) = subagent_events.recv(), if !stopping => {
                 if let Some(pane) = subagent_pane(&panes, &event) {
-                    schedule(
-                        app.update(AppEvent::Subagent {
-                            pane,
-                            update: event.update,
-                        }),
-                        &mut scheduler,
-                    );
+                    apply_app_update!(app.update(AppEvent::Subagent {
+                        pane,
+                        update: event.update,
+                    }));
                 }
             }
             Some(ready) = review_ready_updates.recv(), if !stopping => {
@@ -1937,6 +1934,26 @@ fn apply_pane_effect(
                 context.app.update(AppEvent::Transcript { pane, record }),
                 context.scheduler,
             );
+            let submission = PendingSubmission { id, prompt };
+            if runtime.active_shells == 0 {
+                send_submission(
+                    context.commands,
+                    pane,
+                    &mut runtime.pending_shell_context,
+                    submission,
+                )?;
+            } else {
+                debug_assert!(runtime.pending_submission.is_none());
+                runtime.pending_submission = Some(submission);
+            }
+        }
+        components::RootEffect::ContinueSubagent(prompt) => {
+            let runtime = context
+                .panes
+                .get_mut(&pane)
+                .expect("UI pane must have a runtime");
+            let id = TurnId::new(runtime.next_turn);
+            runtime.next_turn = runtime.next_turn.saturating_add(1);
             let submission = PendingSubmission { id, prompt };
             if runtime.active_shells == 0 {
                 send_submission(


### PR DESCRIPTION
Currently, if no turn is active, subagents complete silently. The user must ask the main agent to check on them, starting a new turn and collecting the results. With this PR, a subagent completion triggers the start of a turn.

I can test this situation reliably with the prompt: `start a subagent that waits 5 seconds`