### PR TITLE
fix(tui): render local images reliably

### DIFF
--- a/bin/tact/src/tui/components/app.rs
+++ b/bin/tact/src/tui/components/app.rs
@@ -546,6 +546,9 @@ impl AppNode {
     }
 
     fn update_terminal(&mut self, event: Event) -> ComponentUpdate<AppEffect> {
+        if matches!(event, Event::FocusGained) {
+            self.refresh_terminal_images();
+        }
         if matches!(event, Event::Resize(_, _)) {
             let mut update = self.update_all(RootEvent::Terminal(event));
             update.render = RenderRequest::Immediate;
@@ -576,6 +579,16 @@ impl AppNode {
             }
         }
         self.update_root(self.focus, RootEvent::Terminal(event))
+    }
+
+    pub(crate) fn refresh_terminal_images(&mut self) {
+        for root in [&mut self.main, &mut self.fork]
+            .into_iter()
+            .filter_map(Option::as_mut)
+            .map(|(_, root)| root)
+        {
+            root.component_mut().refresh_terminal_images();
+        }
     }
 
     fn render_split_hint(&self, frame: &mut Frame<'_>, area: Rect, divider_x: u16) {

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -795,6 +795,11 @@ impl RootNode {
         update
     }
 
+    pub(crate) fn refresh_terminal_images(&mut self) {
+        self.transcript.component_mut().refresh_terminal_images();
+        self.subagents.refresh_terminal_images();
+    }
+
     fn update_terminal_without_confirmation(
         &mut self,
         mut event: Event,

--- a/bin/tact/src/tui/components/subagents.rs
+++ b/bin/tact/src/tui/components/subagents.rs
@@ -151,6 +151,12 @@ impl SubagentTree {
         }
     }
 
+    pub(super) fn refresh_terminal_images(&mut self) {
+        for node in &mut self.nodes {
+            node.transcript.component_mut().refresh_terminal_images();
+        }
+    }
+
     pub(super) fn apply(&mut self, update: AgentUpdate) -> bool {
         match update {
             AgentUpdate::Added(descriptor) => {

--- a/bin/tact/src/tui/components/transcript/image.rs
+++ b/bin/tact/src/tui/components/transcript/image.rs
@@ -1,17 +1,21 @@
-use image::ImageReader;
+use image::{DynamicImage, ImageReader};
 use ratatui::layout::Size;
 use ratatui_image::{
-    Resize,
+    FontSize, Resize,
     picker::{Picker, ProtocolType},
     sliced::SlicedProtocol,
 };
 use std::{
-    collections::HashMap,
-    env, fs,
+    collections::{HashSet, VecDeque},
+    env, fs, mem,
     path::{Path, PathBuf},
     process::Command,
-    sync::{Arc, OnceLock, Weak},
-    time::SystemTime,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        mpsc,
+    },
+    time::{Duration, Instant, SystemTime},
 };
 use url::Url;
 
@@ -19,43 +23,183 @@ pub(super) const MAX_IMAGE_HEIGHT: u16 = 24;
 
 static PICKER: OnceLock<Picker> = OnceLock::new();
 
-#[derive(Default)]
 pub(super) struct Cache {
-    entries: HashMap<CacheKey, CachedProtocol>,
-    width: Option<u16>,
+    entries: BoundedCache<CacheKey, CachedProtocol, PROTOCOL_CACHE_CAPACITY>,
+    sources: BoundedCache<PathBuf, Source, SOURCE_CACHE_CAPACITY>,
+    requests: HashSet<CacheKey>,
+    completions: mpsc::Receiver<Completion>,
+    completion_sender: mpsc::Sender<Completion>,
+    epoch: Arc<AtomicU64>,
+    active_jobs: Arc<AtomicUsize>,
+    generation: u64,
+    inline_images: Option<bool>,
+    blocked_retry: LayoutChange,
+    next_poll: Option<Instant>,
+}
+
+pub(super) enum LoadResult {
+    Unsupported,
+    Deferred,
+    Failed,
+    Loaded(Arc<SlicedProtocol>),
 }
 
 enum CachedProtocol {
-    Failed,
-    Loaded(Weak<SlicedProtocol>),
+    Failed(Fingerprint),
+    Loaded {
+        protocol: Arc<SlicedProtocol>,
+        fingerprint: Fingerprint,
+    },
 }
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct CacheKey {
     path: PathBuf,
-    width: u16,
-    len: Option<u64>,
-    modified: Option<SystemTime>,
+    target: Target,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum Target {
+    Natural { width: u16 },
+    Exact { width: u16, height: u16 },
+}
+
+#[derive(Clone)]
+struct Source {
+    image: Arc<DynamicImage>,
+    fingerprint: Fingerprint,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct Fingerprint(Option<(u64, Option<SystemTime>)>);
+
+struct Completion {
+    key: CacheKey,
+    generation: u64,
+    outcome: CompletionOutcome,
+}
+
+enum CompletionOutcome {
+    Unchanged,
+    Prepared {
+        source: Option<Source>,
+        protocol: Option<Arc<SlicedProtocol>>,
+        fingerprint: Fingerprint,
+        invalidates_path: bool,
+        refresh: bool,
+    },
+}
+
+struct BoundedCache<K, V, const CAPACITY: usize>(VecDeque<(K, V)>);
+
+struct JobPermit(Arc<AtomicUsize>);
+
+impl Drop for JobPermit {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Release);
+    }
+}
+
+impl<K, V, const CAPACITY: usize> Default for BoundedCache<K, V, CAPACITY> {
+    fn default() -> Self {
+        Self(VecDeque::new())
+    }
+}
+
+impl<K: Eq, V, const CAPACITY: usize> BoundedCache<K, V, CAPACITY> {
+    fn get(&mut self, key: &K) -> Option<&V> {
+        let index = self.0.iter().position(|(candidate, _)| candidate == key)?;
+        let entry = self.0.remove(index)?;
+        self.0.push_back(entry);
+        self.0.back().map(|(_, value)| value)
+    }
+
+    fn insert(&mut self, key: K, value: V) {
+        self.0.retain(|(candidate, _)| candidate != &key);
+        self.0.push_back((key, value));
+        if self.0.len() > CAPACITY {
+            self.0.pop_front();
+        }
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&K, &mut V) -> bool) {
+        self.0.retain_mut(|(key, value)| keep(key, value));
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.0.iter().map(|(key, value)| (key, value))
+    }
+}
+
+#[derive(Default)]
+pub(super) struct PollResult {
+    pub(super) layout_change: LayoutChange,
+    pub(super) render_changed: bool,
+}
+
+#[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) enum LayoutChange {
+    #[default]
+    None,
+    Pending,
+    Ready,
+}
+
+const LOAD_POLL_INTERVAL: Duration = Duration::from_millis(16);
+const JOB_QUEUE_CAPACITY: usize = 16;
+const SOURCE_CACHE_CAPACITY: usize = 8;
+const PROTOCOL_CACHE_CAPACITY: usize = 32;
+
+struct TmuxClient {
+    termtype: String,
+    font_size: Option<FontSize>,
 }
 
 pub(crate) fn initialize() {
-    let mut picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
-    if picker.protocol_type() == ProtocolType::Halfblocks {
-        let term = env::var("TERM").ok();
-        let term_program = env::var("TERM_PROGRAM").ok();
-        let inside_tmux = env::var_os("TMUX").is_some();
-        let native_transport = !inside_tmux
-            || picker_supports_tmux_passthrough(term.as_deref(), term_program.as_deref());
-        let tmux_client = native_transport.then(tmux_client_termtype).flatten();
-        if let Some(protocol) = protocol_hint(
-            term_program.as_deref(),
-            tmux_client.as_deref(),
-            native_transport,
-        ) {
-            picker.set_protocol_type(protocol);
-        }
+    let inside_tmux = env::var_os("TMUX").is_some();
+    let tmux_client = inside_tmux.then(tmux_client).flatten();
+    let mut picker = if queries_terminal_for_image_capabilities(inside_tmux) {
+        Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks())
+    } else {
+        tmux_client
+            .as_ref()
+            .and_then(|client| client.font_size)
+            .map(picker_from_font_size)
+            .unwrap_or_else(Picker::halfblocks)
+    };
+    let term = env::var("TERM").ok();
+    let term_program = env::var("TERM_PROGRAM").ok();
+    let native_transport =
+        !inside_tmux || picker_supports_tmux_passthrough(term.as_deref(), term_program.as_deref());
+    if let Some(protocol) = protocol_override(
+        picker.protocol_type(),
+        term_program.as_deref(),
+        tmux_client.as_ref().map(|client| client.termtype.as_str()),
+        inside_tmux,
+        native_transport,
+    ) {
+        picker.set_protocol_type(protocol);
     }
     drop(PICKER.set(picker));
+}
+
+const fn queries_terminal_for_image_capabilities(inside_tmux: bool) -> bool {
+    !inside_tmux
+}
+
+#[allow(deprecated)]
+fn picker_from_font_size(font_size: FontSize) -> Picker {
+    Picker::from_fontsize(font_size)
 }
 
 fn protocol_hint(
@@ -74,83 +218,343 @@ fn protocol_hint(
         .then_some(ProtocolType::Kitty)
 }
 
+fn protocol_override(
+    current: ProtocolType,
+    term_program: Option<&str>,
+    tmux_client_termtype: Option<&str>,
+    inside_tmux: bool,
+    native_transport: bool,
+) -> Option<ProtocolType> {
+    if !native_transport {
+        return None;
+    }
+    if inside_tmux {
+        return protocol_hint(None, tmux_client_termtype, true);
+    }
+    (current == ProtocolType::Halfblocks)
+        .then(|| protocol_hint(term_program, None, true))
+        .flatten()
+}
+
 fn picker_supports_tmux_passthrough(term: Option<&str>, term_program: Option<&str>) -> bool {
     term.is_some_and(|term| term.starts_with("tmux")) || term_program == Some("tmux")
 }
 
-fn tmux_client_termtype() -> Option<String> {
+fn tmux_client() -> Option<TmuxClient> {
     env::var_os("TMUX")?;
     let output = Command::new("tmux")
-        .args(["display-message", "-p", "#{client_termtype}"])
+        .args([
+            "display-message",
+            "-p",
+            "#{client_termtype}\t#{client_cell_width}\t#{client_cell_height}",
+        ])
         .output()
         .ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    if !output.status.success() {
+        return None;
+    }
+    let output = String::from_utf8_lossy(&output.stdout);
+    parse_tmux_client(&output)
+}
+
+fn parse_tmux_client(output: &str) -> Option<TmuxClient> {
+    let mut fields = output.trim().split('\t');
+    let termtype = fields.next()?.to_owned();
+    let width = fields.next().and_then(|value| value.parse().ok());
+    let height = fields.next().and_then(|value| value.parse().ok());
+    let font_size = width
+        .zip(height)
+        .filter(|(width, height)| *width > 0 && *height > 0)
+        .map(|(width, height)| FontSize::new(width, height));
+    Some(TmuxClient {
+        termtype,
+        font_size,
+    })
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        let (completion_sender, completions) = mpsc::channel();
+        Self {
+            entries: BoundedCache::default(),
+            sources: BoundedCache::default(),
+            requests: HashSet::new(),
+            completions,
+            completion_sender,
+            epoch: Arc::new(AtomicU64::new(0)),
+            active_jobs: Arc::new(AtomicUsize::new(0)),
+            generation: 0,
+            inline_images: None,
+            blocked_retry: LayoutChange::None,
+            next_poll: None,
+        }
+    }
 }
 
 impl Cache {
-    pub(super) fn load(
-        &mut self,
-        destination: &str,
-        workspace: &Path,
-        width: u16,
-    ) -> Option<Arc<SlicedProtocol>> {
-        if self.width != Some(width) {
-            self.entries.clear();
-            self.width = Some(width);
+    pub(super) fn load(&mut self, destination: &str, workspace: &Path, width: u16) -> LoadResult {
+        let picker = PICKER.get_or_init(Picker::halfblocks);
+        if !self
+            .inline_images
+            .unwrap_or_else(|| supports_inline_images(picker.protocol_type()))
+        {
+            return LoadResult::Unsupported;
         }
-        let path = local_path(destination, workspace)?;
-        let metadata = fs::metadata(&path).ok();
-        let key = CacheKey {
-            path: path.clone(),
-            width,
-            len: metadata.as_ref().map(fs::Metadata::len),
-            modified: metadata.and_then(|metadata| metadata.modified().ok()),
+        let Some(path) = local_path(destination, workspace) else {
+            return LoadResult::Failed;
         };
-        match self.entries.get(&key) {
-            Some(CachedProtocol::Failed) => return None,
-            Some(CachedProtocol::Loaded(protocol)) => {
-                if let Some(protocol) = protocol.upgrade() {
-                    return Some(protocol);
-                }
-            }
-            None => {}
-        }
-
-        self.entries
-            .retain(|cached, _| cached.path != path || cached.width != width);
-        let protocol = load(&path, width);
-        let cached = protocol
-            .as_ref()
-            .map_or(CachedProtocol::Failed, |protocol| {
-                CachedProtocol::Loaded(Arc::downgrade(protocol))
-            });
-        self.entries.insert(key, cached);
-        protocol
+        let key = CacheKey {
+            path,
+            target: Target::Natural { width },
+        };
+        self.request(key)
     }
 
     pub(super) fn clear(&mut self) {
+        self.sources.clear();
+        self.advance_terminal_generation();
+    }
+
+    pub(super) fn retransmit(
+        &mut self,
+        destination: &str,
+        workspace: &Path,
+        size: Size,
+    ) -> LoadResult {
+        let Some(path) = local_path(destination, workspace) else {
+            return LoadResult::Failed;
+        };
+        let key = CacheKey {
+            path,
+            target: Target::Exact {
+                width: size.width,
+                height: size.height,
+            },
+        };
+        self.request(key)
+    }
+
+    pub(super) fn advance_terminal_generation(&mut self) {
         self.entries.clear();
-        self.width = None;
+        self.requests.clear();
+        self.generation = self.generation.wrapping_add(1);
+        self.epoch.store(self.generation, Ordering::Release);
+        self.blocked_retry = LayoutChange::None;
+        self.next_poll = None;
+    }
+
+    pub(super) const fn animation_deadline(&self) -> Option<Instant> {
+        self.next_poll
+    }
+
+    pub(super) fn poll(&mut self, now: Instant) -> PollResult {
+        let mut result = PollResult::default();
+        while let Ok(completion) = self.completions.try_recv() {
+            if completion.generation != self.generation {
+                continue;
+            }
+            let path = completion.key.path.clone();
+            let requested = self.requests.remove(&completion.key);
+            let CompletionOutcome::Prepared {
+                source,
+                protocol,
+                fingerprint,
+                invalidates_path,
+                refresh,
+            } = completion.outcome
+            else {
+                continue;
+            };
+            if let Some(source) = source {
+                self.sources.insert(path.clone(), source);
+            }
+            if requested {
+                let layout_changed = matches!(completion.key.target, Target::Natural { .. });
+                let cached = protocol.map_or_else(
+                    || CachedProtocol::Failed(fingerprint),
+                    |protocol| CachedProtocol::Loaded {
+                        protocol,
+                        fingerprint,
+                    },
+                );
+                if invalidates_path {
+                    self.entries.retain(|key, _| key.path != path);
+                }
+                self.entries.insert(completion.key.clone(), cached);
+                if layout_changed {
+                    result.layout_change = result.layout_change.max(if refresh {
+                        LayoutChange::Ready
+                    } else {
+                        LayoutChange::Pending
+                    });
+                }
+                result.render_changed = true;
+            }
+        }
+        if self.blocked_retry != LayoutChange::None {
+            result.layout_change = result.layout_change.max(mem::take(&mut self.blocked_retry));
+            result.render_changed = true;
+        }
+        self.next_poll = (!self.requests.is_empty() || self.blocked_retry != LayoutChange::None)
+            .then_some(now + LOAD_POLL_INTERVAL);
+        result
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_inline_images(inline_images: bool) -> Self {
+        Self {
+            inline_images: Some(inline_images),
+            ..Self::default()
+        }
+    }
+
+    fn request(&mut self, key: CacheKey) -> LoadResult {
+        let cached = self.entries.get(&key).map(|cached| match cached {
+            CachedProtocol::Failed(fingerprint) => (None, *fingerprint),
+            CachedProtocol::Loaded {
+                protocol,
+                fingerprint,
+            } => (Some(Arc::clone(protocol)), *fingerprint),
+        });
+        let validate = cached.is_none() || matches!(key.target, Target::Natural { .. });
+        let blocked = validate
+            && !self.requests.contains(&key)
+            && (self.requests.len() >= JOB_QUEUE_CAPACITY || !self.spawn(key.clone()));
+        if blocked {
+            let layout_change = if cached.is_some() {
+                LayoutChange::Ready
+            } else {
+                LayoutChange::Pending
+            };
+            self.blocked_retry = self.blocked_retry.max(layout_change);
+            self.next_poll.get_or_insert_with(Instant::now);
+        }
+        if let Some((protocol, _)) = cached {
+            return protocol.map_or(LoadResult::Failed, LoadResult::Loaded);
+        }
+        LoadResult::Deferred
+    }
+
+    fn spawn(&mut self, key: CacheKey) -> bool {
+        let Some(permit) = self.reserve_job() else {
+            return false;
+        };
+        let source = self.sources.get(&key.path).cloned();
+        let picker = PICKER.get_or_init(Picker::halfblocks).clone();
+        let known_fingerprint = self.entries.get(&key).map(CachedProtocol::fingerprint);
+        let epoch = Arc::clone(&self.epoch);
+        let generation = self.generation;
+        let completion_sender = self.completion_sender.clone();
+        self.requests.insert(key.clone());
+        self.next_poll.get_or_insert_with(Instant::now);
+        rayon::spawn(move || {
+            let _permit = permit;
+            if epoch.load(Ordering::Acquire) != generation {
+                return;
+            }
+            let completion = prepare(key, generation, source, known_fingerprint, &picker);
+            drop(completion_sender.send(completion));
+        });
+        true
+    }
+
+    fn reserve_job(&self) -> Option<JobPermit> {
+        self.active_jobs
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                (active < JOB_QUEUE_CAPACITY).then_some(active + 1)
+            })
+            .ok()
+            .map(|_| JobPermit(Arc::clone(&self.active_jobs)))
+    }
+
+    #[cfg(test)]
+    fn pending_work(&self) -> usize {
+        self.requests.len()
     }
 }
 
-fn load(path: &Path, width: u16) -> Option<Arc<SlicedProtocol>> {
+impl CachedProtocol {
+    const fn fingerprint(&self) -> Fingerprint {
+        match self {
+            Self::Failed(fingerprint) | Self::Loaded { fingerprint, .. } => *fingerprint,
+        }
+    }
+}
+
+fn supports_inline_images(protocol: ProtocolType) -> bool {
+    protocol != ProtocolType::Halfblocks
+}
+
+fn prepare(
+    key: CacheKey,
+    generation: u64,
+    cached: Option<Source>,
+    known_fingerprint: Option<Fingerprint>,
+    picker: &Picker,
+) -> Completion {
+    let metadata = fs::metadata(&key.path).ok();
+    let fingerprint = Fingerprint(
+        metadata
+            .as_ref()
+            .map(|metadata| (metadata.len(), metadata.modified().ok())),
+    );
+    if known_fingerprint == Some(fingerprint) {
+        return Completion {
+            key,
+            generation,
+            outcome: CompletionOutcome::Unchanged,
+        };
+    }
+    let invalidates_path = known_fingerprint.is_some_and(|known| known != fingerprint)
+        || cached
+            .as_ref()
+            .is_some_and(|source| source.fingerprint != fingerprint);
+    let source = cached
+        .filter(|source| source.fingerprint == fingerprint)
+        .or_else(|| {
+            decode(&key.path).map(|image| Source {
+                image: Arc::new(image),
+                fingerprint,
+            })
+        });
+    let protocol = source.as_ref().and_then(|source| {
+        let size = match key.target {
+            Target::Natural { width } => {
+                let natural = Resize::natural_size(&source.image, picker.font_size());
+                Size::new(
+                    natural.width.min(width),
+                    natural.height.min(MAX_IMAGE_HEIGHT),
+                )
+            }
+            Target::Exact { width, height } => Size::new(width, height),
+        };
+        encode(picker, source.image.as_ref().clone(), size)
+    });
+    Completion {
+        key,
+        generation,
+        outcome: CompletionOutcome::Prepared {
+            source,
+            protocol,
+            fingerprint,
+            invalidates_path,
+            refresh: known_fingerprint.is_some(),
+        },
+    }
+}
+
+fn decode(path: &Path) -> Option<DynamicImage> {
     let image = ImageReader::open(path)
         .ok()?
         .with_guessed_format()
         .ok()?
         .decode()
         .ok()?;
-    let picker = PICKER.get_or_init(Picker::halfblocks);
-    let natural = Resize::natural_size(&image, picker.font_size());
-    let available = Size::new(
-        natural.width.min(width),
-        natural.height.min(MAX_IMAGE_HEIGHT),
-    );
-    SlicedProtocol::new_with_resize(picker, image, available, Resize::Fit(None))
+    Some(image)
+}
+
+fn encode(picker: &Picker, image: DynamicImage, size: Size) -> Option<Arc<SlicedProtocol>> {
+    SlicedProtocol::new_with_resize(picker, image, size, Resize::Fit(None))
         .ok()
         .map(Arc::new)
 }
@@ -166,27 +570,74 @@ fn local_path(destination: &str, workspace: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{picker_supports_tmux_passthrough, protocol_hint};
+    use super::{
+        Cache, JOB_QUEUE_CAPACITY, LayoutChange, LoadResult, PROTOCOL_CACHE_CAPACITY,
+        SOURCE_CACHE_CAPACITY, Target, picker_supports_tmux_passthrough, protocol_hint,
+        protocol_override, queries_terminal_for_image_capabilities, supports_inline_images,
+    };
+    use ratatui::layout::Size;
     use ratatui_image::picker::ProtocolType;
+    use std::{
+        fs::File,
+        sync::Arc,
+        time::{Duration, Instant},
+    };
+
+    fn write_png(path: &std::path::Path) {
+        write_png_size(path, 8, 8);
+    }
+
+    fn write_png_size(path: &std::path::Path, width: u32, height: u32) {
+        let file = File::create(path).unwrap();
+        let mut encoder = png::Encoder::new(file, width, height);
+        encoder.set_color(png::ColorType::Rgb);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().unwrap();
+        writer
+            .write_image_data(&[0xff, 0, 0].repeat((width * height) as usize))
+            .unwrap();
+    }
+
+    fn wait_for_load(
+        cache: &mut Cache,
+        destination: &str,
+        workspace: &std::path::Path,
+        width: u16,
+    ) -> std::sync::Arc<ratatui_image::sliced::SlicedProtocol> {
+        eventually(|| {
+            cache.poll(Instant::now());
+            loaded(cache.load(destination, workspace, width))
+        })
+    }
+
+    fn eventually<T>(mut check: impl FnMut() -> Option<T>) -> T {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Some(value) = check() {
+                return value;
+            }
+            assert!(Instant::now() < deadline, "image preparation timed out");
+            std::thread::yield_now();
+        }
+    }
+
+    fn loaded(result: LoadResult) -> Option<Arc<ratatui_image::sliced::SlicedProtocol>> {
+        match result {
+            LoadResult::Loaded(protocol) => Some(protocol),
+            _ => None,
+        }
+    }
 
     #[test]
-    fn ghostty_uses_the_kitty_graphics_protocol() {
+    fn ghostty_protocol_detection_respects_tmux_transport() {
         assert_eq!(
             protocol_hint(Some("ghostty"), None, true),
             Some(ProtocolType::Kitty)
         );
-    }
-
-    #[test]
-    fn ghostty_inside_tmux_uses_the_kitty_graphics_protocol() {
         assert_eq!(
             protocol_hint(Some("tmux"), Some("ghostty 1.3.1"), true),
             Some(ProtocolType::Kitty)
         );
-    }
-
-    #[test]
-    fn ghostty_hint_requires_tmux_passthrough() {
         assert!(!picker_supports_tmux_passthrough(
             Some("screen-256color"),
             Some("ghostty")
@@ -195,5 +646,227 @@ mod tests {
             protocol_hint(Some("ghostty"), Some("ghostty 1.3.1"), false),
             None
         );
+    }
+
+    #[test]
+    fn tmux_image_initialization_does_not_block_on_terminal_queries() {
+        assert!(!queries_terminal_for_image_capabilities(true));
+        assert!(queries_terminal_for_image_capabilities(false));
+    }
+
+    #[test]
+    fn tmux_client_dimensions_supply_the_outer_terminal_font_size() {
+        let client = super::parse_tmux_client("ghostty 1.3.1\t22\t49\n").unwrap();
+
+        assert_eq!(client.termtype, "ghostty 1.3.1");
+        let font_size = client.font_size.unwrap();
+        assert_eq!((font_size.width, font_size.height), (22, 49));
+    }
+
+    #[test]
+    fn current_tmux_client_overrides_stale_terminal_protocol() {
+        assert_eq!(
+            protocol_override(
+                ProtocolType::Iterm2,
+                Some("iTerm.app"),
+                Some("ghostty 1.3.1"),
+                true,
+                true,
+            ),
+            Some(ProtocolType::Kitty),
+        );
+    }
+
+    #[test]
+    fn halfblocks_are_not_an_inline_image_backend() {
+        assert!(!supports_inline_images(ProtocolType::Halfblocks));
+        for protocol in [
+            ProtocolType::Kitty,
+            ProtocolType::Sixel,
+            ProtocolType::Iterm2,
+        ] {
+            assert!(supports_inline_images(protocol));
+        }
+    }
+
+    #[test]
+    fn image_preparation_is_deferred_off_the_render_thread() {
+        let workspace = tempfile::tempdir().unwrap();
+        write_png(&workspace.path().join("sample.png"));
+        let mut cache = Cache::with_inline_images(true);
+
+        assert!(matches!(
+            cache.load("sample.png", workspace.path(), 20),
+            LoadResult::Deferred
+        ));
+        assert!(matches!(
+            cache.retransmit("sample.png", workspace.path(), Size::new(4, 2)),
+            LoadResult::Deferred
+        ));
+    }
+
+    #[test]
+    fn natural_and_exact_size_variants_prepare_independently() {
+        let workspace = tempfile::tempdir().unwrap();
+        write_png_size(&workspace.path().join("sample.png"), 80, 40);
+        let mut cache = Cache::with_inline_images(true);
+        let exact_sizes = [Size::new(4, 2), Size::new(8, 4)];
+
+        for width in [12, 24] {
+            assert!(matches!(
+                cache.load("sample.png", workspace.path(), width),
+                LoadResult::Deferred
+            ));
+        }
+        for size in exact_sizes {
+            assert!(matches!(
+                cache.retransmit("sample.png", workspace.path(), size),
+                LoadResult::Deferred
+            ));
+        }
+
+        let narrow = wait_for_load(&mut cache, "sample.png", workspace.path(), 12);
+        let wide = wait_for_load(&mut cache, "sample.png", workspace.path(), 24);
+        let first_exact = eventually(|| {
+            cache.poll(Instant::now());
+            loaded(cache.retransmit("sample.png", workspace.path(), exact_sizes[0]))
+        });
+        let second_exact = eventually(|| {
+            cache.poll(Instant::now());
+            loaded(cache.retransmit("sample.png", workspace.path(), exact_sizes[1]))
+        });
+
+        assert!(!Arc::ptr_eq(&narrow, &wide));
+        assert!(!Arc::ptr_eq(&first_exact, &second_exact));
+        assert!(Arc::ptr_eq(
+            &narrow,
+            &wait_for_load(&mut cache, "sample.png", workspace.path(), 12)
+        ));
+        assert_eq!(
+            cache
+                .entries
+                .iter()
+                .filter(|(key, _)| matches!(key.target, Target::Exact { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn changed_and_newly_created_images_replace_cached_results() {
+        let workspace = tempfile::tempdir().unwrap();
+        let path = workspace.path().join("sample.png");
+        write_png(&path);
+        let mut cache = Cache::with_inline_images(true);
+        let original = wait_for_load(&mut cache, "sample.png", workspace.path(), 20);
+
+        write_png_size(&path, 80, 40);
+        let changed = eventually(|| {
+            cache.poll(Instant::now());
+            loaded(cache.load("sample.png", workspace.path(), 20))
+                .filter(|protocol| !Arc::ptr_eq(&original, protocol))
+        });
+        assert!(!Arc::ptr_eq(&original, &changed));
+
+        let missing = "created-later.png";
+        eventually(|| {
+            cache.poll(Instant::now());
+            matches!(
+                cache.load(missing, workspace.path(), 20),
+                LoadResult::Failed
+            )
+            .then_some(())
+        });
+        write_png(&workspace.path().join(missing));
+        let _ = wait_for_load(&mut cache, missing, workspace.path(), 20);
+    }
+
+    #[test]
+    fn decoded_sources_and_prepared_protocols_are_bounded() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut cache = Cache::with_inline_images(true);
+        for index in 0..PROTOCOL_CACHE_CAPACITY + 4 {
+            let name = format!("sample-{index}.png");
+            write_png(&workspace.path().join(&name));
+            let _ = wait_for_load(&mut cache, &name, workspace.path(), 20);
+        }
+
+        assert!(cache.sources.len() <= SOURCE_CACHE_CAPACITY);
+        assert!(cache.entries.len() <= PROTOCOL_CACHE_CAPACITY);
+    }
+
+    #[test]
+    fn image_work_is_bounded_and_rejected_images_retry() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut cache = Cache::with_inline_images(true);
+
+        for index in 0..JOB_QUEUE_CAPACITY {
+            let name = format!("queued-{index}.png");
+            write_png(&workspace.path().join(&name));
+            assert!(matches!(
+                cache.retransmit(&name, workspace.path(), Size::new(4, 2)),
+                LoadResult::Deferred
+            ));
+        }
+        write_png(&workspace.path().join("visible.png"));
+        assert!(matches!(
+            cache.load("visible.png", workspace.path(), 20),
+            LoadResult::Deferred
+        ));
+        assert_eq!(cache.pending_work(), JOB_QUEUE_CAPACITY);
+
+        eventually(|| {
+            (cache.poll(Instant::now()).layout_change == LayoutChange::Pending).then_some(())
+        });
+        eventually(|| {
+            cache.poll(Instant::now());
+            loaded(cache.load("visible.png", workspace.path(), 20))
+        });
+    }
+
+    #[test]
+    fn rejected_cached_validation_retries_when_capacity_opens() {
+        let workspace = tempfile::tempdir().unwrap();
+        let path = workspace.path().join("sample.png");
+        write_png(&path);
+        let mut cache = Cache::with_inline_images(true);
+        let original = wait_for_load(&mut cache, "sample.png", workspace.path(), 20);
+        eventually(|| {
+            cache.poll(Instant::now());
+            (cache.pending_work() == 0).then_some(())
+        });
+        let permits = (0..JOB_QUEUE_CAPACITY)
+            .map(|_| cache.reserve_job().unwrap())
+            .collect::<Vec<_>>();
+
+        write_png_size(&path, 80, 40);
+        let cached = loaded(cache.load("sample.png", workspace.path(), 20)).unwrap();
+        assert!(Arc::ptr_eq(&original, &cached));
+        drop(permits);
+
+        assert!(matches!(
+            cache.poll(Instant::now()).layout_change,
+            LayoutChange::Ready
+        ));
+
+        eventually(|| {
+            cache.poll(Instant::now());
+            loaded(cache.load("sample.png", workspace.path(), 20))
+                .filter(|protocol| !Arc::ptr_eq(&original, protocol))
+        });
+    }
+
+    #[test]
+    fn image_work_permits_survive_generation_changes() {
+        let mut cache = Cache::with_inline_images(true);
+        let permits = (0..JOB_QUEUE_CAPACITY)
+            .map(|_| cache.reserve_job().unwrap())
+            .collect::<Vec<_>>();
+
+        cache.advance_terminal_generation();
+        assert!(cache.reserve_job().is_none());
+
+        drop(permits);
+        assert!(cache.reserve_job().is_some());
     }
 }

--- a/bin/tact/src/tui/components/transcript/markdown.rs
+++ b/bin/tact/src/tui/components/transcript/markdown.rs
@@ -17,11 +17,22 @@ pub(super) struct Layout {
     pub(super) selections: Vec<Vec<SourceSpan>>,
     pub(super) envelopes: Vec<SourceEnvelope>,
     pub(super) selection_source: Option<String>,
+    pub(super) image_state: ImageState,
+}
+
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+pub(super) enum ImageState {
+    #[default]
+    None,
+    Ready,
+    Pending,
 }
 
 pub(super) struct ImagePlacement {
     pub(super) line: usize,
+    pub(super) destination: Arc<str>,
     pub(super) protocol: Arc<SlicedProtocol>,
+    pub(super) retransmit: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -73,6 +84,7 @@ pub(super) fn render_cached(
             selections: Vec::new(),
             envelopes: Vec::new(),
             selection_source: None,
+            image_state: ImageState::None,
         };
     }
     let options = Options::ENABLE_TABLES
@@ -97,9 +109,14 @@ pub(super) fn render_cached(
             event => renderer.event(event),
         }
     }
-    let (mut layout, selection_exclusions) = renderer.finish();
-    let (selections, envelopes) =
-        markdown_selection_spans(markdown, &layout.lines, options, &selection_exclusions);
+    let (mut layout, selection_exclusions, image_selection_modes) = renderer.finish();
+    let (selections, envelopes) = markdown_selection_spans(
+        markdown,
+        &layout.lines,
+        options,
+        &selection_exclusions,
+        &image_selection_modes,
+    );
     layout.selections = selections;
     layout.envelopes = envelopes;
     layout
@@ -168,8 +185,10 @@ struct Renderer<'a> {
     links: Vec<LinkState>,
     rendered_links: Vec<(usize, LinkSpan)>,
     selection_exclusions: Vec<Vec<Range<u16>>>,
+    image_selection_modes: Vec<ImageSelectionMode>,
     images: Vec<ImagePlacement>,
-    image: Option<String>,
+    image_state: ImageState,
+    image: Option<LinkState>,
     workspace: &'a Path,
     images_cache: &'a mut super::image::Cache,
 }
@@ -181,6 +200,13 @@ struct ListState {
 struct LinkState {
     destination: Arc<str>,
     label: String,
+}
+
+#[derive(Clone, Copy)]
+enum ImageSelectionMode {
+    Hidden,
+    AltText,
+    Link,
 }
 
 struct TaggedSpan {
@@ -206,7 +232,9 @@ impl<'a> Renderer<'a> {
             links: Vec::new(),
             rendered_links: Vec::new(),
             selection_exclusions: Vec::new(),
+            image_selection_modes: Vec::new(),
             images: Vec::new(),
+            image_state: ImageState::None,
             image: None,
             workspace,
             images_cache,
@@ -322,7 +350,10 @@ impl<'a> Renderer<'a> {
                 );
             }
             Tag::Image { dest_url, .. } => {
-                self.image = Some(sanitize(&dest_url));
+                self.image = Some(LinkState {
+                    destination: Arc::from(sanitize(&dest_url)),
+                    label: String::new(),
+                });
             }
             Tag::FootnoteDefinition(label) => {
                 self.flush();
@@ -399,25 +430,45 @@ impl<'a> Renderer<'a> {
                 }
             }
             TagEnd::Image => {
-                if let Some(destination) = self.image.take() {
-                    if let Some(protocol) =
-                        self.images_cache
-                            .load(&destination, self.workspace, self.width)
+                if self.image_state == ImageState::None {
+                    self.image_state = ImageState::Ready;
+                }
+                if let Some(image) = self.image.take() {
+                    match self
+                        .images_cache
+                        .load(&image.destination, self.workspace, self.width)
                     {
-                        self.flush();
-                        let line = self.lines.len();
-                        let size = protocol.size();
-                        self.lines.extend(
-                            (0..size.height).map(|_| {
+                        super::image::LoadResult::Loaded(protocol) => {
+                            self.image_selection_modes.push(ImageSelectionMode::Hidden);
+                            self.flush();
+                            let line = self.lines.len();
+                            let size = protocol.size();
+                            self.lines.extend((0..size.height).map(|_| {
                                 Line::from(Span::raw(" ".repeat(usize::from(size.width))))
-                            }),
-                        );
-                        self.images.push(ImagePlacement { line, protocol });
-                    } else {
-                        self.push_unlinked(Span::styled(
-                            "image could not be rendered",
-                            Style::default().fg(ratatui::style::Color::Red),
-                        ));
+                            }));
+                            self.images.push(ImagePlacement {
+                                line,
+                                destination: image.destination,
+                                protocol,
+                                retransmit: false,
+                            });
+                        }
+                        super::image::LoadResult::Unsupported => {
+                            self.image_selection_modes.push(ImageSelectionMode::Link);
+                            self.render_image_link(image);
+                        }
+                        super::image::LoadResult::Deferred => {
+                            self.image_state = ImageState::Pending;
+                            self.image_selection_modes.push(ImageSelectionMode::Link);
+                            self.render_image_link(image);
+                        }
+                        super::image::LoadResult::Failed => {
+                            self.image_selection_modes.push(ImageSelectionMode::Hidden);
+                            self.push_unlinked(Span::styled(
+                                "image could not be rendered",
+                                Style::default().fg(ratatui::style::Color::Red),
+                            ));
+                        }
                     }
                 }
             }
@@ -441,7 +492,8 @@ impl<'a> Renderer<'a> {
 
     fn text(&mut self, text: &str) {
         let text = sanitize(text);
-        if self.image.is_some() {
+        if let Some(image) = &mut self.image {
+            image.label.push_str(&text);
             return;
         }
         if let Some(link) = self.links.last_mut() {
@@ -453,7 +505,8 @@ impl<'a> Renderer<'a> {
 
     fn span(&mut self, text: &str, style: Style) {
         let text = sanitize(text);
-        if self.image.is_some() {
+        if let Some(image) = &mut self.image {
+            image.label.push_str(&text);
             return;
         }
         self.ensure_prefix();
@@ -597,6 +650,9 @@ impl<'a> Renderer<'a> {
                     cell.clear();
                     in_cell = true;
                 }
+                Event::Start(Tag::Image { .. }) => {
+                    self.image_selection_modes.push(ImageSelectionMode::AltText)
+                }
                 Event::End(TagEnd::TableCell) => {
                     row.push(cell.trim().to_owned());
                     in_cell = false;
@@ -663,6 +719,36 @@ impl<'a> Renderer<'a> {
         });
     }
 
+    fn render_image_link(&mut self, image: LinkState) {
+        self.ensure_prefix();
+        let label = if image.label.is_empty() {
+            image.destination.to_string()
+        } else {
+            image.label
+        };
+        let include_destination = label.trim() != image.destination.as_ref();
+        self.push_linked(
+            Span::styled(
+                label,
+                Style::default()
+                    .fg(self.theme.accent())
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Arc::clone(&image.destination),
+        );
+        if include_destination {
+            self.push_linked(
+                Span::styled(
+                    format!(" ↗ {}", image.destination),
+                    Style::default()
+                        .fg(self.theme.accent())
+                        .add_modifier(Modifier::DIM),
+                ),
+                image.destination,
+            );
+        }
+    }
+
     fn flush(&mut self) {
         if self.current.is_empty() {
             return;
@@ -696,7 +782,7 @@ impl<'a> Renderer<'a> {
         self.selection_exclusions[line].push(columns);
     }
 
-    fn finish(mut self) -> (Layout, Vec<Vec<Range<u16>>>) {
+    fn finish(mut self) -> (Layout, Vec<Vec<Range<u16>>>, Vec<ImageSelectionMode>) {
         self.flush();
         while self.lines.last().is_some_and(|line| line.width() == 0) {
             self.lines.pop();
@@ -707,16 +793,19 @@ impl<'a> Renderer<'a> {
                 line_links.push(link);
             }
         }
+        let layout = Layout {
+            lines: self.lines,
+            images: self.images,
+            links,
+            selections: Vec::new(),
+            envelopes: Vec::new(),
+            selection_source: None,
+            image_state: self.image_state,
+        };
         (
-            Layout {
-                lines: self.lines,
-                images: self.images,
-                links,
-                selections: Vec::new(),
-                envelopes: Vec::new(),
-                selection_source: None,
-            },
+            layout,
             self.selection_exclusions,
+            self.image_selection_modes,
         )
     }
 }
@@ -732,15 +821,29 @@ fn markdown_selection_spans(
     lines: &[Line<'static>],
     options: Options,
     exclusions: &[Vec<Range<u16>>],
+    image_selection_modes: &[ImageSelectionMode],
 ) -> (Vec<Vec<SourceSpan>>, Vec<SourceEnvelope>) {
     let mut graphemes = Vec::<SourceGrapheme>::new();
-    let mut envelopes = Vec::<(TagEnd, Range<usize>, usize, bool, Option<String>)>::new();
+    let mut envelopes = Vec::<(TagEnd, Range<usize>, usize, bool, Option<String>, bool)>::new();
     let mut source_envelopes = Vec::new();
+    let mut image_modes = image_selection_modes.iter().copied();
+    let mut hidden_image_depth = 0_usize;
     for (event, range) in Parser::new_ext(markdown, options).into_offset_iter() {
         match event {
             Event::Start(tag) => {
+                let image_mode = matches!(tag, Tag::Image { .. })
+                    .then(|| image_modes.next().unwrap_or(ImageSelectionMode::Hidden));
+                let hidden_image = matches!(image_mode, Some(ImageSelectionMode::Hidden));
+                if hidden_image {
+                    hidden_image_depth = hidden_image_depth.saturating_add(1);
+                }
                 let destination = match &tag {
                     Tag::Link { dest_url, .. } => Some(sanitize(dest_url)),
+                    Tag::Image { dest_url, .. }
+                        if matches!(image_mode, Some(ImageSelectionMode::Link)) =>
+                    {
+                        Some(sanitize(dest_url))
+                    }
                     _ => None,
                 };
                 let preserve_delimiters = !matches!(tag, Tag::CodeBlock(_));
@@ -750,13 +853,15 @@ fn markdown_selection_spans(
                     graphemes.len(),
                     preserve_delimiters,
                     destination,
+                    hidden_image,
                 ));
             }
             Event::End(end) => {
                 let Some(index) = envelopes.iter().rposition(|(tag, ..)| *tag == end) else {
                     continue;
                 };
-                let (_, source, first, preserve_delimiters, destination) = envelopes.remove(index);
+                let (_, source, first, preserve_delimiters, destination, hidden_image) =
+                    envelopes.remove(index);
                 if preserve_delimiters && first != graphemes.len() {
                     source_envelopes.push(SourceEnvelope {
                         content: graphemes[first].source.start
@@ -791,47 +896,52 @@ fn markdown_selection_spans(
                         ));
                     }
                 }
+                if hidden_image {
+                    hidden_image_depth = hidden_image_depth.saturating_sub(1);
+                }
             }
-            Event::Text(text) | Event::Code(text) | Event::Html(text) | Event::InlineHtml(text) => {
+            Event::Text(text) | Event::Code(text) | Event::Html(text) | Event::InlineHtml(text)
+                if hidden_image_depth == 0 =>
+            {
                 graphemes.extend(source_graphemes(markdown, &sanitize(&text), range));
             }
-            Event::InlineMath(math) => {
+            Event::InlineMath(math) if hidden_image_depth == 0 => {
                 graphemes.extend(source_graphemes(
                     markdown,
                     &format!("${}$", sanitize(&math)),
                     range,
                 ));
             }
-            Event::DisplayMath(math) => {
+            Event::DisplayMath(math) if hidden_image_depth == 0 => {
                 graphemes.extend(source_graphemes(
                     markdown,
                     &format!("$${}$$", sanitize(&math)),
                     range,
                 ));
             }
-            Event::FootnoteReference(reference) => {
+            Event::FootnoteReference(reference) if hidden_image_depth == 0 => {
                 graphemes.extend(source_graphemes(
                     markdown,
                     &format!("[{}]", sanitize(&reference)),
                     range,
                 ));
             }
-            Event::SoftBreak => graphemes.push(SourceGrapheme {
+            Event::SoftBreak if hidden_image_depth == 0 => graphemes.push(SourceGrapheme {
                 text: " ".to_owned(),
                 source: range,
             }),
-            Event::HardBreak => graphemes.push(SourceGrapheme {
+            Event::HardBreak if hidden_image_depth == 0 => graphemes.push(SourceGrapheme {
                 text: "\n".to_owned(),
                 source: range,
             }),
-            Event::TaskListMarker(checked) => {
+            Event::TaskListMarker(checked) if hidden_image_depth == 0 => {
                 graphemes.extend(source_graphemes(
                     markdown,
                     if checked { "✓ " } else { "□ " },
                     range,
                 ));
             }
-            Event::Rule => {}
+            _ => {}
         }
     }
     (
@@ -1416,11 +1526,11 @@ fn render_stacked_table(
 mod tests {
     use super::{
         super::image::{Cache, MAX_IMAGE_HEIGHT},
-        render, render_cached, render_in,
+        ImageState, Layout, render, render_cached,
     };
     use crate::tui::theme::Theme;
     use ratatui::style::{Color, Modifier};
-    use std::{fs::File, path::Path, sync::Arc};
+    use std::{fs::File, path::Path, sync::Arc, time::Instant};
 
     fn write_png(path: &Path) {
         write_solid_png(path, 1, 1);
@@ -1435,6 +1545,29 @@ mod tests {
         writer
             .write_image_data(&[0xff, 0, 0].repeat((width * height) as usize))
             .unwrap();
+    }
+
+    fn render_inline_image_in(markdown: &str, width: u16, workspace: &Path) -> Layout {
+        let mut images = Cache::with_inline_images(true);
+        render_cached_until_ready(markdown, width, workspace, &mut images)
+    }
+
+    fn render_cached_until_ready(
+        markdown: &str,
+        width: u16,
+        workspace: &Path,
+        images: &mut Cache,
+    ) -> Layout {
+        let deadline = Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let layout = render_cached(markdown, width, &Theme::default(), workspace, images);
+            if layout.image_state != ImageState::Pending {
+                return layout;
+            }
+            images.poll(Instant::now());
+            assert!(Instant::now() < deadline, "image preparation timed out");
+            std::thread::yield_now();
+        }
     }
 
     #[test]
@@ -1650,12 +1783,8 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("sample.png");
         write_png(&path);
-        let layout = render_in(
-            "before ![sample](sample.png) after",
-            80,
-            &Theme::default(),
-            directory.path(),
-        );
+        let layout =
+            render_inline_image_in("before ![sample](sample.png) after", 80, directory.path());
         let lines = layout
             .lines
             .iter()
@@ -1669,11 +1798,27 @@ mod tests {
     }
 
     #[test]
+    fn absolute_images_outside_the_workspace_are_rendered() {
+        let workspace = tempfile::tempdir().unwrap();
+        let scratchpad = tempfile::tempdir().unwrap();
+        let path = scratchpad.path().join("sample.png");
+        write_png(&path);
+
+        let layout = render_inline_image_in(
+            &format!("![sample]({})", path.display()),
+            80,
+            workspace.path(),
+        );
+
+        assert_eq!(layout.images.len(), 1);
+    }
+
+    #[test]
     fn image_failures_are_red_and_remain_inline() {
-        let layout = render(
+        let layout = render_inline_image_in(
             "before ![sample](/definitely/missing/image.png) after",
             80,
-            &Theme::default(),
+            Path::new("/workspace"),
         );
 
         assert_eq!(layout.lines.len(), 1);
@@ -1690,21 +1835,87 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_image_backends_render_images_as_markdown_links() {
+        let mut images = Cache::with_inline_images(false);
+        let layout = render_cached(
+            "before ![sample](outside.png) after",
+            80,
+            &Theme::default(),
+            Path::new("/workspace"),
+            &mut images,
+        );
+
+        assert!(layout.images.is_empty());
+        assert_eq!(
+            layout.lines[0].to_string(),
+            "before sample ↗ outside.png after"
+        );
+        assert_eq!(layout.links[0].len(), 1);
+        assert_eq!(layout.links[0][0].destination.as_ref(), "outside.png");
+        let label = layout.lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content == "sample")
+            .unwrap();
+        assert_eq!(label.style.fg, Some(Color::Blue));
+        assert!(label.style.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn native_images_do_not_map_invisible_link_text_into_selection() {
+        let directory = tempfile::tempdir().unwrap();
+        write_png(&directory.path().join("after"));
+        let markdown = "![sample](after) after";
+        let destination = markdown.find("after").unwrap();
+        let layout = render_inline_image_in(markdown, 80, directory.path());
+
+        assert!(
+            layout
+                .selections
+                .iter()
+                .flatten()
+                .all(|span| !span.source.contains(&destination))
+        );
+    }
+
+    #[test]
+    fn table_images_do_not_consume_later_fallback_selection_metadata() {
+        let markdown = concat!(
+            "| image |\n",
+            "|---|\n",
+            "| ![table](table.png) |\n\n",
+            "![sample](outside.png)",
+        );
+        let destination = markdown.rfind("outside.png").unwrap();
+        let mut images = Cache::with_inline_images(false);
+        let layout = render_cached(
+            markdown,
+            80,
+            &Theme::default(),
+            Path::new("/workspace"),
+            &mut images,
+        );
+
+        assert!(layout.selections.iter().flatten().any(|span| {
+            span.source.start >= destination
+                && span.source.end <= destination.saturating_add("outside.png".len())
+        }));
+    }
+
+    #[test]
     fn streaming_markdown_reuses_unchanged_image_protocols() {
         let directory = tempfile::tempdir().unwrap();
         write_png(&directory.path().join("sample.png"));
-        let mut images = Cache::default();
-        let first = render_cached(
+        let mut images = Cache::with_inline_images(true);
+        let first = render_cached_until_ready(
             "before ![sample](sample.png)",
             80,
-            &Theme::default(),
             directory.path(),
             &mut images,
         );
-        let second = render_cached(
+        let second = render_cached_until_ready(
             "before ![sample](sample.png) after",
             80,
-            &Theme::default(),
             directory.path(),
             &mut images,
         );
@@ -1715,7 +1926,7 @@ mod tests {
         ));
         let protocol = Arc::downgrade(&second.images[0].protocol);
         drop((first, second));
-        assert!(protocol.upgrade().is_none());
+        assert!(protocol.upgrade().is_some());
     }
 
     #[test]
@@ -1723,7 +1934,7 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         write_solid_png(&directory.path().join("tall.png"), 1, 1_000);
 
-        let layout = render_in("![tall](tall.png)", 80, &Theme::default(), directory.path());
+        let layout = render_inline_image_in("![tall](tall.png)", 80, directory.path());
 
         assert!(layout.images[0].protocol.size().height <= MAX_IMAGE_HEIGHT);
     }

--- a/bin/tact/src/tui/components/transcript/mod.rs
+++ b/bin/tact/src/tui/components/transcript/mod.rs
@@ -110,6 +110,7 @@ struct CachedEntry {
     selections: Vec<Vec<markdown::SourceSpan>>,
     envelopes: Vec<markdown::SourceEnvelope>,
     selection_source: Option<String>,
+    image_state: markdown::ImageState,
 }
 
 struct LayoutCache {
@@ -292,6 +293,10 @@ impl Transcript {
         self.cache.images.clear();
     }
 
+    pub(crate) fn refresh_terminal_images(&mut self) {
+        self.cache.refresh_terminal_images();
+    }
+
     pub(crate) const fn set_effort(&mut self, effort: ReasoningEffort) {
         self.effort = effort;
     }
@@ -330,6 +335,7 @@ impl Transcript {
             .into_iter()
             .chain(empty)
             .chain(self.retry_timer.and_then(|timer| timer.next_frame))
+            .chain(self.cache.images.animation_deadline())
             .min()
     }
 
@@ -459,13 +465,19 @@ impl Transcript {
             .as_mut()
             .is_some_and(|spinner| spinner.advance(now));
         let logo_changed = self.is_empty() && self.empty_logo.advance(now);
+        let images_changed = self.cache.poll_images(now);
         let activity = self.activity();
         ComponentUpdate {
             effects: (previous_activity != activity)
                 .then_some(activity)
                 .into_iter()
                 .collect(),
-            render: if retry_changed || timer_changed || tool_changed || logo_changed {
+            render: if retry_changed
+                || timer_changed
+                || tool_changed
+                || logo_changed
+                || images_changed
+            {
                 RenderRequest::Streaming
             } else {
                 RenderRequest::None
@@ -1282,6 +1294,33 @@ fn is_expandable(entry: &TranscriptEntry) -> bool {
 }
 
 impl LayoutCache {
+    fn refresh_terminal_images(&mut self) {
+        self.images.advance_terminal_generation();
+        self.entries
+            .retain(|_, entry| entry.image_state != markdown::ImageState::Pending);
+        for entry in self.entries.values_mut() {
+            for image in &mut entry.images {
+                image.retransmit = true;
+            }
+        }
+    }
+
+    fn poll_images(&mut self, now: Instant) -> bool {
+        let result = self.images.poll(now);
+        match result.layout_change {
+            image::LayoutChange::Ready => {
+                self.entries
+                    .retain(|_, entry| entry.image_state == markdown::ImageState::None);
+            }
+            image::LayoutChange::Pending => {
+                self.entries
+                    .retain(|_, entry| entry.image_state != markdown::ImageState::Pending);
+            }
+            image::LayoutChange::None => {}
+        }
+        result.render_changed
+    }
+
     fn forget(&mut self, id: EntryId) {
         self.entries.remove(&id);
         self.live_tool_durations.remove(&id);
@@ -1389,15 +1428,38 @@ impl LayoutCache {
             .map_or(&[], Vec::as_slice)
     }
 
-    fn image(&self, anchor: Anchor) -> Option<(usize, Arc<ratatui_image::sliced::SlicedProtocol>)> {
-        self.entries.get(&anchor.entry).and_then(|cached| {
-            cached.images.iter().find_map(|image| {
-                let end = image
-                    .line
-                    .saturating_add(usize::from(image.protocol.size().height));
-                (anchor.line >= image.line && anchor.line < end)
-                    .then(|| (image.line, Arc::clone(&image.protocol)))
-            })
+    fn image(
+        &mut self,
+        anchor: Anchor,
+    ) -> Option<(usize, Arc<ratatui_image::sliced::SlicedProtocol>)> {
+        let workspace = &self.workspace;
+        let images = &mut self.images;
+        self.entries.get_mut(&anchor.entry).and_then(|cached| {
+            let index = cached
+                .images
+                .partition_point(|image| image.line <= anchor.line)
+                .checked_sub(1)?;
+            let image = cached.images.get_mut(index)?;
+            let end = image
+                .line
+                .saturating_add(usize::from(image.protocol.size().height));
+            if anchor.line >= end {
+                return None;
+            }
+            if image.retransmit {
+                let size = image.protocol.size();
+                match images.retransmit(&image.destination, workspace, size) {
+                    image::LoadResult::Loaded(protocol) => {
+                        image.protocol = protocol;
+                        image.retransmit = false;
+                    }
+                    image::LoadResult::Failed | image::LoadResult::Unsupported => {
+                        image.retransmit = false;
+                    }
+                    image::LoadResult::Deferred => {}
+                }
+            }
+            Some((image.line, Arc::clone(&image.protocol)))
         })
     }
 
@@ -1465,6 +1527,7 @@ impl CachedEntry {
             selections: layout.selections,
             envelopes: layout.envelopes,
             selection_source: layout.selection_source,
+            image_state: layout.image_state,
         }
     }
 
@@ -1574,11 +1637,16 @@ impl Component for Transcript {
                     }
                 }));
             self.selection_rows.push((y, anchor));
-            if let Some((line, protocol)) = self.cache.image(anchor)
-                && visible_images
+            let covered_by_last_image =
+                visible_images
                     .last()
-                    .is_none_or(|(entry, start, ..)| (*entry, *start) != (anchor.entry, line))
-            {
+                    .is_some_and(|(entry, start, protocol, _)| {
+                        *entry == anchor.entry
+                            && anchor.line >= *start
+                            && anchor.line
+                                < start.saturating_add(usize::from(protocol.size().height))
+                    });
+            if !covered_by_last_image && let Some((line, protocol)) = self.cache.image(anchor) {
                 let offset = i32::try_from(anchor.line.saturating_sub(line)).unwrap_or(i32::MAX);
                 let position = i32::from(y)
                     .saturating_sub(i32::from(transcript_area.y))
@@ -1886,6 +1954,7 @@ fn layout_without_links(lines: Vec<Line<'static>>) -> markdown::Layout {
         selections,
         envelopes: Vec::new(),
         selection_source: None,
+        image_state: markdown::ImageState::None,
     }
 }
 
@@ -1931,6 +2000,7 @@ fn render_user(text: &str, width: u16, theme: &Theme) -> markdown::Layout {
             std::borrow::Cow::Borrowed(_) => None,
             std::borrow::Cow::Owned(text) => Some(text),
         },
+        image_state: markdown::ImageState::None,
     }
 }
 
@@ -1960,7 +2030,12 @@ mod tests {
     };
     use ratatui::{Terminal, backend::TestBackend, layout::Position, style::Color};
     use serde_json::{json, value::to_raw_value};
-    use std::{fs::File, path::Path, sync::Arc, time::Duration};
+    use std::{
+        fs::File,
+        path::Path,
+        sync::Arc,
+        time::{Duration, Instant},
+    };
     use tact_subagents::{AgentMessageUpdate, MessageSender};
 
     #[test]
@@ -2113,13 +2188,58 @@ mod tests {
         terminal.backend().clone()
     }
 
+    fn render_until_image_ready(
+        transcript: &mut Transcript,
+        width: u16,
+        height: u16,
+    ) -> TestBackend {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let backend = render(transcript, width, height);
+            if transcript
+                .cache
+                .entries
+                .values()
+                .any(|entry| !entry.images.is_empty())
+            {
+                return backend;
+            }
+            transcript.update(TranscriptEvent::AnimationFrame(Instant::now()));
+            assert!(Instant::now() < deadline, "image preparation timed out");
+            std::thread::yield_now();
+        }
+    }
+
     fn write_png(path: &Path) {
+        write_png_size(path, 1, 1);
+    }
+
+    fn write_png_size(path: &Path, width: u32, height: u32) {
         let file = File::create(path).unwrap();
-        let mut encoder = png::Encoder::new(file, 1, 1);
+        let mut encoder = png::Encoder::new(file, width, height);
         encoder.set_color(png::ColorType::Rgb);
         encoder.set_depth(png::BitDepth::Eight);
         let mut writer = encoder.write_header().unwrap();
-        writer.write_image_data(&[0xff, 0, 0]).unwrap();
+        writer
+            .write_image_data(&[0xff, 0, 0].repeat((width * height) as usize))
+            .unwrap();
+    }
+
+    fn transcript_with_image(workspace: &Path, text: &str) -> Transcript {
+        let mut transcript = Transcript::new();
+        transcript.cache.images = super::image::Cache::with_inline_images(true);
+        transcript.set_workspace(workspace);
+        transcript.update(TranscriptEvent::Record(agent_with_payload(
+            1,
+            AgentEventKind::AssistantMessage,
+            json!({
+                "model_call_index": 1,
+                "item_id": "answer",
+                "phase": "final_answer",
+                "text": text,
+            }),
+        )));
+        transcript
     }
 
     fn scroll(transcript: &mut Transcript, event: Event) {
@@ -2152,20 +2272,10 @@ mod tests {
     fn assistant_markdown_images_render_between_surrounding_text_rows() {
         let workspace = tempfile::tempdir().unwrap();
         write_png(&workspace.path().join("sample.png"));
-        let mut transcript = Transcript::new();
-        transcript.set_workspace(workspace.path());
-        transcript.update(TranscriptEvent::Record(agent_with_payload(
-            1,
-            AgentEventKind::AssistantMessage,
-            json!({
-                "model_call_index": 1,
-                "item_id": "answer",
-                "phase": "final_answer",
-                "text": "before ![sample](sample.png) after",
-            }),
-        )));
+        let mut transcript =
+            transcript_with_image(workspace.path(), "before ![sample](sample.png) after");
 
-        let backend = render(&mut transcript, 20, 5);
+        let backend = render_until_image_ready(&mut transcript, 20, 5);
         let rows = backend
             .buffer()
             .content()
@@ -2177,6 +2287,123 @@ mod tests {
 
         assert_eq!(after, before + 2);
         assert!(rows[before + 1].chars().any(|character| character != ' '));
+    }
+
+    #[test]
+    fn refreshing_terminal_images_preserves_their_dimensions() {
+        let workspace = tempfile::tempdir().unwrap();
+        write_png_size(&workspace.path().join("sample.png"), 80, 40);
+        let mut transcript = transcript_with_image(workspace.path(), "![sample](sample.png)");
+
+        let _ = render_until_image_ready(&mut transcript, 20, 3);
+        let original = Arc::clone(
+            &transcript
+                .cache
+                .entries
+                .values()
+                .find_map(|entry| entry.images.first())
+                .unwrap()
+                .protocol,
+        );
+        let original_size = original.size();
+        assert!(original_size.width > 1);
+        assert!(original_size.height > 1);
+
+        transcript.refresh_terminal_images();
+        let pending = &transcript
+            .cache
+            .entries
+            .values()
+            .find_map(|entry| entry.images.first())
+            .unwrap()
+            .protocol;
+        assert!(Arc::ptr_eq(&original, pending));
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let _ = render(&mut transcript, 20, 3);
+            transcript.update(TranscriptEvent::AnimationFrame(Instant::now()));
+            let retransmitted = &transcript
+                .cache
+                .entries
+                .values()
+                .find_map(|entry| entry.images.first())
+                .unwrap()
+                .protocol;
+            if !Arc::ptr_eq(&original, retransmitted) {
+                assert_eq!(retransmitted.size(), original_size);
+                break;
+            }
+            assert!(Instant::now() < deadline, "image retransmission timed out");
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn restored_images_present_a_link_before_native_image_hydration() {
+        let workspace = tempfile::tempdir().unwrap();
+        write_png(&workspace.path().join("sample.png"));
+        let mut transcript =
+            transcript_with_image(workspace.path(), "before ![sample](sample.png) after");
+        let first = render(&mut transcript, 40, 5);
+        let first_text = first
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(first_text.contains("sample ↗ sample.png"));
+        assert!(
+            transcript
+                .cache
+                .entries
+                .values()
+                .all(|entry| entry.images.is_empty())
+        );
+        assert!(transcript.animation_deadline().is_some());
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut rendered_completion = false;
+        while transcript
+            .cache
+            .entries
+            .values()
+            .all(|entry| entry.images.is_empty())
+        {
+            let update = transcript.update(TranscriptEvent::AnimationFrame(Instant::now()));
+            rendered_completion |= update.render == RenderRequest::Streaming;
+            let _ = render(&mut transcript, 40, 5);
+            assert!(Instant::now() < deadline, "image hydration timed out");
+            std::thread::yield_now();
+        }
+        assert!(rendered_completion);
+
+        assert!(
+            transcript
+                .cache
+                .entries
+                .values()
+                .any(|entry| !entry.images.is_empty())
+        );
+    }
+
+    #[test]
+    fn pending_image_hydration_restarts_after_terminal_refresh() {
+        let workspace = tempfile::tempdir().unwrap();
+        write_png(&workspace.path().join("sample.png"));
+        let mut transcript = transcript_with_image(workspace.path(), "![sample](sample.png)");
+
+        let _ = render(&mut transcript, 20, 3);
+        transcript.refresh_terminal_images();
+        let _ = render_until_image_ready(&mut transcript, 20, 3);
+
+        assert!(
+            transcript
+                .cache
+                .entries
+                .values()
+                .any(|entry| !entry.images.is_empty())
+        );
     }
 
     #[test]

--- a/bin/tact/src/tui/components/transcript/tool.rs
+++ b/bin/tact/src/tui/components/transcript/tool.rs
@@ -60,6 +60,7 @@ pub(super) fn render_layout(
             selections: Vec::new(),
             envelopes: Vec::new(),
             selection_source: None,
+            image_state: super::markdown::ImageState::None,
         };
     }
     let detail_width = width.saturating_sub(6).max(1);
@@ -80,6 +81,7 @@ pub(super) fn render_layout(
             images: Vec::new(),
             envelopes: Vec::new(),
             selection_source: None,
+            image_state: super::markdown::ImageState::None,
         };
     }
     let detail_start = lines.len();
@@ -110,6 +112,7 @@ pub(super) fn render_layout(
         selections,
         envelopes: Vec::new(),
         selection_source,
+        image_state: super::markdown::ImageState::None,
     }
 }
 

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -1167,6 +1167,7 @@ pub(crate) async fn run(
             }, if editor_task.is_some() && !stopping => {
                 editor_task = None;
                 terminal.resume().map_err(RuntimeError::Terminal)?;
+                app.refresh_terminal_images();
                 input = Some(EventStream::new());
                 match result.map_err(RuntimeError::ExternalEditorTask)?? {
                     EditorCompletion::Draft { pane, outcome: EditorOutcome::Updated(draft) } => {


### PR DESCRIPTION
## Summary

- render local Markdown images inline only when the terminal supports a native image protocol
- degrade unsupported backends to ordinary clickable Markdown links
- accept absolute scratchpad and other local paths outside the workspace
- move metadata, decode, resize, and protocol preparation off the render thread
- bound image work and caches while preserving independent placement sizes
- hydrate restored transcripts without blocking first paint
- lazily retransmit images after focus and resume without changing their dimensions
- avoid redraw-time filesystem work and unnecessary image reconstruction

## Testing

- cargo check --all-features
- just check-fmt
- just clippy
- just test (946 tests)

## Stack

1. #179 — Markdown image-link prompting
2. This PR
3. #180 — prepare 0.6.6

Depends on #179. No matching open issue exists to close.
