### PR TITLE
feat(config): enable one-million-token context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,8 +2536,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223def7aa7a85ccdb7bc0ecfef6a9f36ee332db6730c10a757cfd382e08487d4"
+source = "git+https://github.com/birdmanmandbir/nanocodex.git?rev=82b1e046d323fcafea46ab6714f5a339260f45f3#82b1e046d323fcafea46ab6714f5a339260f45f3"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-oai-api",
@@ -2547,8 +2546,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-agent"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bf178f13a34a0e77a4039644d48e823b613c7ebbcfcc6fbf88f7442cb924f8"
+source = "git+https://github.com/birdmanmandbir/nanocodex.git?rev=82b1e046d323fcafea46ab6714f5a339260f45f3#82b1e046d323fcafea46ab6714f5a339260f45f3"
 dependencies = [
  "chrono",
  "futures-util",
@@ -2570,8 +2568,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-oai-api"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb1a99937e9af21fb452d6ebfde1151d2cfaa763c98e22540593a5e22525478"
+source = "git+https://github.com/birdmanmandbir/nanocodex.git?rev=82b1e046d323fcafea46ab6714f5a339260f45f3#82b1e046d323fcafea46ab6714f5a339260f45f3"
 dependencies = [
  "async-trait",
  "base64",
@@ -2597,8 +2594,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2749e5464e7251c1f67e8f1ab6c608c175f66a1c5c64e0fbd8b27b7928cc343"
+source = "git+https://github.com/birdmanmandbir/nanocodex.git?rev=82b1e046d323fcafea46ab6714f5a339260f45f3#82b1e046d323fcafea46ab6714f5a339260f45f3"
 dependencies = [
  "async-trait",
  "base64",
@@ -2628,8 +2624,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools-macros"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e27623b5720bc25e4d52e10eba53c0fac0a68213b55b9f1fd91021165429930"
+source = "git+https://github.com/birdmanmandbir/nanocodex.git?rev=82b1e046d323fcafea46ab6714f5a339260f45f3#82b1e046d323fcafea46ab6714f5a339260f45f3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ image = { version = "0.25.10", default-features = false, features = ["bmp", "dds
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = "0.5.0"
+nanocodex = { git = "https://github.com/birdmanmandbir/nanocodex.git", rev = "82b1e046d323fcafea46ab6714f5a339260f45f3" }
 png = "0.18.1"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = "0.30.2"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ workspace = "/path/to/workspace"
 thinking = "medium" # low, medium, high, xhigh, or max
 reasoning_mode = "standard" # standard or pro
 fast_mode = false
+context_window_1m = false
 max_subagents = 32
 instructions = ""
 append_instructions = ""
@@ -179,6 +180,11 @@ thinking_high = "yellow"
 thinking_xhigh = "red"
 thinking_max = "magenta"
 ```
+
+Set `agent.context_window_1m = true` only when the selected endpoint supports a one-million-token
+input context. Tact will retain up to 1,000,000 tokens and compact at 900,000; this changes its
+client-side history policy and does not increase the provider's capacity. The setting applies to
+new or restored sessions.
 
 Set `agent.completion_hook` to a shell command to run after each conversation turn finishes. Tact
 runs the command in the configured workspace and ignores its output and exit status. Interactive

--- a/bin/tact/src/app/config.rs
+++ b/bin/tact/src/app/config.rs
@@ -5,7 +5,7 @@ use crate::{
     tui::theme::{Theme, ThemeMode},
 };
 use clap::ValueEnum;
-use nanocodex::Thinking;
+use nanocodex::{ContextWindow, Thinking};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -142,6 +142,7 @@ pub(crate) struct AgentConfig {
     thinking: ReasoningEffort,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
+    context_window_1m: bool,
     max_subagents: usize,
     #[serde(serialize_with = "serialize_optional_string")]
     instructions: Option<String>,
@@ -321,6 +322,7 @@ struct AgentConfigFile {
     thinking: Option<ReasoningEffort>,
     reasoning_mode: Option<ReasoningMode>,
     fast_mode: Option<bool>,
+    context_window_1m: Option<bool>,
     max_subagents: Option<usize>,
     instructions: Option<String>,
     append_instructions: Option<String>,
@@ -420,6 +422,7 @@ impl Config {
                     .or(file.agent.reasoning_mode)
                     .unwrap_or_default(),
                 fast_mode: file.agent.fast_mode.unwrap_or(false),
+                context_window_1m: file.agent.context_window_1m.unwrap_or(false),
                 max_subagents: overrides
                     .max_subagents
                     .or(file.agent.max_subagents)
@@ -975,6 +978,14 @@ impl AgentConfig {
         self.fast_mode
     }
 
+    pub(crate) const fn context_window(&self) -> ContextWindow {
+        if self.context_window_1m {
+            ContextWindow::OneMillion
+        } else {
+            ContextWindow::Standard
+        }
+    }
+
     pub(crate) const fn max_subagents(&self) -> usize {
         self.max_subagents
     }
@@ -1516,6 +1527,7 @@ mod tests {
         assert_eq!(config.agent.thinking, ReasoningEffort::Medium);
         assert_eq!(config.agent.reasoning_mode, ReasoningMode::Standard);
         assert!(!config.agent.fast_mode);
+        assert!(!config.agent.context_window_1m);
         assert_eq!(config.agent.max_subagents, 32);
         assert!(config.agent.web_search);
         assert!(config.agent.image_generation);
@@ -1544,6 +1556,7 @@ mod tests {
                 "thinking",
                 "reasoning_mode",
                 "fast_mode",
+                "context_window_1m",
                 "max_subagents",
                 "instructions",
                 "append_instructions",
@@ -2455,7 +2468,7 @@ mod tests {
         let config_path = directory.path().join("config.toml");
         fs::write(
             &config_path,
-            "[agent]\nworkspace = \"workspace\"\nthinking = \"xhigh\"\nreasoning_mode = \"pro\"\nfast_mode = true\nmax_subagents = 7\n\
+            "[agent]\nworkspace = \"workspace\"\nthinking = \"xhigh\"\nreasoning_mode = \"pro\"\nfast_mode = true\ncontext_window_1m = true\nmax_subagents = 7\n\
              instructions = \"Be concise.\"\nappend_instructions = \"Use project conventions.\"\n\
              web_search = false\nimage_generation = false\n\
              websocket_url = \"wss://example.com/responses\"\n\
@@ -2480,6 +2493,10 @@ mod tests {
         assert_eq!(config.agent.thinking, ReasoningEffort::Xhigh);
         assert_eq!(config.agent.reasoning_mode, ReasoningMode::Pro);
         assert!(config.agent.fast_mode);
+        assert_eq!(
+            config.agent.context_window(),
+            nanocodex::ContextWindow::OneMillion
+        );
         assert_eq!(config.agent.max_subagents, 7);
         assert_eq!(config.agent.instructions.as_deref(), Some("Be concise."));
         assert_eq!(
@@ -2496,6 +2513,8 @@ mod tests {
             config.agent.api_base_url.as_deref(),
             Some("https://example.com/v1")
         );
+        let rendered: toml::Value = toml::from_str(&config.to_toml().unwrap()).unwrap();
+        assert_eq!(rendered["agent"]["context_window_1m"].as_bool(), Some(true));
     }
 
     #[test]

--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -266,6 +266,7 @@ impl ConfiguredAgent {
         let subagents = subagent_control.downgrade();
         let mut builder = Nanocodex::builder(openai)
             .model(model)
+            .context_window(agent_config.context_window())
             .workspace(workspace)
             .thinking(thinking.into())
             .reasoning_mode(reasoning_mode.into())

--- a/bin/tact/src/tui/components/app.rs
+++ b/bin/tact/src/tui/components/app.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
-use nanocodex::Model;
+use nanocodex::{ContextWindow, Model};
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -68,6 +68,7 @@ pub(crate) enum AppEvent {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        context_window: ContextWindow,
         skills: Arc<[Skill]>,
     },
     HandoffCancelled(PaneId),
@@ -105,6 +106,7 @@ pub(crate) enum AppEvent {
         effort: ReasoningEffort,
         reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        context_window: ContextWindow,
         model: Model,
         draft_reset: DraftReset,
         skills: Arc<[Skill]>,
@@ -157,6 +159,7 @@ pub(crate) enum AppEvent {
         reasoning_mode: ReasoningMode,
         preferred_reasoning_mode: ReasoningMode,
         fast_mode: bool,
+        context_window: ContextWindow,
         model: Model,
         skills: Arc<[Skill]>,
     },
@@ -265,6 +268,7 @@ impl AppNode {
                 effort,
                 reasoning_mode,
                 fast_mode,
+                context_window,
                 skills,
             } => {
                 let workspace = self.workspace.clone();
@@ -272,6 +276,7 @@ impl AppNode {
                     let Some(root) = self.pane_mut(pane) else {
                         return ComponentUpdate::none();
                     };
+                    root.component_mut().set_context_window(context_window);
                     root.component_mut().reset_session(
                         &workspace,
                         effort,
@@ -322,6 +327,7 @@ impl AppNode {
                 effort,
                 reasoning_mode,
                 fast_mode,
+                context_window,
                 model,
                 draft_reset,
                 skills,
@@ -330,6 +336,7 @@ impl AppNode {
                 let Some(root) = self.pane_mut(pane) else {
                     return ComponentUpdate::none();
                 };
+                root.component_mut().set_context_window(context_window);
                 root.component_mut().reset_session(
                     &workspace,
                     effort,
@@ -398,20 +405,27 @@ impl AppNode {
                 reasoning_mode,
                 preferred_reasoning_mode,
                 fast_mode,
+                context_window,
                 model,
                 skills,
-            } => self.update_root(
-                pane,
-                RootEvent::SessionRestored {
-                    projection,
-                    effort,
-                    reasoning_mode,
-                    preferred_reasoning_mode,
-                    fast_mode,
-                    model,
-                    skills,
-                },
-            ),
+            } => {
+                let Some(root) = self.pane_mut(pane) else {
+                    return ComponentUpdate::none();
+                };
+                root.component_mut().set_context_window(context_window);
+                self.update_root(
+                    pane,
+                    RootEvent::SessionRestored {
+                        projection,
+                        effort,
+                        reasoning_mode,
+                        preferred_reasoning_mode,
+                        fast_mode,
+                        model,
+                        skills,
+                    },
+                )
+            }
             AppEvent::NotifyError { pane, error } => {
                 self.update_root(pane, RootEvent::NotifyError(error))
             }
@@ -815,7 +829,7 @@ mod tests {
     use crossterm::event::{
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
-    use nanocodex::Model;
+    use nanocodex::{ContextWindow, Model};
     use ratatui::{Terminal, backend::TestBackend};
     use semver::Version;
     use std::{path::PathBuf, sync::Arc};
@@ -855,6 +869,7 @@ mod tests {
             effort: ReasoningEffort::Low,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
+            context_window: ContextWindow::Standard,
             model: Model::Luna,
             draft_reset: DraftReset::Preserve,
             skills: Arc::from([]),
@@ -1023,6 +1038,7 @@ mod tests {
             effort: ReasoningEffort::High,
             reasoning_mode: ReasoningMode::Standard,
             fast_mode: false,
+            context_window: ContextWindow::Standard,
             skills: Arc::from([]),
         });
 

--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -11,7 +11,6 @@ use super::{
 use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
     tui::{
-        context::MODEL_WINDOW_TOKENS,
         format::{
             format_turn_duration, normalize_line_endings, sanitize_terminal_text, shorten_home,
             terminal_text_width,
@@ -23,7 +22,7 @@ use crate::{
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use history::PromptHistory;
 use layout::{VisualLayout, byte_at_column, grapheme_at_column};
-use nanocodex::Model;
+use nanocodex::{ContextWindow, Model};
 use ratatui::{
     Frame,
     buffer::Buffer,
@@ -105,6 +104,7 @@ pub(crate) struct Composer {
     scroll: usize,
     last_width: usize,
     context_tokens: u64,
+    context_window: ContextWindow,
     workspace: String,
     thinking: ReasoningEffort,
     model: Model,
@@ -204,6 +204,7 @@ impl Composer {
             scroll: 0,
             last_width: 78,
             context_tokens: 0,
+            context_window: ContextWindow::Standard,
             workspace: shorten_home(workspace),
             thinking,
             model: Model::Sol,
@@ -227,6 +228,10 @@ impl Composer {
 
     pub(crate) const fn context_tokens(&self) -> u64 {
         self.context_tokens
+    }
+
+    pub(crate) const fn set_context_window(&mut self, context_window: ContextWindow) {
+        self.context_window = context_window;
     }
 
     pub(crate) fn update(&mut self, event: ComposerEvent) -> ComposerUpdate {
@@ -1165,7 +1170,11 @@ impl Composer {
         let content_start = area.x + 2;
         let content_width = usize::from(area.width - 4);
         let content_end = content_start + u16::try_from(content_width).unwrap_or(u16::MAX);
-        let usage_prefix = format!(" {}%/272k ", context_percent(self.context_tokens));
+        let usage_prefix = format!(
+            " {}%/{} ",
+            context_percent(self.context_tokens, self.context_window),
+            context_window_label(self.context_window),
+        );
         let input_mode_segment = self
             .input_mode
             .as_ref()
@@ -1479,11 +1488,16 @@ impl ComposerUpdate {
     }
 }
 
-fn context_percent(tokens: u64) -> u64 {
-    tokens
-        .saturating_mul(100)
-        .saturating_add(MODEL_WINDOW_TOKENS / 2)
-        / MODEL_WINDOW_TOKENS
+fn context_percent(tokens: u64, context_window: ContextWindow) -> u64 {
+    let token_limit = context_window.token_limit();
+    tokens.saturating_mul(100).saturating_add(token_limit / 2) / token_limit
+}
+
+fn context_window_label(context_window: ContextWindow) -> &'static str {
+    match context_window {
+        ContextWindow::Standard => "272k",
+        ContextWindow::OneMillion => "1M",
+    }
 }
 
 fn draw_symbol(buffer: &mut Buffer, x: u16, y: u16, symbol: &str, style: Style) {
@@ -1567,7 +1581,7 @@ fn render_selection(
 mod tests {
     use super::{
         super::selection::{Selection, Surface, TextRange},
-        Composer, ComposerEffect, ComposerEvent, context_percent,
+        Composer, ComposerEffect, ComposerEvent, context_percent, context_window_label,
     };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
@@ -1575,7 +1589,7 @@ mod tests {
     };
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
     use nanocodex::{
-        Model,
+        ContextWindow, Model,
         agent::input::{PromptInput, UserInput},
     };
     use ratatui::{
@@ -2460,9 +2474,11 @@ mod tests {
 
     #[test]
     fn context_percentage_is_rounded() {
-        assert_eq!(context_percent(0), 0);
-        assert_eq!(context_percent(136_000), 50);
-        assert_eq!(context_percent(1_400), 1);
+        assert_eq!(context_percent(0, ContextWindow::Standard), 0);
+        assert_eq!(context_percent(136_000, ContextWindow::Standard), 50);
+        assert_eq!(context_percent(1_400, ContextWindow::Standard), 1);
+        assert_eq!(context_percent(500_000, ContextWindow::OneMillion), 50);
+        assert_eq!(context_window_label(ContextWindow::OneMillion), "1M");
     }
 
     #[test]

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -37,7 +37,7 @@ use crate::{
     },
 };
 use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind};
-use nanocodex::Model;
+use nanocodex::{ContextWindow, Model};
 use ratatui::{
     Frame,
     layout::{Position, Rect},
@@ -344,6 +344,7 @@ pub(crate) struct RootNode {
     theme_mode: ThemeMode,
     preferred_reasoning_mode: ReasoningMode,
     subagents: SubagentTree,
+    context_window: ContextWindow,
     context_diagnostics: ContextDiagnostics,
     recent_prompts: Vec<RecentPromptDraft>,
     pending_session_mention: Option<usize>,
@@ -386,6 +387,7 @@ impl RootNode {
             theme_mode: ThemeMode::Auto,
             preferred_reasoning_mode: ReasoningMode::Standard,
             subagents,
+            context_window: ContextWindow::Standard,
             context_diagnostics: ContextDiagnostics::default(),
             recent_prompts: Vec::new(),
             pending_session_mention: None,
@@ -395,6 +397,7 @@ impl RootNode {
 
     pub(crate) fn fork(&self, workspace: &Path, thinking: ReasoningEffort) -> Self {
         let mut root = Self::new(workspace, thinking);
+        root.set_context_window(self.context_window);
         root.transcript = Node::new(self.transcript.component().fork_snapshot());
         root.composer
             .component_mut()
@@ -486,6 +489,14 @@ impl RootNode {
         self.subagents.set_max_subagents(limit);
     }
 
+    pub(crate) fn set_context_window(&mut self, context_window: ContextWindow) {
+        self.context_window = context_window;
+        self.context_diagnostics.set_context_window(context_window);
+        self.composer
+            .component_mut()
+            .set_context_window(context_window);
+    }
+
     pub(crate) fn reset_session(
         &mut self,
         workspace: &Path,
@@ -505,7 +516,9 @@ impl RootNode {
         let memory_enabled = self.memory_enabled;
         let theme_mode = self.theme_mode;
         let max_subagents = self.subagents.max_subagents();
+        let context_window = self.context_window;
         *self = Self::new(workspace, thinking);
+        self.set_context_window(context_window);
         self.set_reasoning_modes(reasoning_mode, preferred_reasoning_mode);
         self.discarded_draft = discarded_draft;
         self.fork_available = fork_available;
@@ -586,6 +599,9 @@ impl RootNode {
         );
         self.set_fast_mode(fast_mode);
         projection.transcript.set_workspace(workspace);
+        projection
+            .context_diagnostics
+            .set_context_window(self.context_window);
         self.transcript = Node::new(projection.transcript);
         self.context_diagnostics = projection.context_diagnostics;
         self.recent_prompts = projection.recent_prompts;

--- a/bin/tact/src/tui/context.rs
+++ b/bin/tact/src/tui/context.rs
@@ -1,10 +1,12 @@
 //! Content-free context diagnostics projected from transcript telemetry.
 
 use crate::tui::transcript::TranscriptRecord;
-use nanocodex::oai::{
-    self,
-    events::{CompactionStarted, ModelCallCompleted},
-    responses::Usage,
+use nanocodex::{
+    ContextWindow,
+    oai::{
+        events::{CompactionStarted, ModelCallCompleted},
+        responses::Usage,
+    },
 };
 use serde::Deserialize;
 use serde_json::value::RawValue;
@@ -14,9 +16,6 @@ pub(crate) enum ContinuationMode {
     FullContext,
     PreviousResponse,
 }
-
-pub(crate) const MODEL_WINDOW_TOKENS: u64 = oai::CONTEXT_WINDOW_TOKENS;
-pub(crate) const AUTO_COMPACT_TOKEN_LIMIT: u64 = 244_800;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct TokenUsage {
@@ -62,9 +61,10 @@ pub(crate) struct ContextObservation {
 
 impl Default for ContextDiagnostics {
     fn default() -> Self {
+        let context_window = ContextWindow::Standard;
         Self {
-            model_window_tokens: MODEL_WINDOW_TOKENS,
-            auto_compact_token_limit: AUTO_COMPACT_TOKEN_LIMIT,
+            model_window_tokens: context_window.token_limit(),
+            auto_compact_token_limit: context_window.auto_compact_token_limit(),
             usage: None,
             continuation: None,
             prompt_cache: None,
@@ -77,6 +77,11 @@ impl Default for ContextDiagnostics {
 }
 
 impl ContextDiagnostics {
+    pub(crate) fn set_context_window(&mut self, context_window: ContextWindow) {
+        self.model_window_tokens = context_window.token_limit();
+        self.auto_compact_token_limit = context_window.auto_compact_token_limit();
+    }
+
     #[cfg(test)]
     fn rebuild<'a>(records: impl IntoIterator<Item = &'a TranscriptRecord>) -> Self {
         let mut diagnostics = Self::default();
@@ -288,6 +293,7 @@ pub(crate) fn outbound_context_snapshot(record: &TranscriptRecord) -> Option<(bo
 mod tests {
     use super::{ContextDiagnostics, ContinuationMode};
     use crate::tui::transcript::TranscriptRecord;
+    use nanocodex::ContextWindow;
     use nanocodex::agent::events::{AgentEvent, AgentEventKind};
     use serde_json::{Value, json, value::to_raw_value};
     use std::sync::Arc;
@@ -324,6 +330,16 @@ mod tests {
             "tool_calls": 0,
             "usage": usage
         })
+    }
+
+    #[test]
+    fn one_million_context_uses_matching_diagnostic_limits() {
+        let mut diagnostics = ContextDiagnostics::default();
+
+        diagnostics.set_context_window(ContextWindow::OneMillion);
+
+        assert_eq!(diagnostics.model_window_tokens, 1_000_000);
+        assert_eq!(diagnostics.auto_compact_token_limit, 900_000);
     }
 
     #[test]

--- a/bin/tact/src/tui/handoff_controller.rs
+++ b/bin/tact/src/tui/handoff_controller.rs
@@ -3,6 +3,7 @@ use crate::{
     core::ConfiguredAgent,
     tui::{pane::PaneId, worker::AuxiliaryError},
 };
+use nanocodex::ContextWindow;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -26,6 +27,7 @@ pub(crate) struct PreparedHandoff {
     pub(crate) effort: ReasoningEffort,
     pub(crate) reasoning_mode: ReasoningMode,
     pub(crate) fast_mode: bool,
+    pub(crate) context_window: ContextWindow,
     pub(crate) configured: ConfiguredAgent,
 }
 

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -53,7 +53,7 @@ use crate::{
 };
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind};
 use futures_util::StreamExt;
-use nanocodex::Model;
+use nanocodex::{ContextWindow, Model};
 use std::{
     collections::{HashMap, HashSet},
     io::{self, IsTerminal},
@@ -94,6 +94,7 @@ type NewSessionTask = JoinHandle<(
     ReasoningEffort,
     ReasoningMode,
     bool,
+    ContextWindow,
     Model,
     components::DraftReset,
     Result<ConfiguredAgent>,
@@ -148,6 +149,7 @@ struct RestoredSession {
     projection: RestoredSessionProjection,
     reasoning_mode: ReasoningMode,
     model: Model,
+    context_window: ContextWindow,
     next_sequence: u64,
 }
 
@@ -441,6 +443,7 @@ pub(crate) async fn run(
 
     let initial_effort = config.agent().thinking();
     let initial_fast_mode = config.agent().fast_mode();
+    let initial_context_window = config.agent().context_window();
     let initial_max_subagents = config.agent().max_subagents();
     let preferred_reasoning_mode = config.agent().reasoning_mode();
     let open_resume_selector = matches!(&startup, StartupMode::ResumeSelector);
@@ -545,6 +548,7 @@ pub(crate) async fn run(
         subagent_sender.clone(),
     );
     let mut root = RootNode::new(&workspace, initial_effort);
+    root.set_context_window(initial_context_window);
     root.set_reasoning_modes(reasoning_mode, preferred_reasoning_mode);
     root.set_fast_mode(initial_fast_mode);
     root.set_max_subagents(initial_max_subagents);
@@ -1234,6 +1238,7 @@ pub(crate) async fn run(
                             effort,
                             reasoning_mode,
                             fast_mode,
+                            context_window,
                             configured,
                         } = prepared;
                         let skills = install_configured_agent(
@@ -1256,6 +1261,7 @@ pub(crate) async fn run(
                                 effort,
                                 reasoning_mode,
                                 fast_mode,
+                                context_window,
                                 skills,
                             }),
                             &mut scheduler,
@@ -1279,7 +1285,7 @@ pub(crate) async fn run(
             }, if new_session_task.is_some() && !stopping => {
                 new_session_task = None;
                 input = Some(EventStream::new());
-                let (pane, effort, reasoning_mode, fast_mode, model, draft_reset, configured) =
+                let (pane, effort, reasoning_mode, fast_mode, context_window, model, draft_reset, configured) =
                     result.map_err(RuntimeError::NewSessionTask)?;
                 match configured {
                     Ok(configured) => {
@@ -1303,6 +1309,7 @@ pub(crate) async fn run(
                                 effort,
                                 reasoning_mode,
                                 fast_mode,
+                                context_window,
                                 model,
                                 draft_reset,
                                 skills,
@@ -1428,6 +1435,7 @@ pub(crate) async fn run(
                         projection,
                         reasoning_mode,
                         model,
+                        context_window,
                         next_sequence,
                     }) => {
                         let ConfiguredAgent {
@@ -1497,6 +1505,7 @@ pub(crate) async fn run(
                                 reasoning_mode,
                                 preferred_reasoning_mode,
                                 fast_mode,
+                                context_window,
                                 model,
                                 skills,
                             }),
@@ -2077,6 +2086,7 @@ fn apply_pane_effect(
                 .current_fast_mode;
             let config = context.config.clone();
             *context.new_session_task = Some(tokio::task::spawn_blocking(move || {
+                let context_window = config.agent().context_window();
                 let configured =
                     ConfiguredAgent::from_config_with_model(&config, effort, reasoning_mode, model);
                 (
@@ -2084,6 +2094,7 @@ fn apply_pane_effect(
                     effort,
                     reasoning_mode,
                     fast_mode,
+                    context_window,
                     model,
                     components::DraftReset::Preserve,
                     configured,
@@ -2203,6 +2214,7 @@ fn apply_pane_effect(
             let config = context.config.clone();
             *context.new_session_task = Some(tokio::task::spawn_blocking(move || {
                 let fast_mode = config.agent().fast_mode();
+                let context_window = config.agent().context_window();
                 let configured = ConfiguredAgent::from_config_with_session(
                     &config,
                     effort,
@@ -2216,6 +2228,7 @@ fn apply_pane_effect(
                     effort,
                     reasoning_mode,
                     fast_mode,
+                    context_window,
                     Model::Sol,
                     components::DraftReset::Clear,
                     configured,
@@ -2340,6 +2353,7 @@ fn apply_pane_effect(
             let fast_mode = context.config.agent().fast_mode();
             let config = context.config.clone();
             *context.resume_session_task = Some(tokio::spawn(async move {
+                let context_window = config.agent().context_window();
                 let config_path = config.path().to_path_buf();
                 let checkpoint_session_id = session_id.clone();
                 let checkpoint = tokio::task::spawn_blocking(move || {
@@ -2369,6 +2383,7 @@ fn apply_pane_effect(
                             projection,
                             reasoning_mode,
                             model,
+                            context_window,
                             next_sequence,
                         })
                     })
@@ -2606,6 +2621,7 @@ async fn prepare_handoff(
     let effort = config.agent().thinking();
     let reasoning_mode = config.agent().reasoning_mode();
     let fast_mode = config.agent().fast_mode();
+    let context_window = config.agent().context_window();
     let task = tokio::task::spawn_blocking(move || {
         ConfiguredAgent::from_config_with_session(
             &config,
@@ -2630,6 +2646,7 @@ async fn prepare_handoff(
         effort,
         reasoning_mode,
         fast_mode,
+        context_window,
         configured,
     })
 }


### PR DESCRIPTION
#### Summary

- Add `[agent] context_window_1m = true` to opt into a 1,000,000-token context window.
- Compact automatically at 900,000 tokens and update TUI context diagnostics and status display accordingly.
- Apply the selected context profile to new, restored, handed-off, and subagent sessions.
- Pin Nanocodex to the accompanying context-window implementation.

#### Configuration

~~~toml
[agent]
context_window_1m = true
~~~

This changes Tact's client-side retention and compaction policy; the selected endpoint must support a 1M-token input context.

#### Testing

- `cargo check --all-features`
- `SHELL=/bin/sh cargo test -p tact -- --test-threads=1`
- `cargo clippy -p tact --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`

### Dependency note

Merge or release the Nanocodex change before merging this PR, then replace the temporary git revision with the released Nanocodex version when available. https://github.com/gakonst/nanocodex/pull/211
