### PR TITLE
chore(release): prepare 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "arboard",
  "axum",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "tact-memory"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "axum",
  "const_format",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "tact-memory-cloudflare"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "axum",
  "rusqlite",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "tact-subagents"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "futures-util",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["bin/tact", "crates/*", "examples/tact-memory-cloudflare"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 rust-version = "1.97.0"
 authors = ["Ben Clabby"]
@@ -56,8 +56,8 @@ sha2 = "0.10.9"
 shlex = "2.0.1"
 syntect = { version = "5.3.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
 tar = "0.4.44"
-tact-memory = { version = "0.6.5", path = "crates/memory", default-features = false }
-tact-subagents = { version = "0.6.5", path = "crates/subagents" }
+tact-memory = { version = "0.6.6", path = "crates/memory", default-features = false }
+tact-subagents = { version = "0.6.6", path = "crates/subagents" }
 tempfile = "3.27.0"
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }


### PR DESCRIPTION
## Summary

- bump every workspace crate from 0.6.5 to 0.6.6
- update internal workspace dependency versions
- refresh the workspace lockfile

## Testing

- just check-fmt
- just clippy
- just test (946 tests)

## Stack

1. #179 — Markdown image-link prompting
2. #182 — nonblocking native image rendering
3. This PR

Depends on #182. No matching open issue exists to close.
