### PR TITLE
fix(session): resume snapshots across tool contract changes

### DIFF
--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -7,14 +7,14 @@ mod orchestration;
 use crate::{
     app::{
         config::{Config, ReasoningEffort, ReasoningMode, SkillsConfig},
-        error::{ConfigError, Result, RuntimeError},
+        error::{ConfigError, Error, Result, RuntimeError},
         hook,
     },
     core::extensions::{
         CurrentSessionTool, Skill, SkillCatalog, mcp_provider,
         sessions::{FindSessionsTool, ReadSessionTool},
     },
-    tui::session::ResumeState,
+    tui::session::{ResumeState, migrate_snapshot_contract},
 };
 use nanocodex::{
     AgentEvents, Model, Nanocodex, NanocodexError, OpenAi, Tools, TurnControl,
@@ -322,11 +322,21 @@ impl ConfiguredAgent {
                 .map_err(RuntimeError::InvalidSessionId)?;
             builder = builder.session_id(session_id);
         }
-        if let Some(snapshot) = snapshot {
-            builder = builder.resume(snapshot);
-        }
-
-        let (agent, events) = builder.build()?;
+        let (agent, events) = match snapshot {
+            Some(snapshot) => match builder.clone().resume(snapshot.clone()).build() {
+                Ok(result) => Ok(result),
+                Err(error @ NanocodexError::InvalidSessionSnapshot(_)) => {
+                    // The retry revalidates every retained field, so avoid coupling the fallback
+                    // to one Nanocodex error message.
+                    match migrate_snapshot_contract(&snapshot)? {
+                        Some(snapshot) => builder.resume(snapshot).build().map_err(Error::from),
+                        None => Err(error.into()),
+                    }
+                }
+                Err(error) => Err(error.into()),
+            },
+            None => builder.build().map_err(Error::from),
+        }?;
         Ok(Self {
             agent,
             events,
@@ -711,11 +721,11 @@ impl Cancellation {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT, SCRATCHPAD_INSTRUCTIONS,
-        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS_SELECTED_ONLY,
-        TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS, configured_memory_store,
-        fresh_instructions, reconcile_tact_instructions, session_instructions,
-        session_instructions_with_luna,
+        ConfiguredAgent, CurrentSessionTool, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT,
+        SCRATCHPAD_INSTRUCTIONS, SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS,
+        SUBAGENT_INSTRUCTIONS_SELECTED_ONLY, TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS,
+        configured_memory_store, fresh_instructions, migrate_snapshot_contract,
+        reconcile_tact_instructions, session_instructions, session_instructions_with_luna,
     };
     use crate::{
         app::{
@@ -725,7 +735,8 @@ mod tests {
         core::extensions::Skill,
     };
     use nanocodex::{
-        Nanocodex, OpenAi,
+        Nanocodex, NanocodexError, OpenAi, Tools,
+        agent::session::SessionSnapshot,
         oai::{
             ResponseError,
             tower::{ResponsesAttempt, ResponsesServiceConfig, ResponsesServiceResponse},
@@ -734,6 +745,7 @@ mod tests {
     use std::{
         fs,
         future::{Pending, pending},
+        path::Path,
         result::Result as StdResult,
         sync::Arc,
         task::{Context, Poll},
@@ -798,6 +810,51 @@ mod tests {
             self.called.notify_one();
             pending()
         }
+    }
+
+    fn snapshot_with_older_tool_contract(workspace: &Path) -> SessionSnapshot {
+        serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "model": nanocodex::oai::MODEL,
+            "lineage_id": "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            "prompt_cache_key": "older-tool-contract",
+            "workspace": workspace.to_str().unwrap(),
+            "request_prefix": [
+                {"type": "additional_tools", "role": "developer", "tools": []},
+                {"type": "message", "role": "developer", "content": []}
+            ],
+            "canonical_context": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "canonical"}]
+            },
+            "history": [
+                {"type": "message", "role": "user",
+                 "content": [{"type": "input_text", "text": "hello"}]}
+            ]
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn resumed_sessions_adopt_tools_added_after_the_checkpoint() {
+        let workspace = tempdir().unwrap();
+        let snapshot = snapshot_with_older_tool_contract(workspace.path());
+        let openai = OpenAi::builder("test-key").build().unwrap();
+        let tools = Tools::builder().tool(CurrentSessionTool).build().unwrap();
+        let builder = Nanocodex::builder(openai)
+            .workspace(workspace.path())
+            .instructions("stored instructions")
+            .tools(tools);
+
+        assert!(matches!(
+            builder.clone().resume(snapshot.clone()).build(),
+            Err(NanocodexError::InvalidSessionSnapshot(_))
+        ));
+        let snapshot = migrate_snapshot_contract(&snapshot).unwrap().unwrap();
+        let (agent, events) = builder.resume(snapshot).build().unwrap();
+
+        agent.shutdown().await.unwrap();
+        drop(events);
     }
 
     #[test]

--- a/bin/tact/src/tui/session.rs
+++ b/bin/tact/src/tui/session.rs
@@ -18,6 +18,7 @@ use std::{
 use thiserror::Error;
 
 const RESUME_STATE_FORMAT_VERSION: u32 = 2;
+const CONTRACT_MIGRATION_SNAPSHOT_VERSION: u32 = 1;
 pub(crate) const MAX_RECENT_PROMPTS: usize = 100;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -81,6 +82,10 @@ pub(crate) enum SessionError {
         "session {session_id} uses resume-state format {found}; expected {RESUME_STATE_FORMAT_VERSION}"
     )]
     IncompatibleCheckpoint { session_id: String, found: u32 },
+    #[error("failed to encode the session snapshot for contract migration: {0}")]
+    EncodeContractMigration(#[source] serde_json::Error),
+    #[error("failed to decode the migrated session snapshot: {0}")]
+    DecodeContractMigration(#[source] serde_json::Error),
     #[error("session lineage contains a cycle at {session_id}")]
     LineageCycle { session_id: String },
     #[error("session lineage references missing ancestor {session_id}")]
@@ -148,6 +153,29 @@ pub(crate) fn load_checkpoint(
         stored.instructions,
         stored.skills_catalog_present,
     ))
+}
+
+pub(crate) fn migrate_snapshot_contract(
+    snapshot: &SessionSnapshot,
+) -> Result<Option<SessionSnapshot>, SessionError> {
+    // Nanocodex snapshot format 1 interprets an absent request prefix as a history resume. Keep
+    // this wire adaptation version-gated so a dependency update cannot silently rewrite a new
+    // snapshot contract.
+    if snapshot.version() != CONTRACT_MIGRATION_SNAPSHOT_VERSION {
+        return Ok(None);
+    }
+    let mut value =
+        serde_json::to_value(snapshot).map_err(SessionError::EncodeContractMigration)?;
+    if value
+        .as_object_mut()
+        .and_then(|snapshot| snapshot.remove("request_prefix"))
+        .is_none()
+    {
+        return Ok(None);
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(SessionError::DecodeContractMigration)
 }
 
 #[allow(dead_code, reason = "used by session benchmarks")]
@@ -370,7 +398,10 @@ pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{encode_checkpoint, load_checkpoint, load_transcript, model, save_checkpoint};
+    use super::{
+        encode_checkpoint, load_checkpoint, load_transcript, migrate_snapshot_contract, model,
+        save_checkpoint,
+    };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::{
@@ -697,6 +728,45 @@ mod tests {
         assert_eq!(catalog, Some(true));
         assert!(directory.path().join("sessions/v2.sqlite3").is_file());
         assert!(!directory.path().join("checkpoints").exists());
+    }
+
+    #[test]
+    fn contract_migration_discards_only_the_stored_request_prefix() {
+        let snapshot = snapshot("lineage");
+        let original = serde_json::to_value(&snapshot).unwrap();
+        let mut expected = original.clone();
+        expected
+            .as_object_mut()
+            .unwrap()
+            .remove("request_prefix")
+            .unwrap();
+
+        let migrated = migrate_snapshot_contract(&snapshot).unwrap().unwrap();
+
+        assert_eq!(serde_json::to_value(migrated).unwrap(), expected);
+        assert!(original.get("request_prefix").is_some());
+    }
+
+    #[test]
+    fn history_snapshots_do_not_need_contract_migration() {
+        let mut snapshot = serde_json::to_value(snapshot("lineage")).unwrap();
+        snapshot
+            .as_object_mut()
+            .unwrap()
+            .remove("request_prefix")
+            .unwrap();
+        let snapshot = serde_json::from_value(snapshot).unwrap();
+
+        assert!(migrate_snapshot_contract(&snapshot).unwrap().is_none());
+    }
+
+    #[test]
+    fn unknown_snapshot_formats_are_not_rewritten() {
+        let mut snapshot = serde_json::to_value(snapshot("lineage")).unwrap();
+        snapshot["version"] = json!(2);
+        let snapshot = serde_json::from_value(snapshot).unwrap();
+
+        assert!(migrate_snapshot_contract(&snapshot).unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Adding or changing tools could prevent older sessions from resuming because their stored request prefix no longer matched the current tool contract. This PR preserves exact resume when the contract still matches, retaining the existing cache behavior. When exact resume rejects a version 1 snapshot, tact removes only the stored request prefix and retries through nanocodex's history-resume path. The conversation history, instructions, workspace, and lineage are preserved while the session adopts the current tools.