### PR TITLE
feat(tui): clarify keyboard help

### DIFF
--- a/bin/tact/src/app/update.rs
+++ b/bin/tact/src/app/update.rs
@@ -843,7 +843,7 @@ fn parse_hex_checksum(value: &str) -> Option<[u8; 32]> {
         return None;
     }
     let mut output = [0_u8; 32];
-    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+    for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         let pair = std::str::from_utf8(pair).ok()?;
         output[index] = u8::from_str_radix(pair, 16).ok()?;
     }

--- a/bin/tact/src/review/assets.rs
+++ b/bin/tact/src/review/assets.rs
@@ -372,7 +372,7 @@ fn parse_sha256(path: &str, value: &str) -> Result<[u8; 32], AssetError> {
         return Err(AssetError::AssetChecksum(PathBuf::from(path)));
     }
     let mut checksum = [0_u8; 32];
-    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+    for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         let pair = std::str::from_utf8(pair)
             .map_err(|_| AssetError::AssetChecksum(PathBuf::from(path)))?;
         checksum[index] = u8::from_str_radix(pair, 16)

--- a/bin/tact/src/tui/components/actions.rs
+++ b/bin/tact/src/tui/components/actions.rs
@@ -34,7 +34,7 @@ const ACTIONS: [Action; 16] = [
     Action::Review,
     Action::Model,
 ];
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab open", "esc close"];
+const KEY_BINDINGS: [(&str, &str); 3] = [("↑↓", "move"), ("enter/tab", "open"), ("esc", "close")];
 const SEARCH_LABEL: &str = "Search: ";
 const SELECTION_MARKER: &str = "› ";
 
@@ -423,7 +423,7 @@ mod tests {
     use super::{Action, ActionAvailability, ActionsEffect, ActionsEvent, ActionsMenu, Component};
     use crate::tui::theme::Theme;
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-    use ratatui::{Terminal, backend::TestBackend};
+    use ratatui::{Terminal, backend::TestBackend, style::Color};
 
     fn key(code: KeyCode) -> ActionsEvent {
         ActionsEvent::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
@@ -537,6 +537,11 @@ mod tests {
         );
         assert_eq!(
             terminal.backend().buffer()[(18, 2)].fg,
+            Theme::default().muted()
+        );
+        assert_eq!(terminal.backend().buffer()[(12, 17)].fg, Color::Reset);
+        assert_eq!(
+            terminal.backend().buffer()[(15, 17)].fg,
             Theme::default().muted()
         );
     }

--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -1362,8 +1362,8 @@ impl Composer {
         let development_start =
             directory_start.saturating_sub(u16::try_from(development_width).unwrap_or(u16::MAX));
         let hint_space = usize::from(development_start.saturating_sub(content_start));
-        let entry_hint = entry_hint(theme);
-        if self.draft.is_empty() && entry_hint.width() <= hint_space {
+        let entry_hint = entry_hint(theme, self.draft.is_empty());
+        if entry_hint.width() <= hint_space {
             buffer.set_line(
                 content_start,
                 bottom,
@@ -1411,16 +1411,21 @@ impl Composer {
     }
 }
 
-fn entry_hint(theme: &Theme) -> Line<'static> {
-    Line::from(vec![
-        Span::raw(" "),
-        Span::styled("/", Style::reset()),
-        Span::styled(" actions · ", Style::default().fg(theme.muted())),
+fn entry_hint(theme: &Theme, include_actions: bool) -> Line<'static> {
+    let mut spans = vec![Span::raw(" ")];
+    if include_actions {
+        spans.extend([
+            Span::styled("/", Style::reset()),
+            Span::styled(" actions · ", Style::default().fg(theme.muted())),
+        ]);
+    }
+    spans.extend([
         Span::styled("@", Style::reset()),
         Span::styled(" paths · ", Style::default().fg(theme.muted())),
         Span::styled("@@", Style::reset()),
         Span::styled(" sessions ", Style::default().fg(theme.muted())),
-    ])
+    ]);
+    Line::from(spans)
 }
 
 impl Component for Composer {
@@ -1845,12 +1850,14 @@ mod tests {
     }
 
     #[test]
-    fn entry_hint_is_only_shown_for_an_empty_draft_with_room() {
+    fn entry_hint_keeps_file_and_session_shortcuts_visible_while_typing() {
         let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
         assert!(rows(&render(&mut composer, 60, 5))[4].contains("@@ sessions"));
 
         composer.replace_draft("hello".to_owned());
-        assert!(!rows(&render(&mut composer, 40, 5))[4].contains("/ actions"));
+        let footer = &rows(&render(&mut composer, 60, 5))[4];
+        assert!(!footer.contains("/ actions"));
+        assert!(footer.contains("@ paths · @@ sessions"));
 
         composer.replace_draft(String::new());
         assert!(!rows(&render(&mut composer, 20, 5))[4].contains("/ actions"));

--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -29,6 +29,7 @@ use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
     style::{Color, Modifier, Style},
+    text::{Line, Span},
 };
 use std::{
     collections::VecDeque,
@@ -42,7 +43,6 @@ use unicode_width::UnicodeWidthStr;
 
 const MIN_CONTENT_ROWS: usize = 3;
 const MAX_CONTENT_ROWS: usize = 6;
-const ENTRY_HINT: &str = " / actions · @ paths · @@ sessions ";
 const DEVELOPMENT_BADGE: &str = " ◉ dev ";
 
 #[derive(Debug, Eq, PartialEq)]
@@ -1362,15 +1362,13 @@ impl Composer {
         let development_start =
             directory_start.saturating_sub(u16::try_from(development_width).unwrap_or(u16::MAX));
         let hint_space = usize::from(development_start.saturating_sub(content_start));
-        if self.draft.is_empty() && ENTRY_HINT.width() <= hint_space {
-            buffer.set_stringn(
+        let entry_hint = entry_hint(theme);
+        if self.draft.is_empty() && entry_hint.width() <= hint_space {
+            buffer.set_line(
                 content_start,
                 bottom,
-                ENTRY_HINT,
-                hint_space,
-                Style::default()
-                    .fg(theme.muted())
-                    .add_modifier(Modifier::DIM),
+                &entry_hint,
+                u16::try_from(hint_space).unwrap_or(u16::MAX),
             );
         }
         if shell_mode {
@@ -1411,6 +1409,18 @@ impl Composer {
             theme.border()
         })
     }
+}
+
+fn entry_hint(theme: &Theme) -> Line<'static> {
+    Line::from(vec![
+        Span::raw(" "),
+        Span::styled("/", Style::reset()),
+        Span::styled(" actions · ", Style::default().fg(theme.muted())),
+        Span::styled("@", Style::reset()),
+        Span::styled(" paths · ", Style::default().fg(theme.muted())),
+        Span::styled("@@", Style::reset()),
+        Span::styled(" sessions ", Style::default().fg(theme.muted())),
+    ])
 }
 
 impl Component for Composer {
@@ -1573,6 +1583,7 @@ mod tests {
         path::Path,
         time::{Duration, Instant},
     };
+    use unicode_width::UnicodeWidthStr;
 
     fn key(code: KeyCode, modifiers: KeyModifiers) -> ComposerEvent {
         ComposerEvent::Terminal(Event::Key(KeyEvent::new(code, modifiers)))
@@ -1638,6 +1649,14 @@ mod tests {
                 footer,
             ]
         );
+
+        let buffer = terminal.backend().buffer();
+        let footer = &rows(&terminal)[4];
+        let action_key =
+            u16::try_from(footer[..footer.find("/ actions").unwrap()].width()).unwrap();
+        let action_help = action_key + 2;
+        assert_eq!(buffer[(action_key, 4)].fg, Color::Reset);
+        assert_eq!(buffer[(action_help, 4)].fg, Theme::default().muted());
     }
 
     #[test]

--- a/bin/tact/src/tui/components/context_diagnostics.rs
+++ b/bin/tact/src/tui/components/context_diagnostics.rs
@@ -18,7 +18,7 @@ use ratatui::{
     widgets::{Paragraph, Wrap},
 };
 
-const FOOTER: [&str; 2] = ["r refresh", "esc close"];
+const FOOTER: [(&str, &str); 2] = [("r", "refresh"), ("esc", "close")];
 
 pub(super) enum ContextDiagnosticsEvent {
     Terminal(Event),

--- a/bin/tact/src/tui/components/effort.rs
+++ b/bin/tact/src/tui/components/effort.rs
@@ -26,7 +26,12 @@ const ANIMATION_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 const DIAL_WIDTH: u16 = 17;
 const DIAL_HEIGHT: u16 = 9;
 const DIAL_SAMPLES: usize = 96;
-const KEY_BINDINGS: [&str; 4] = ["←/→ effort", "p pro", "enter apply", "esc cancel"];
+const KEY_BINDINGS: [(&str, &str); 4] = [
+    ("←/→", "effort"),
+    ("p", "pro"),
+    ("enter", "apply"),
+    ("esc", "cancel"),
+];
 const FILLER_DOT: &str = "•";
 const THICK_DOT: &str = "●";
 

--- a/bin/tact/src/tui/components/file_finder.rs
+++ b/bin/tact/src/tui/components/file_finder.rs
@@ -17,7 +17,7 @@ use std::{cmp::Reverse, fs, path::Path};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab insert", "esc close"];
+const KEY_BINDINGS: [(&str, &str); 3] = [("↑↓", "move"), ("enter/tab", "insert"), ("esc", "close")];
 const SEARCH_LABEL: &str = "Search: ";
 const FOCUS_MARKER: &str = "› ";
 const SKIPPED_DIRECTORIES: [&str; 4] = [".git", ".jj", "node_modules", "target"];

--- a/bin/tact/src/tui/components/floating.rs
+++ b/bin/tact/src/tui/components/floating.rs
@@ -12,11 +12,13 @@ use unicode_width::UnicodeWidthStr;
 
 const KEY_BINDING_SEPARATOR: &str = " · ";
 
+pub(super) type KeyBinding = (&'static str, &'static str);
+
 pub(super) struct Floating<'a> {
     title: &'a str,
     width: u16,
     height: u16,
-    key_bindings: &'a [&'a str],
+    key_bindings: &'a [KeyBinding],
     placement: Placement,
     border_color: Option<Color>,
     title_color: Option<Color>,
@@ -38,7 +40,7 @@ impl<'a> Floating<'a> {
         title: &'a str,
         width: u16,
         height: u16,
-        key_bindings: &'a [&'a str],
+        key_bindings: &'a [KeyBinding],
     ) -> Self {
         Self {
             title,
@@ -87,21 +89,19 @@ impl<'a> Floating<'a> {
         frame.render_widget(Clear, popup);
         frame.render_widget(block, popup);
 
-        let key_bindings = self.key_binding_lines(inner.width);
+        let key_bindings = self.key_binding_lines(inner.width, theme);
         let footer_height = u16::try_from(key_bindings.len()).unwrap_or(u16::MAX);
         let (body, footer) = split_footer(inner, footer_height);
         if !footer.is_empty() {
             frame.render_widget(
-                Paragraph::new(key_bindings)
-                    .style(Style::default().fg(theme.border()))
-                    .alignment(Alignment::Center),
+                Paragraph::new(key_bindings).alignment(Alignment::Center),
                 footer,
             );
         }
         FloatingLayout { body }
     }
 
-    fn key_binding_lines(&self, width: u16) -> Vec<Line<'a>> {
+    fn key_binding_lines(&self, width: u16, theme: &Theme) -> Vec<Line<'a>> {
         if width == 0 {
             return Vec::new();
         }
@@ -111,17 +111,33 @@ impl<'a> Floating<'a> {
         let mut lines = Vec::new();
         let mut spans = Vec::new();
         let mut line_width = 0;
-        for key_binding in self.key_bindings {
-            let key_binding_width = key_binding.width();
+        for &(key, help) in self.key_bindings {
+            let key_binding_width =
+                key.width() + usize::from(!key.is_empty() && !help.is_empty()) + help.width();
             if !spans.is_empty() && line_width + separator_width + key_binding_width > width {
                 lines.push(Line::from(std::mem::take(&mut spans)));
                 line_width = 0;
             }
             if !spans.is_empty() {
-                spans.push(Span::raw(KEY_BINDING_SEPARATOR));
+                spans.push(Span::styled(
+                    KEY_BINDING_SEPARATOR,
+                    Style::default().fg(theme.muted()),
+                ));
                 line_width += separator_width;
             }
-            spans.push(Span::raw(*key_binding));
+            if !key.is_empty() {
+                spans.push(Span::styled(key, Style::reset()));
+            }
+            if !help.is_empty() {
+                spans.push(Span::styled(
+                    if key.is_empty() {
+                        help.to_owned()
+                    } else {
+                        format!(" {help}")
+                    },
+                    Style::default().fg(theme.muted()),
+                ));
+            }
             line_width += key_binding_width;
         }
         if !spans.is_empty() {
@@ -176,12 +192,12 @@ mod tests {
     use ratatui::{Terminal, backend::TestBackend, layout::Rect, style::Color};
 
     #[test]
-    fn floating_centers_rounded_chrome_and_border_colored_key_bindings() {
+    fn floating_centers_rounded_chrome_and_styles_keys_separately_from_help() {
         let mut terminal = Terminal::new(TestBackend::new(20, 8)).unwrap();
 
         terminal
             .draw(|frame| {
-                Floating::new("Test", 16, 6, &["left", "right"]).render(
+                Floating::new("Test", 16, 6, &[("left", "help")]).render(
                     frame,
                     frame.area(),
                     &Theme::default(),
@@ -192,9 +208,12 @@ mod tests {
         let buffer = terminal.backend().buffer();
         assert_eq!(buffer[(2, 1)].symbol(), "╭");
         assert_eq!(buffer[(17, 6)].symbol(), "╯");
-        assert_eq!(buffer[(4, 5)].symbol(), "l");
-        assert_eq!(buffer[(9, 5)].symbol(), "·");
-        assert_eq!(buffer[(9, 5)].fg, Color::DarkGray);
+        let row = 5;
+        let start = (0..20)
+            .find(|&column| buffer[(column, row)].symbol() == "l")
+            .unwrap();
+        assert_eq!(buffer[(start, row)].fg, Color::Reset);
+        assert_eq!(buffer[(start + 5, row)].fg, Theme::default().muted());
     }
 
     #[test]
@@ -208,7 +227,11 @@ mod tests {
                     "Test",
                     24,
                     8,
-                    &["first option", "second option", "third option"],
+                    &[
+                        ("first", "option"),
+                        ("second", "option"),
+                        ("third", "option"),
+                    ],
                 )
                 .render(frame, frame.area(), &Theme::default())
                 .body;

--- a/bin/tact/src/tui/components/keybindings.rs
+++ b/bin/tact/src/tui/components/keybindings.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 const FOOTER: [&str; 2] = ["↑↓ scroll", "esc close"];
-const BINDINGS: [(&str, &str); 25] = [
+const BINDINGS: [(&str, &str); 26] = [
     ("ctrl+s", "change reasoning effort"),
     ("ctrl+d", "select model · before first prompt"),
     ("ctrl+t", "fork session · when available"),
@@ -32,6 +32,7 @@ const BINDINGS: [(&str, &str); 25] = [
     ("ctrl+c ctrl+c", "split closes pane · else exit"),
     ("esc esc", "interrupt the active response"),
     ("enter", "submit prompt"),
+    ("enter + enter", "submit prompt and steer"),
     ("shift+enter/ctrl+j", "insert newline"),
     ("ctrl+a/e", "move to line start · end"),
     ("ctrl+b/f", "move to previous · next character"),
@@ -198,6 +199,8 @@ mod tests {
             "ctrl+c ctrl+c",
             "clear input · when composer is focused and nonempty",
             "split closes pane · else exit",
+            "enter + enter",
+            "submit prompt and steer",
             "shift+enter/ctrl+j",
             "ctrl+a/e",
             "move to line start · end",

--- a/bin/tact/src/tui/components/keybindings.rs
+++ b/bin/tact/src/tui/components/keybindings.rs
@@ -9,13 +9,13 @@ use crossterm::event::{Event, KeyCode, KeyEventKind};
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
 };
 use unicode_width::UnicodeWidthStr;
 
-const FOOTER: [&str; 2] = ["↑↓ scroll", "esc close"];
+const FOOTER: [(&str, &str); 2] = [("↑↓", "scroll"), ("esc", "close")];
 const BINDINGS: [(&str, &str); 26] = [
     ("ctrl+s", "change reasoning effort"),
     ("ctrl+d", "select model · before first prompt"),
@@ -123,7 +123,7 @@ fn binding_line(
         Span::styled(
             format!(" {key}"),
             Style::default()
-                .fg(Color::Green)
+                .fg(theme.accent())
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" ".repeat(gap)),
@@ -167,7 +167,10 @@ mod tests {
                 + unicode_width::UnicodeWidthStr::width(description);
             assert_eq!(end, 75);
         }
-        assert_eq!(buffer[(5, u16::try_from(row).unwrap())].fg, Color::Green);
+        assert_eq!(
+            buffer[(5, u16::try_from(row).unwrap())].fg,
+            Theme::default().accent()
+        );
         assert_eq!(
             buffer[(74, u16::try_from(row).unwrap())].fg,
             Color::DarkGray

--- a/bin/tact/src/tui/components/memory.rs
+++ b/bin/tact/src/tui/components/memory.rs
@@ -19,33 +19,48 @@ use tact_memory::{MemoryAccess, MemoryKey, MemoryRecord, MemorySource, RemoteRol
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const LIST_KEYS: [&str; 5] = [
-    "↑↓ move",
-    "enter inspect",
-    "ctrl+s sort",
-    "ctrl+d remove",
-    "ctrl+r refresh · esc close",
+const LIST_KEYS: [(&str, &str); 6] = [
+    ("↑↓", "move"),
+    ("enter", "inspect"),
+    ("ctrl+s", "sort"),
+    ("ctrl+d", "remove"),
+    ("ctrl+r", "refresh"),
+    ("esc", "close"),
 ];
-const REMOTE_LIST_KEYS: [&str; 4] = [
-    "↑↓ move",
-    "enter inspect",
-    "ctrl+s sort · ctrl+n namespaces",
-    "ctrl+r refresh · esc close",
+const REMOTE_LIST_KEYS: [(&str, &str); 6] = [
+    ("↑↓", "move"),
+    ("enter", "inspect"),
+    ("ctrl+s", "sort"),
+    ("ctrl+n", "namespaces"),
+    ("ctrl+r", "refresh"),
+    ("esc", "close"),
 ];
-const REMOTE_WRITABLE_LIST_KEYS: [&str; 5] = [
-    "↑↓ move",
-    "enter inspect",
-    "ctrl+s sort · ctrl+n namespaces",
-    "ctrl+d remove",
-    "ctrl+r refresh · esc close",
+const REMOTE_WRITABLE_LIST_KEYS: [(&str, &str); 7] = [
+    ("↑↓", "move"),
+    ("enter", "inspect"),
+    ("ctrl+s", "sort"),
+    ("ctrl+n", "namespaces"),
+    ("ctrl+d", "remove"),
+    ("ctrl+r", "refresh"),
+    ("esc", "close"),
 ];
-const DETAIL_KEYS: [&str; 3] = ["↑↓/pgup/pgdn scroll", "d delete", "r refresh · esc back"];
-const REMOTE_DETAIL_KEYS: [&str; 2] = ["↑↓/pgup/pgdn scroll", "r refresh · esc back"];
-const CONFIRM_KEYS: [&str; 2] = ["d/delete confirm", "esc cancel"];
-const DELETING_KEYS: [&str; 1] = ["deleting…"];
-const LOAD_ERROR_KEYS: [&str; 2] = ["r retry", "esc close"];
-const DELETE_ERROR_KEYS: [&str; 3] = ["d/delete retry", "r refresh", "esc back"];
-const LOADING_KEYS: [&str; 2] = ["r retry", "esc close"];
+const DETAIL_KEYS: [(&str, &str); 4] = [
+    ("↑↓/pgup/pgdn", "scroll"),
+    ("d", "delete"),
+    ("r", "refresh"),
+    ("esc", "back"),
+];
+const REMOTE_DETAIL_KEYS: [(&str, &str); 3] = [
+    ("↑↓/pgup/pgdn", "scroll"),
+    ("r", "refresh"),
+    ("esc", "back"),
+];
+const CONFIRM_KEYS: [(&str, &str); 2] = [("d/delete", "confirm"), ("esc", "cancel")];
+const DELETING_KEYS: [(&str, &str); 1] = [("", "deleting…")];
+const LOAD_ERROR_KEYS: [(&str, &str); 2] = [("r", "retry"), ("esc", "close")];
+const DELETE_ERROR_KEYS: [(&str, &str); 3] =
+    [("d/delete", "retry"), ("r", "refresh"), ("esc", "back")];
+const LOADING_KEYS: [(&str, &str); 2] = [("r", "retry"), ("esc", "close")];
 const FILTER_LABEL: &str = " Filter: ";
 const MAX_PREVIEW_GRAPHEMES: usize = 160;
 const MAX_ERROR_WIDTH: usize = 240;
@@ -571,7 +586,7 @@ impl MemoryBrowser {
         }
     }
 
-    fn footer(&self) -> &'static [&'static str] {
+    fn footer(&self) -> &'static [(&'static str, &'static str)] {
         match &self.state {
             BrowserState::Loading => &LOADING_KEYS,
             BrowserState::Error(error) => match error.action {

--- a/bin/tact/src/tui/components/model_selector.rs
+++ b/bin/tact/src/tui/components/model_selector.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 const MODELS: [Model; 3] = [Model::Luna, Model::Terra, Model::Sol];
 const ANIMATION_DURATION: Duration = Duration::from_millis(280);
 const ANIMATION_FRAME_INTERVAL: Duration = Duration::from_millis(16);
-const KEY_BINDINGS: [&str; 3] = ["←/→ model", "enter apply", "esc cancel"];
+const KEY_BINDINGS: [(&str, &str); 3] = [("←/→", "model"), ("enter", "apply"), ("esc", "cancel")];
 
 pub(super) enum ModelSelectorEvent {
     Terminal { event: Event, now: Instant },

--- a/bin/tact/src/tui/components/queue.rs
+++ b/bin/tact/src/tui/components/queue.rs
@@ -467,7 +467,7 @@ impl Component for MessageQueue {
             spans.push(Span::styled(" ", Style::default().fg(border)));
             Line::from(spans)
         } else {
-            Line::styled(" queue ", Style::default().fg(border))
+            Line::styled(" queue · enter steer latest ", Style::default().fg(border))
         };
         let mut block = Block::new()
             .borders(Borders::ALL)
@@ -640,6 +640,16 @@ mod tests {
             [QueueEffect::Steer { prompt: submission, .. }]
                 if submission.display_text() == prompt
         ));
+    }
+
+    #[test]
+    fn queue_title_explains_how_to_steer_the_latest_message() {
+        let mut queue = MessageQueue::default();
+        queue.push("queued".to_owned());
+
+        let rows = rendered_rows(&mut queue, 100, 3);
+
+        assert!(rows[0].contains(" queue · enter steer latest "));
     }
 
     #[test]

--- a/bin/tact/src/tui/components/recent_prompt_picker.rs
+++ b/bin/tact/src/tui/components/recent_prompt_picker.rs
@@ -18,13 +18,13 @@ use std::cmp::Reverse;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const KEY_BINDINGS: [&str; 6] = [
-    "type search",
-    "↑↓ move",
-    "pgup/pgdn preview",
-    "enter/tab select",
-    "ctrl+f scope",
-    "esc close",
+const KEY_BINDINGS: [(&str, &str); 6] = [
+    ("type", "search"),
+    ("↑↓", "move"),
+    ("pgup/pgdn", "preview"),
+    ("enter/tab", "select"),
+    ("ctrl+f", "scope"),
+    ("esc", "close"),
 ];
 const LIST_HEIGHT: u16 = 7;
 const SEARCH_LABEL: &str = "Search: ";

--- a/bin/tact/src/tui/components/review_confirmation.rs
+++ b/bin/tact/src/tui/components/review_confirmation.rs
@@ -12,7 +12,7 @@ use ratatui::{
     widgets::{Paragraph, Wrap},
 };
 
-const KEY_BINDINGS: [&str; 2] = ["enter/y download", "esc/n cancel"];
+const KEY_BINDINGS: [(&str, &str); 2] = [("enter/y", "download"), ("esc/n", "cancel")];
 
 pub(super) enum ReviewConfirmationEvent {
     Terminal(Event),

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -2822,9 +2822,7 @@ fn render_key_confirmation(
     let title = Line::from(vec![
         Span::styled(
             format!(" {} ", action.title_key()),
-            Style::default()
-                .fg(theme.accent())
-                .add_modifier(Modifier::BOLD),
+            Style::reset().add_modifier(Modifier::BOLD),
         ),
         Span::styled("then ", Style::default().fg(theme.muted())),
     ]);
@@ -2857,12 +2855,7 @@ fn render_key_confirmation(
 fn confirmation_line(key: &'static str, label: &'static str, theme: &Theme) -> Line<'static> {
     Line::from(vec![
         Span::raw(" "),
-        Span::styled(
-            key,
-            Style::default()
-                .fg(theme.code_text())
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(key, Style::reset().add_modifier(Modifier::BOLD)),
         Span::styled(format!(" {label}"), Style::default().fg(theme.muted())),
     ])
 }

--- a/bin/tact/src/tui/components/session_picker.rs
+++ b/bin/tact/src/tui/components/session_picker.rs
@@ -19,8 +19,10 @@ use ratatui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const RESUME_KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab resume", "esc close"];
-const MENTION_KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab insert", "esc close"];
+const RESUME_KEY_BINDINGS: [(&str, &str); 3] =
+    [("↑↓", "move"), ("enter/tab", "resume"), ("esc", "close")];
+const MENTION_KEY_BINDINGS: [(&str, &str); 3] =
+    [("↑↓", "move"), ("enter/tab", "insert"), ("esc", "close")];
 const SEARCH_LABEL: &str = "Search: ";
 
 pub(super) enum SessionPickerEvent {

--- a/bin/tact/src/tui/components/skill_picker.rs
+++ b/bin/tact/src/tui/components/skill_picker.rs
@@ -17,7 +17,7 @@ use ratatui::{
 use std::{cmp::Reverse, sync::Arc};
 use unicode_width::UnicodeWidthStr;
 
-const KEY_BINDINGS: [&str; 3] = ["↑↓ move", "enter/tab insert", "esc close"];
+const KEY_BINDINGS: [(&str, &str); 3] = [("↑↓", "move"), ("enter/tab", "insert"), ("esc", "close")];
 const SEARCH_LABEL: &str = "Search: ";
 const FOCUS_MARKER: &str = "› ";
 

--- a/bin/tact/src/tui/components/subagents.rs
+++ b/bin/tact/src/tui/components/subagents.rs
@@ -30,22 +30,26 @@ use tact_subagents::{AgentDescriptor, AgentId, AgentStatus, AgentUpdate, Message
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-const TREE_KEYS: [&str; 7] = [
-    "←/→ row",
-    "↑ parent",
-    "↓ child",
-    "enter inspect",
-    "-/+ limit",
-    "f filter",
-    "esc close",
+const TREE_KEYS: [(&str, &str); 7] = [
+    ("←/→", "row"),
+    ("↑", "parent"),
+    ("↓", "child"),
+    ("enter", "inspect"),
+    ("-/+", "limit"),
+    ("f", "filter"),
+    ("esc", "close"),
 ];
-const TRANSCRIPT_KEYS: [&str; 4] = [
-    "pgup/pgdn scroll",
-    "ctrl+home/end",
-    "ctrl+o expand all",
-    "esc back",
+const TRANSCRIPT_KEYS: [(&str, &str); 4] = [
+    ("pgup/pgdn", "scroll"),
+    ("ctrl+home/end", ""),
+    ("ctrl+o", "expand all"),
+    ("esc", "back"),
 ];
-const FOCUSED_ENTRY_KEYS: [&str; 3] = ["↑↓ item", "enter toggle", "esc blur, then back"];
+const FOCUSED_ENTRY_KEYS: [(&str, &str); 3] = [
+    ("↑↓", "item"),
+    ("enter", "toggle"),
+    ("esc", "blur, then back"),
+];
 const CAMERA_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 const CAMERA_MIN_DURATION: Duration = Duration::from_millis(120);
 const CAMERA_MAX_DURATION: Duration = Duration::from_millis(240);
@@ -436,7 +440,7 @@ impl SubagentTree {
             model_name(node.descriptor.model),
             node.descriptor.id
         );
-        let keys: &[&str] = if node.transcript.component().expandables_focused() {
+        let keys: &[(&str, &str)] = if node.transcript.component().expandables_focused() {
             &FOCUSED_ENTRY_KEYS
         } else {
             &TRANSCRIPT_KEYS

--- a/bin/tact/src/tui/components/theme_selector.rs
+++ b/bin/tact/src/tui/components/theme_selector.rs
@@ -14,7 +14,7 @@ use ratatui::{
     widgets::{List, ListItem, ListState},
 };
 
-const KEY_BINDINGS: [&str; 3] = ["↑↓ change", "enter apply", "esc cancel"];
+const KEY_BINDINGS: [(&str, &str); 3] = [("↑↓", "change"), ("enter", "apply"), ("esc", "cancel")];
 
 pub(super) enum ThemeSelectorEvent {
     Terminal(Event),


### PR DESCRIPTION
## Overview

Clarifies how to steer the latest queued message and makes keyboard help easier to scan.

## Changes

- Add queue and keyboard-reference hints for steering after prompt submission.
- Keep `@` file and `@@` session insertion guidance visible while typing.
- Render shortcut keys in the default color and their descriptions in muted text across modal and composer help.
- Use the theme accent for keys in the keyboard-shortcuts popup.

## Validation

- `cargo test -p tact --bin tact`
- `just fmt`