### PR TITLE
feat(cli): add startup model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ For scripts and integrations, `tact run` submits one prompt and streams Nanocode
 tact run "inspect the workspace"
 ```
 
+Choose the model for a newly started agent without changing configuration:
+
+```sh
+tact --model terra
+tact --model luna run "inspect the workspace"
+```
+
+`--model` accepts `sol`, `terra`, or `luna`; `TACT_MODEL` provides the same per-launch setting.
+Resumed sessions continue with the model recorded when they were created.
+
 ## Configuration
 
 The configuration file is optional. Tact reads `$TACT_HOME/config.toml`, or

--- a/bin/tact/src/app/cli.rs
+++ b/bin/tact/src/app/cli.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use clap::{ArgAction, Parser, Subcommand, builder::NonEmptyStringValueParser};
 use crossterm::style::{Color, Stylize};
+use nanocodex::Model;
 use std::{env, env::VarError, fmt, path::PathBuf};
 use tokio_util::sync::CancellationToken;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
@@ -85,6 +86,10 @@ pub(crate) struct Cli {
         value_name = "MODE"
     )]
     reasoning_mode: Option<ReasoningMode>,
+
+    /// Model used when starting a new agent.
+    #[arg(long, global = true, env = "TACT_MODEL", value_name = "MODEL")]
+    model: Option<Model>,
 
     /// Maximum number of sub-agents that may run concurrently.
     #[arg(long, global = true, env = "TACT_MAX_SUBAGENTS", value_name = "COUNT")]
@@ -359,14 +364,17 @@ impl Cli {
         } else {
             Config::load(overrides)?
         };
+        let model = self.model.unwrap_or_default();
 
         match self.command {
-            Some(Command::Resume) => Self::run_tui(config, tui::StartupMode::ResumeSelector).await,
-            Some(command) => command.run_with_config(&config).await,
+            Some(Command::Resume) => {
+                Self::run_tui(config, tui::StartupMode::ResumeSelector(model)).await
+            }
+            Some(command) => command.run_with_config(&config, model).await,
             None => {
                 let startup = self
                     .resume
-                    .map_or(tui::StartupMode::NewSession, |session_id| {
+                    .map_or(tui::StartupMode::NewSession(model), |session_id| {
                         tui::StartupMode::ResumeSession(session_id)
                     });
                 Self::run_tui(config, startup).await
@@ -444,7 +452,7 @@ impl Command {
         Ok(())
     }
 
-    async fn run_with_config(self, config: &Config) -> Result<()> {
+    async fn run_with_config(self, config: &Config, model: Model) -> Result<()> {
         match self {
             Self::Auth { command } => command.run(config).await.map_err(Into::into),
             Self::Config { command } => command.run(config),
@@ -456,6 +464,7 @@ impl Command {
             } => {
                 Self::run_agent(
                     config,
+                    model,
                     prompt,
                     #[cfg(feature = "harbor-evals")]
                     orchestration_log,
@@ -470,12 +479,14 @@ impl Command {
 
     async fn run_agent(
         config: &Config,
+        model: Model,
         prompt: String,
         #[cfg(feature = "harbor-evals")] orchestration_log: Option<PathBuf>,
     ) -> Result<()> {
         let shutdown = CancellationToken::new();
         let run = ConfiguredAgent::run_from_config(
             config,
+            model,
             prompt,
             shutdown.clone(),
             #[cfg(feature = "harbor-evals")]
@@ -728,6 +739,7 @@ mod tests {
         error::{ConfigError, Error},
     };
     use clap::{CommandFactory, Parser, error::ErrorKind};
+    use nanocodex::Model;
     use std::{
         env::VarError,
         ffi::OsString,
@@ -804,6 +816,13 @@ mod tests {
     }
 
     #[test]
+    fn model_selects_the_initial_agent() {
+        let cli = Cli::try_parse_from(["tact", "--model", "terra"]).unwrap();
+
+        assert_eq!(cli.model, Some(Model::Terra));
+    }
+
+    #[test]
     fn resume_selects_a_persisted_tui_session() {
         let cli = Cli::try_parse_from(["tact", "--resume", "session one"]).unwrap();
 
@@ -831,6 +850,8 @@ mod tests {
             "chatgpt",
             "--auth-file",
             "auth.json",
+            "--model",
+            "luna",
             "--max-subagents",
             "12",
         ])
@@ -839,6 +860,7 @@ mod tests {
         assert_eq!(cli.config.unwrap(), PathBuf::from("tact.toml"));
         assert_eq!(cli.auth, Some(AuthMode::ChatGpt));
         assert_eq!(cli.auth_file.unwrap(), PathBuf::from("auth.json"));
+        assert_eq!(cli.model, Some(Model::Luna));
         assert_eq!(cli.max_subagents, Some(12));
         assert!(matches!(cli.command, Some(Command::Config { .. })));
     }
@@ -1318,6 +1340,7 @@ mod tests {
             ("workspace", "TACT_WORKSPACE"),
             ("thinking", "TACT_THINKING"),
             ("reasoning_mode", "TACT_REASONING_MODE"),
+            ("model", "TACT_MODEL"),
             ("max_subagents", "TACT_MAX_SUBAGENTS"),
             ("instructions", "TACT_INSTRUCTIONS"),
             ("append_instructions", "TACT_APPEND_INSTRUCTIONS"),

--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -166,32 +166,29 @@ enum Cancellation {
 impl ConfiguredAgent {
     pub(crate) async fn run_from_config(
         config: &Config,
+        model: Model,
         prompt: String,
         shutdown: CancellationToken,
         #[cfg(feature = "harbor-evals")] orchestration_log: Option<PathBuf>,
     ) -> Result<()> {
-        let result = Self::from_config(config)?
-            .run(
-                prompt,
-                shutdown,
-                io::stdout(),
-                #[cfg(feature = "harbor-evals")]
-                orchestration_log,
-            )
-            .await;
+        let result = Self::from_config_with_model(
+            config,
+            config.agent().thinking(),
+            config.agent().reasoning_mode(),
+            model,
+        )?
+        .run(
+            prompt,
+            shutdown,
+            io::stdout(),
+            #[cfg(feature = "harbor-evals")]
+            orchestration_log,
+        )
+        .await;
         if let Some(command) = config.agent().completion_hook() {
             drop(hook::execute(command, config.agent().workspace()).await);
         }
         result
-    }
-
-    pub(crate) fn from_config(config: &Config) -> Result<Self> {
-        Self::from_config_with_model(
-            config,
-            config.agent().thinking(),
-            config.agent().reasoning_mode(),
-            Model::Sol,
-        )
     }
 
     pub(crate) fn from_config_with_model(

--- a/bin/tact/src/tui/components/app.rs
+++ b/bin/tact/src/tui/components/app.rs
@@ -68,6 +68,7 @@ pub(crate) enum AppEvent {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        model: Model,
         skills: Arc<[Skill]>,
     },
     HandoffCancelled(PaneId),
@@ -265,6 +266,7 @@ impl AppNode {
                 effort,
                 reasoning_mode,
                 fast_mode,
+                model,
                 skills,
             } => {
                 let workspace = self.workspace.clone();
@@ -280,6 +282,7 @@ impl AppNode {
                         DraftReset::Clear,
                     );
                     root.component_mut().set_fast_mode(fast_mode);
+                    root.component_mut().set_model(model);
                     root.component_mut().set_skills(skills);
                 }
                 self.update_root(pane, RootEvent::HandoffFinished(prompt))
@@ -1014,7 +1017,7 @@ mod tests {
     }
 
     #[test]
-    fn handoff_starts_a_fresh_session_with_an_editable_draft() {
+    fn handoff_starts_a_fresh_session_with_an_editable_draft_and_selected_model() {
         let mut app = app();
 
         let update = app.update(AppEvent::HandoffReady {
@@ -1023,6 +1026,7 @@ mod tests {
             effort: ReasoningEffort::High,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
+            model: Model::Luna,
             skills: Arc::from([]),
         });
 
@@ -1032,6 +1036,7 @@ mod tests {
             root.composer().draft(),
             "Continue from the validated parser design."
         );
+        assert_eq!(root.composer().model(), Model::Luna);
     }
 
     #[test]

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -232,7 +232,7 @@ pub(crate) enum RootEffect {
     OpenConfigEditor,
     OpenLink(String),
     ReloadConfig,
-    NewSession,
+    NewSession(Model),
     LoadSessions(SessionListKind),
     LoadRecentPrompts(Vec<RecentPromptDraft>),
     LoadMemories,
@@ -1681,7 +1681,7 @@ impl RootNode {
                 now: Instant::now(),
             });
         ComponentUpdate {
-            effects: vec![RootEffect::NewSession],
+            effects: vec![RootEffect::NewSession(self.composer.component().model())],
             render: RenderRequest::Immediate,
         }
     }
@@ -6102,6 +6102,7 @@ mod tests {
     #[test]
     fn new_session_action_clears_the_completed_thread_after_runtime_replacement() {
         let mut root = RootNode::new(Path::new("/work"), ReasoningEffort::Medium);
+        root.set_model(Model::Luna);
         for character in "old prompt".chars() {
             root.update(key(KeyCode::Char(character), KeyModifiers::NONE));
         }
@@ -6116,7 +6117,7 @@ mod tests {
 
         let requested = root.update(key(KeyCode::Enter, KeyModifiers::NONE));
 
-        assert_eq!(requested.effects, [RootEffect::NewSession]);
+        assert_eq!(requested.effects, [RootEffect::NewSession(Model::Luna)]);
         assert!(root.overlay.is_none());
         assert!(!root.interactive);
 

--- a/bin/tact/src/tui/handoff_controller.rs
+++ b/bin/tact/src/tui/handoff_controller.rs
@@ -3,6 +3,7 @@ use crate::{
     core::ConfiguredAgent,
     tui::{pane::PaneId, worker::AuxiliaryError},
 };
+use nanocodex::Model;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -26,6 +27,7 @@ pub(crate) struct PreparedHandoff {
     pub(crate) effort: ReasoningEffort,
     pub(crate) reasoning_mode: ReasoningMode,
     pub(crate) fast_mode: bool,
+    pub(crate) model: Model,
     pub(crate) configured: ConfiguredAgent,
 }
 

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -444,9 +444,9 @@ pub(crate) async fn run(
     let initial_max_subagents = config.agent().max_subagents();
     let preferred_reasoning_mode = config.agent().reasoning_mode();
     let open_resume_selector = matches!(&startup, StartupMode::ResumeSelector(_));
-    let (resume_session_id, startup_model) = match startup {
-        StartupMode::NewSession(model) | StartupMode::ResumeSelector(model) => (None, model),
-        StartupMode::ResumeSession(session_id) => (Some(session_id), Model::Sol),
+    let (resume_session_id, fresh_model) = match startup {
+        StartupMode::NewSession(model) | StartupMode::ResumeSelector(model) => (None, Some(model)),
+        StartupMode::ResumeSession(session_id) => (Some(session_id), None),
     };
     let resuming = resume_session_id.is_some();
     let (configured, restored_projection, reasoning_mode, model, next_sequence) =
@@ -488,16 +488,17 @@ pub(crate) async fn run(
             .await
             .map_err(RuntimeError::SessionTask)??
         } else {
+            let model = fresh_model.expect("a fresh TUI startup must select a model");
             (
                 ConfiguredAgent::from_config_with_model(
                     &config,
                     initial_effort,
                     preferred_reasoning_mode,
-                    startup_model,
+                    model,
                 )?,
                 None,
                 preferred_reasoning_mode,
-                startup_model,
+                model,
                 1,
             )
         };
@@ -2203,7 +2204,7 @@ fn apply_pane_effect(
                 context.scheduler,
             ),
         },
-        components::RootEffect::NewSession => {
+        components::RootEffect::NewSession(model) => {
             *context.input = None;
             let effort = context.config.agent().thinking();
             let reasoning_mode = context.config.agent().reasoning_mode();
@@ -2214,7 +2215,7 @@ fn apply_pane_effect(
                     &config,
                     effort,
                     reasoning_mode,
-                    Model::Sol,
+                    model,
                     None,
                     None,
                 );
@@ -2223,7 +2224,7 @@ fn apply_pane_effect(
                     effort,
                     reasoning_mode,
                     fast_mode,
-                    Model::Sol,
+                    model,
                     components::DraftReset::Clear,
                     configured,
                 )

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -77,9 +77,9 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 pub(crate) enum StartupMode {
-    NewSession,
+    NewSession(Model),
     ResumeSession(String),
-    ResumeSelector,
+    ResumeSelector(Model),
 }
 
 type EditorTask =
@@ -443,10 +443,10 @@ pub(crate) async fn run(
     let initial_fast_mode = config.agent().fast_mode();
     let initial_max_subagents = config.agent().max_subagents();
     let preferred_reasoning_mode = config.agent().reasoning_mode();
-    let open_resume_selector = matches!(&startup, StartupMode::ResumeSelector);
-    let resume_session_id = match startup {
-        StartupMode::ResumeSession(session_id) => Some(session_id),
-        StartupMode::NewSession | StartupMode::ResumeSelector => None,
+    let open_resume_selector = matches!(&startup, StartupMode::ResumeSelector(_));
+    let (resume_session_id, startup_model) = match startup {
+        StartupMode::NewSession(model) | StartupMode::ResumeSelector(model) => (None, model),
+        StartupMode::ResumeSession(session_id) => (Some(session_id), Model::Sol),
     };
     let resuming = resume_session_id.is_some();
     let (configured, restored_projection, reasoning_mode, model, next_sequence) =
@@ -489,10 +489,15 @@ pub(crate) async fn run(
             .map_err(RuntimeError::SessionTask)??
         } else {
             (
-                ConfiguredAgent::from_config(&config)?,
+                ConfiguredAgent::from_config_with_model(
+                    &config,
+                    initial_effort,
+                    preferred_reasoning_mode,
+                    startup_model,
+                )?,
                 None,
                 preferred_reasoning_mode,
-                Model::Sol,
+                startup_model,
                 1,
             )
         };

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -1239,12 +1239,13 @@ pub(crate) async fn run(
                             effort,
                             reasoning_mode,
                             fast_mode,
+                            model,
                             configured,
                         } = prepared;
                         let skills = install_configured_agent(
                             pane,
                             configured,
-                            PaneSettings::new(effort, reasoning_mode, fast_mode, Model::Sol),
+                            PaneSettings::new(effort, reasoning_mode, fast_mode, model),
                             &config,
                             &mut panes,
                             &commands,
@@ -1261,6 +1262,7 @@ pub(crate) async fn run(
                                 effort,
                                 reasoning_mode,
                                 fast_mode,
+                                model,
                                 skills,
                             }),
                             &mut scheduler,
@@ -2549,6 +2551,7 @@ fn start_handoff(context: &mut EffectContext<'_>, pane: PaneId) {
     let pane_generation = runtime.generation;
     let id = TurnId::new(runtime.next_turn);
     runtime.next_turn = runtime.next_turn.saturating_add(1);
+    let model = runtime.current_model;
     let commands = context.commands.clone();
     let config = context.config.clone();
     let started =
@@ -2578,7 +2581,7 @@ fn start_handoff(context: &mut EffectContext<'_>, pane: PaneId) {
                             )),
                         }
                     };
-                    let result = prepare_handoff(result, config, cancellation).await;
+                    let result = prepare_handoff(result, config, model, cancellation).await;
                     HandoffCompletion { identity, result }
                 })
             });
@@ -2596,6 +2599,7 @@ fn start_handoff(context: &mut EffectContext<'_>, pane: PaneId) {
 async fn prepare_handoff(
     result: std::result::Result<String, AuxiliaryError>,
     config: Config,
+    model: Model,
     cancellation: CancellationToken,
 ) -> std::result::Result<PreparedHandoff, AuxiliaryError> {
     let prompt = result?;
@@ -2616,7 +2620,7 @@ async fn prepare_handoff(
             &config,
             effort,
             reasoning_mode,
-            Model::Sol,
+            model,
             None,
             None,
         )
@@ -2635,6 +2639,7 @@ async fn prepare_handoff(
         effort,
         reasoning_mode,
         fast_mode,
+        model,
         configured,
     })
 }


### PR DESCRIPTION
## Summary

- add `--model MODEL` and `TACT_MODEL` to select the model for a newly started agent
- apply the selected model to a fresh interactive session and to `tact run`
- keep the default model unchanged when no override is provided
- document the option and cover CLI parsing and global-option behavior

## Scope

- Keep model selection per launch; do not persist it to Tact configuration.
- Preserve the model recorded by an existing session when using `--resume` or selecting a saved session.
- Reuse Nanocodex's existing model parser and supported model set; do not add a Tact-specific model registry.

## Validation

- `cargo test -p tact app::cli::tests`
- `cargo check --all-features`
- `cargo fmt --all -- --check`
- `cargo run -p tact -- --help`