### PR TITLE
feat: add Astra model support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,7 +1042,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
@@ -1877,7 +1883,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2536,10 +2542,11 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223def7aa7a85ccdb7bc0ecfef6a9f36ee332db6730c10a757cfd382e08487d4"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
 dependencies = [
  "nanocodex-agent",
+ "nanocodex-durability",
+ "nanocodex-managed",
  "nanocodex-oai-api",
  "nanocodex-tools",
 ]
@@ -2547,8 +2554,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-agent"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bf178f13a34a0e77a4039644d48e823b613c7ebbcfcc6fbf88f7442cb924f8"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
 dependencies = [
  "chrono",
  "futures-util",
@@ -2568,13 +2574,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanocodex-durability"
+version = "0.5.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+dependencies = [
+ "nanocodex-agent",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "uuid",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "nanocodex-managed"
+version = "0.5.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+dependencies = [
+ "futures-util",
+ "nanocodex-agent",
+ "nanocodex-oai-api",
+ "nanocodex-tools",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "url",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "nanocodex-oai-api"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb1a99937e9af21fb452d6ebfde1151d2cfaa763c98e22540593a5e22525478"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures-util",
  "getrandom 0.4.3",
  "http",
@@ -2597,11 +2638,10 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2749e5464e7251c1f67e8f1ab6c608c175f66a1c5c64e0fbd8b27b7928cc343"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bm25",
  "futures-util",
  "getrandom 0.4.3",
@@ -2615,21 +2655,24 @@ dependencies = [
  "reqwest",
  "rmcp",
  "rquickjs",
+ "rustls",
  "schemars",
  "serde",
  "serde_json",
  "sha1",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
 name = "nanocodex-tools-macros"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e27623b5720bc25e4d52e10eba53c0fac0a68213b55b9f1fd91021165429930"
+source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2805,7 +2848,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -3708,7 +3751,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3757,11 +3800,13 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
 dependencies = [
  "async-trait",
+ "base64 0.23.1",
+ "bytes",
  "chrono",
  "futures",
  "http",
@@ -4580,7 +4625,7 @@ version = "0.6.7"
 dependencies = [
  "arboard",
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "codspeed-criterion-compat",
@@ -4763,7 +4808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex 0.11.0",
  "filedescriptor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-durability",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-agent"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
  "chrono",
  "futures-util",
@@ -2576,8 +2576,10 @@ dependencies = [
 [[package]]
 name = "nanocodex-durability"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
+ "base64 0.22.1",
+ "flate2",
  "nanocodex-agent",
  "serde",
  "serde_json",
@@ -2590,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-managed"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
  "futures-util",
  "nanocodex-agent",
@@ -2612,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-oai-api"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2638,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2672,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools-macros"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=4f3344400ee3d2a2446b96e342f8c9871aab9637#4f3344400ee3d2a2446b96e342f8c9871aab9637"
+source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -880,7 +880,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1306,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1912,7 +1912,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-durability",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-agent"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
  "chrono",
  "futures-util",
@@ -2576,13 +2576,12 @@ dependencies = [
 [[package]]
 name = "nanocodex-durability"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
- "base64 0.22.1",
- "flate2",
  "nanocodex-agent",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
  "tokio",
  "uuid",
@@ -2592,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-managed"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
  "futures-util",
  "nanocodex-agent",
@@ -2614,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-oai-api"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2640,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2674,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools-macros"
 version = "0.5.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=371ed9adf40271f9efa477b6a8a27381d0e2d8e3#371ed9adf40271f9efa477b6a8a27381d0e2d8e3"
+source = "git+https://github.com/gakonst/nanocodex?rev=4be96acd90455fb2fad60b11f9a15968d0664274#4be96acd90455fb2fad60b11f9a15968d0664274"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2736,7 +2735,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3947,7 +3946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4003,7 +4002,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4425,7 +4424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4753,10 +4752,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4769,7 +4768,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4779,7 +4778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5251,7 +5250,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5667,7 +5666,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5682,7 +5681,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.58.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -5692,24 +5691,11 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5724,32 +5710,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5772,31 +5736,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ image = { version = "0.25.10", default-features = false, features = ["bmp", "dds
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = "0.5.0"
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "4f3344400ee3d2a2446b96e342f8c9871aab9637" }
 png = "0.18.1"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = "0.30.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ image = { version = "0.25.10", default-features = false, features = ["bmp", "dds
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "371ed9adf40271f9efa477b6a8a27381d0e2d8e3" }
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "4be96acd90455fb2fad60b11f9a15968d0664274" }
 png = "0.18.1"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = "0.30.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ image = { version = "0.25.10", default-features = false, features = ["bmp", "dds
 jsonschema = { version = "0.48.5", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 minisign-verify = "0.2.5"
-nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "4f3344400ee3d2a2446b96e342f8c9871aab9637" }
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "371ed9adf40271f9efa477b6a8a27381d0e2d8e3" }
 png = "0.18.1"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = "0.30.2"

--- a/README.md
+++ b/README.md
@@ -102,14 +102,15 @@ For scripts and integrations, `tact run` submits one prompt and streams Nanocode
 tact run "inspect the workspace"
 ```
 
-Choose the model for a newly started agent without changing configuration:
+Override the configured model for a newly started agent:
 
 ```sh
 tact --model terra
 tact --model luna run "inspect the workspace"
 ```
 
-`--model` accepts `sol`, `terra`, or `luna`; `TACT_MODEL` provides the same per-launch setting.
+`--model` accepts `sol`, `terra`, `luna`, or `astra`; `TACT_MODEL` provides the same per-launch
+override.
 Resumed sessions continue with the model recorded when they were created.
 
 ## Configuration
@@ -135,6 +136,7 @@ file = "/path/to/.codex/auth.json"
 
 [agent]
 workspace = "/path/to/workspace"
+model = "sol" # sol, terra, luna, or astra
 thinking = "medium" # low, medium, high, xhigh, or max
 reasoning_mode = "standard" # standard or pro
 fast_mode = false

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ file = "/path/to/.codex/auth.json"
 
 [agent]
 workspace = "/path/to/workspace"
-model = "sol" # sol, terra, luna, or astra
-thinking = "medium" # low, medium, high, xhigh, or max
+model = "astra" # sol, terra, luna, or astra
+thinking = "low" # low, medium, high, xhigh, or max
 reasoning_mode = "standard" # standard or pro
 fast_mode = false
 max_subagents = 32

--- a/README.md
+++ b/README.md
@@ -392,15 +392,17 @@ persisted separately and can be resumed like other sessions.
 
 ### Resume
 
-Tact checkpoints each completed turn and keeps an append-only transcript. Open **Resume session**
+Tact checkpoints each successful turn and keeps an append-only transcript. Ordinary failed turns
+retain the last successful checkpoint. A terminal provider policy stop makes the session
+non-resumable; its transcript remains available for inspection. Open **Resume session**
 from the Actions menu to search sessions for the current workspace, or resume a known ID directly:
 
 ```sh
 tact --resume SESSION_ID
 ```
 
-Tact prints the active session's resume command when it exits. Session files live beside the
-selected configuration in private, versioned `checkpoints` and `transcripts` directories.
+Tact prints the active session's resume command when it exits. Sessions are stored in
+`sessions/v2.sqlite3` beside the selected configuration.
 Checkpoints contain the complete model-visible conversation and are not redacted, so treat them as
 private data.
 

--- a/bin/tact/src/app/auth.rs
+++ b/bin/tact/src/app/auth.rs
@@ -6,8 +6,8 @@ use crate::app::{
     secret::SecretString,
 };
 use nanocodex::oai::auth::{
-    ChatGptAuthStatus, ChatGptLogin, OpenAiAuth, chatgpt_auth_status, load_chatgpt_auth,
-    logout_chatgpt,
+    ChatGptAuthStatus, ChatGptLogin, OpenAiAuth, load_chatgpt_auth, logout_chatgpt,
+    resolve_chatgpt_auth_status,
 };
 use std::{path::Path, result::Result as StdResult};
 
@@ -43,9 +43,9 @@ impl AuthConfig {
         selected.into_openai_auth(self.file())
     }
 
-    pub(crate) fn status(&self) -> AuthResult<()> {
+    pub(crate) async fn status(&self) -> AuthResult<()> {
         match self.select_auth(|| SecretString::from_environment(OPENAI_API_KEY))? {
-            SelectedAuth::ChatGpt => self.print_chatgpt_status()?,
+            SelectedAuth::ChatGpt => self.print_chatgpt_status().await?,
             SelectedAuth::ApiKey(_api_key) => {
                 println!("Authentication: OpenAI API key");
                 println!("Source: {OPENAI_API_KEY}");
@@ -101,8 +101,8 @@ impl AuthConfig {
         }
     }
 
-    fn print_chatgpt_status(&self) -> AuthResult<()> {
-        let account = chatgpt_auth_status(self.file())?;
+    async fn print_chatgpt_status(&self) -> AuthResult<()> {
+        let account = resolve_chatgpt_auth_status(self.file()).await?;
         println!("Authentication: ChatGPT");
         if let Some(email) = account.email {
             println!("Email: {email}");

--- a/bin/tact/src/app/cli.rs
+++ b/bin/tact/src/app/cli.rs
@@ -349,6 +349,7 @@ impl Cli {
             auth_mode: self.auth,
             auth_file: self.auth_file,
             workspace: self.workspace,
+            model: self.model,
             thinking: self.thinking,
             reasoning_mode: self.reasoning_mode,
             max_subagents: self.max_subagents,
@@ -364,7 +365,7 @@ impl Cli {
         } else {
             Config::load(overrides)?
         };
-        let model = self.model.unwrap_or_default();
+        let model = config.agent().model();
 
         match self.command {
             Some(Command::Resume) => {

--- a/bin/tact/src/app/cli.rs
+++ b/bin/tact/src/app/cli.rs
@@ -636,7 +636,7 @@ impl AuthCommand {
     async fn run(self, config: &Config) -> AuthResult<()> {
         match self {
             Self::Login => config.auth().login().await,
-            Self::Status => config.auth().status(),
+            Self::Status => config.auth().status().await,
             Self::Logout => config.auth().logout(),
         }
     }

--- a/bin/tact/src/app/config.rs
+++ b/bin/tact/src/app/config.rs
@@ -5,7 +5,7 @@ use crate::{
     tui::theme::{Theme, ThemeMode},
 };
 use clap::ValueEnum;
-use nanocodex::Thinking;
+use nanocodex::{Model, Thinking};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -139,6 +139,7 @@ pub(crate) struct AuthConfig {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct AgentConfig {
     workspace: PathBuf,
+    model: Model,
     thinking: ReasoningEffort,
     reasoning_mode: ReasoningMode,
     fast_mode: bool,
@@ -198,6 +199,7 @@ pub(crate) struct ConfigOverrides {
     pub(crate) auth_mode: Option<AuthMode>,
     pub(crate) auth_file: Option<PathBuf>,
     pub(crate) workspace: Option<PathBuf>,
+    pub(crate) model: Option<Model>,
     pub(crate) thinking: Option<ReasoningEffort>,
     pub(crate) reasoning_mode: Option<ReasoningMode>,
     pub(crate) max_subagents: Option<usize>,
@@ -318,6 +320,7 @@ struct AuthConfigFile {
 #[serde(default, deny_unknown_fields)]
 struct AgentConfigFile {
     workspace: Option<PathBuf>,
+    model: Option<Model>,
     thinking: Option<ReasoningEffort>,
     reasoning_mode: Option<ReasoningMode>,
     fast_mode: Option<bool>,
@@ -411,6 +414,7 @@ impl Config {
             ),
             agent: AgentConfig {
                 workspace,
+                model: overrides.model.or(file.agent.model).unwrap_or_default(),
                 thinking: overrides
                     .thinking
                     .or(file.agent.thinking)
@@ -963,6 +967,10 @@ impl AgentConfig {
         &self.workspace
     }
 
+    pub(crate) const fn model(&self) -> Model {
+        self.model
+    }
+
     pub(crate) const fn thinking(&self) -> ReasoningEffort {
         self.thinking
     }
@@ -1418,6 +1426,7 @@ mod tests {
         RemoteMemoryTokenFile, ThemeMode, validate_mcp_url,
     };
     use crate::app::error::{ConfigError, Error, McpUrlError, RemoteMemoryConfigError};
+    use nanocodex::Model;
     use ratatui::style::Color;
     use std::{
         collections::BTreeMap,
@@ -1513,6 +1522,7 @@ mod tests {
         assert_eq!(config.auth.mode, AuthMode::Auto);
         assert_eq!(config.auth.file, home.join(".codex/auth.json"));
         assert_eq!(config.agent.workspace, directory.path());
+        assert_eq!(config.agent.model, Model::Sol);
         assert_eq!(config.agent.thinking, ReasoningEffort::Medium);
         assert_eq!(config.agent.reasoning_mode, ReasoningMode::Standard);
         assert!(!config.agent.fast_mode);
@@ -1541,6 +1551,7 @@ mod tests {
             &rendered["agent"],
             &[
                 "workspace",
+                "model",
                 "thinking",
                 "reasoning_mode",
                 "fast_mode",
@@ -1583,6 +1594,7 @@ mod tests {
             rendered["auth"]["file"].as_str(),
             home.join(".codex/auth.json").to_str()
         );
+        assert_eq!(rendered["agent"]["model"].as_str(), Some("sol"));
         assert_eq!(
             rendered["agent"]["workspace"].as_str(),
             directory.path().to_str()
@@ -2352,7 +2364,7 @@ mod tests {
         fs::write(
             &config_path,
             "[auth]\nmode = \"auto\"\nfile = \"stored.json\"\n\
-             \n[agent]\nworkspace = \"configured\"\nthinking = \"low\"\nweb_search = true\n",
+             \n[agent]\nworkspace = \"configured\"\nmodel = \"astra\"\nthinking = \"low\"\nweb_search = true\n",
         )
         .unwrap();
 
@@ -2362,6 +2374,7 @@ mod tests {
                 auth_mode: Some(AuthMode::ChatGpt),
                 auth_file: Some("cli-auth.json".into()),
                 workspace: Some("cli-workspace".into()),
+                model: Some(Model::Luna),
                 thinking: Some(ReasoningEffort::High),
                 web_search: Some(false),
                 ..ConfigOverrides::default()
@@ -2377,6 +2390,7 @@ mod tests {
             config.agent.workspace,
             directory.path().join("cli-workspace")
         );
+        assert_eq!(config.agent.model, Model::Luna);
         assert_eq!(config.agent.thinking, ReasoningEffort::High);
         assert!(!config.agent.web_search);
     }
@@ -2455,7 +2469,7 @@ mod tests {
         let config_path = directory.path().join("config.toml");
         fs::write(
             &config_path,
-            "[agent]\nworkspace = \"workspace\"\nthinking = \"xhigh\"\nreasoning_mode = \"pro\"\nfast_mode = true\nmax_subagents = 7\n\
+            "[agent]\nworkspace = \"workspace\"\nmodel = \"astra\"\nthinking = \"xhigh\"\nreasoning_mode = \"pro\"\nfast_mode = true\nmax_subagents = 7\n\
              instructions = \"Be concise.\"\nappend_instructions = \"Use project conventions.\"\n\
              web_search = false\nimage_generation = false\n\
              websocket_url = \"wss://example.com/responses\"\n\
@@ -2477,6 +2491,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.agent.workspace, directory.path().join("workspace"));
+        assert_eq!(config.agent.model, Model::Astra);
         assert_eq!(config.agent.thinking, ReasoningEffort::Xhigh);
         assert_eq!(config.agent.reasoning_mode, ReasoningMode::Pro);
         assert!(config.agent.fast_mode);

--- a/bin/tact/src/app/config.rs
+++ b/bin/tact/src/app/config.rs
@@ -41,8 +41,8 @@ pub(crate) enum AuthMode {
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ReasoningEffort {
-    Low,
     #[default]
+    Low,
     Medium,
     High,
     Xhigh,
@@ -1522,8 +1522,8 @@ mod tests {
         assert_eq!(config.auth.mode, AuthMode::Auto);
         assert_eq!(config.auth.file, home.join(".codex/auth.json"));
         assert_eq!(config.agent.workspace, directory.path());
-        assert_eq!(config.agent.model, Model::Sol);
-        assert_eq!(config.agent.thinking, ReasoningEffort::Medium);
+        assert_eq!(config.agent.model, Model::Astra);
+        assert_eq!(config.agent.thinking, ReasoningEffort::Low);
         assert_eq!(config.agent.reasoning_mode, ReasoningMode::Standard);
         assert!(!config.agent.fast_mode);
         assert_eq!(config.agent.max_subagents, 32);
@@ -1594,12 +1594,12 @@ mod tests {
             rendered["auth"]["file"].as_str(),
             home.join(".codex/auth.json").to_str()
         );
-        assert_eq!(rendered["agent"]["model"].as_str(), Some("sol"));
+        assert_eq!(rendered["agent"]["model"].as_str(), Some("astra"));
         assert_eq!(
             rendered["agent"]["workspace"].as_str(),
             directory.path().to_str()
         );
-        assert_eq!(rendered["agent"]["thinking"].as_str(), Some("medium"));
+        assert_eq!(rendered["agent"]["thinking"].as_str(), Some("low"));
         assert_eq!(rendered["agent"]["fast_mode"].as_bool(), Some(false));
         assert_eq!(rendered["agent"]["max_subagents"].as_integer(), Some(32));
         for field in [

--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -163,6 +163,14 @@ enum Cancellation {
     Failed(NanocodexError),
 }
 
+pub(crate) fn supported_reasoning_mode(model: Model, preferred: ReasoningMode) -> ReasoningMode {
+    if model.supports_reasoning_mode(preferred.into()) {
+        preferred
+    } else {
+        ReasoningMode::Standard
+    }
+}
+
 impl ConfiguredAgent {
     pub(crate) async fn run_from_config(
         config: &Config,
@@ -171,20 +179,17 @@ impl ConfiguredAgent {
         shutdown: CancellationToken,
         #[cfg(feature = "harbor-evals")] orchestration_log: Option<PathBuf>,
     ) -> Result<()> {
-        let result = Self::from_config_with_model(
-            config,
-            config.agent().thinking(),
-            config.agent().reasoning_mode(),
-            model,
-        )?
-        .run(
-            prompt,
-            shutdown,
-            io::stdout(),
-            #[cfg(feature = "harbor-evals")]
-            orchestration_log,
-        )
-        .await;
+        let reasoning_mode = supported_reasoning_mode(model, config.agent().reasoning_mode());
+        let result =
+            Self::from_config_with_model(config, config.agent().thinking(), reasoning_mode, model)?
+                .run(
+                    prompt,
+                    shutdown,
+                    io::stdout(),
+                    #[cfg(feature = "harbor-evals")]
+                    orchestration_log,
+                )
+                .await;
         if let Some(command) = config.agent().completion_hook() {
             drop(hook::execute(command, config.agent().workspace()).await);
         }

--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -157,6 +157,36 @@ struct SessionInstructions {
     skills: Arc<[Skill]>,
 }
 
+struct AgentInstructions {
+    session: SessionInstructions,
+    selected: Arc<str>,
+    luna: Arc<str>,
+}
+
+impl AgentInstructions {
+    fn from_config(
+        config: &Config,
+        model: Model,
+        restored: Option<(String, Option<bool>)>,
+        memory_enabled: bool,
+    ) -> Self {
+        let selected = SessionInstructions::from_config(config, model, None, memory_enabled);
+        let luna = SessionInstructions::from_config(config, Model::Luna, None, memory_enabled).text;
+        let selected_text = Arc::clone(&selected.text);
+        let session = match restored {
+            Some(restored) => {
+                SessionInstructions::from_config(config, model, Some(restored), memory_enabled)
+            }
+            None => selected,
+        };
+        Self {
+            session,
+            selected: selected_text,
+            luna,
+        }
+    }
+}
+
 impl SessionInstructions {
     fn from_config(
         config: &Config,
@@ -316,25 +346,17 @@ impl ConfiguredAgent {
                 (Some(snapshot), Some((instructions, catalog_present)))
             },
         );
-        let SessionInstructions {
-            text: instructions,
-            skills,
-        } = SessionInstructions::from_config(
-            config,
-            model,
-            restored_instructions.clone(),
-            memory_enabled,
-        );
+        let AgentInstructions {
+            session:
+                SessionInstructions {
+                    text: instructions,
+                    skills,
+                },
+            selected: selected_instructions,
+            luna: luna_instructions,
+        } = AgentInstructions::from_config(config, model, restored_instructions, memory_enabled);
         builder = builder.instructions(Arc::clone(&instructions));
         let subagent_builder = builder.clone();
-        let selected_instructions = Arc::clone(&instructions);
-        let luna_instructions = SessionInstructions::from_config(
-            config,
-            Model::Luna,
-            restored_instructions,
-            memory_enabled,
-        )
-        .text;
         subagent_control.set_agent_factory(
             thinking.into(),
             agent_config.fast_mode(),
@@ -753,11 +775,11 @@ impl Cancellation {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT, SCRATCHPAD_INSTRUCTIONS,
-        SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS_SELECTED_ONLY,
-        SessionInstructions, TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS,
-        configured_memory_store, fresh_instructions, reconcile_tact_instructions,
-        session_instructions, session_instructions_with_luna,
+        AgentInstructions, ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT,
+        SCRATCHPAD_INSTRUCTIONS, SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS,
+        SUBAGENT_INSTRUCTIONS_SELECTED_ONLY, SessionInstructions, TACT_INSTRUCTIONS,
+        TOOL_ORCHESTRATION_INSTRUCTIONS, configured_memory_store, fresh_instructions,
+        reconcile_tact_instructions, session_instructions, session_instructions_with_luna,
     };
     use crate::{
         app::{
@@ -939,6 +961,49 @@ mod tests {
                 );
                 assert_eq!(resumed.text.as_ref(), stored);
                 assert!(resumed.skills.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn resumed_parent_preserves_its_prompt_while_clean_children_use_their_model() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("config.toml");
+        fs::write(&path, "[skills]\nenabled = false\n").unwrap();
+        for custom in [None, Some("Current custom instructions.")] {
+            let config = Config::load(ConfigOverrides {
+                path: Some(path.clone()),
+                workspace: Some(directory.path().to_path_buf()),
+                model: Some(Model::Astra),
+                instructions: custom.map(str::to_owned),
+                append_instructions: Some("Current project instructions.".to_owned()),
+                ..ConfigOverrides::default()
+            })
+            .unwrap();
+            let stored =
+                "You are Tact, an agent based on GPT-6 Astra.\n\nSaved project instructions.";
+            let instructions = AgentInstructions::from_config(
+                &config,
+                Model::Astra,
+                Some((stored.to_owned(), Some(false))),
+                true,
+            );
+            assert_eq!(instructions.session.text.as_ref(), stored);
+            for (model, actual) in [
+                (Model::Luna, &instructions.luna),
+                (Model::Astra, &instructions.selected),
+            ] {
+                let expected = SessionInstructions::from_config(&config, model, None, true);
+                assert!(
+                    actual == &expected.text,
+                    "{model:?} child must use fresh instructions"
+                );
+                assert!(!actual.contains("Saved project instructions."));
+                assert!(actual.contains("Current project instructions."));
+                assert_eq!(actual.matches(MEMORY_INSTRUCTIONS).count(), 1);
+                if custom.is_none() {
+                    assert_eq!(actual.contains("GPT-6 Astra"), model == Model::Astra);
+                }
             }
         }
     }

--- a/bin/tact/src/core/mod.rs
+++ b/bin/tact/src/core/mod.rs
@@ -157,6 +157,30 @@ struct SessionInstructions {
     skills: Arc<[Skill]>,
 }
 
+impl SessionInstructions {
+    fn from_config(
+        config: &Config,
+        model: Model,
+        restored: Option<(String, Option<bool>)>,
+        memory_enabled: bool,
+    ) -> Self {
+        let agent = config.agent();
+        let defaults = ResponsesServiceConfig {
+            model,
+            ..ResponsesServiceConfig::default()
+        };
+        session_instructions_with_luna(
+            Some(agent.instructions().unwrap_or(&defaults.system_prompt())),
+            agent.append_instructions(),
+            config.skills(),
+            restored,
+            config.subagents().enabled(),
+            config.subagents().allow_luna(),
+            memory_enabled,
+        )
+    }
+}
+
 enum Cancellation {
     NotRequested,
     Requested,
@@ -295,17 +319,22 @@ impl ConfiguredAgent {
         let SessionInstructions {
             text: instructions,
             skills,
-        } = session_instructions_with_luna(
-            agent_config.instructions(),
-            agent_config.append_instructions(),
-            config.skills(),
-            restored_instructions,
-            subagents_enabled,
-            allow_luna_subagents,
+        } = SessionInstructions::from_config(
+            config,
+            model,
+            restored_instructions.clone(),
             memory_enabled,
         );
         builder = builder.instructions(Arc::clone(&instructions));
         let subagent_builder = builder.clone();
+        let selected_instructions = Arc::clone(&instructions);
+        let luna_instructions = SessionInstructions::from_config(
+            config,
+            Model::Luna,
+            restored_instructions,
+            memory_enabled,
+        )
+        .text;
         subagent_control.set_agent_factory(
             thinking.into(),
             agent_config.fast_mode(),
@@ -313,6 +342,11 @@ impl ConfiguredAgent {
                 subagent_builder
                     .clone()
                     .model(model)
+                    .instructions(Arc::clone(if model == Model::Luna {
+                        &luna_instructions
+                    } else {
+                        &selected_instructions
+                    }))
                     .thinking(thinking)
                     .fast_mode(fast_mode)
                     .build()
@@ -612,9 +646,11 @@ fn fresh_instructions_with_catalog(
     subagents_enabled: bool,
     allow_luna: bool,
 ) -> String {
-    let mut instructions = custom
-        .map(str::to_owned)
-        .unwrap_or_else(|| ResponsesServiceConfig::default().system_prompt.to_string());
+    let mut instructions = custom.map(str::to_owned).unwrap_or_else(|| {
+        ResponsesServiceConfig::default()
+            .system_prompt()
+            .into_owned()
+    });
     instructions = reconcile_tact_instructions(instructions);
     instructions = reconcile_tool_orchestration_instructions(instructions);
     instructions = reconcile_session_reference_instructions(instructions);
@@ -635,10 +671,14 @@ fn fresh_instructions_with_catalog(
 }
 
 fn reconcile_tact_instructions(mut instructions: String) -> String {
-    if let Some(rest) = instructions.strip_prefix("You are Codex") {
+    if let Some(rest) = instructions
+        .strip_prefix("You are Codex")
+        .or_else(|| instructions.strip_prefix("You are Nanocodex"))
+    {
         let rest = rest.trim_start_matches([',', '.']);
         instructions = format!("You are Tact,{rest}");
         instructions = instructions.replacen("As Codex,", "As Tact,", 1);
+        instructions = instructions.replacen("As Nanocodex,", "As Tact,", 1);
     }
 
     let separator_and_instructions = format!("\n\n{TACT_INSTRUCTIONS}");
@@ -715,9 +755,9 @@ mod tests {
     use super::{
         ConfiguredAgent, MEMORY_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT, SCRATCHPAD_INSTRUCTIONS,
         SESSION_REFERENCE_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS, SUBAGENT_INSTRUCTIONS_SELECTED_ONLY,
-        TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS, configured_memory_store,
-        fresh_instructions, reconcile_tact_instructions, session_instructions,
-        session_instructions_with_luna,
+        SessionInstructions, TACT_INSTRUCTIONS, TOOL_ORCHESTRATION_INSTRUCTIONS,
+        configured_memory_store, fresh_instructions, reconcile_tact_instructions,
+        session_instructions, session_instructions_with_luna,
     };
     use crate::{
         app::{
@@ -727,7 +767,7 @@ mod tests {
         core::extensions::Skill,
     };
     use nanocodex::{
-        Nanocodex, OpenAi,
+        Model, Nanocodex, OpenAi,
         oai::{
             ResponseError,
             tower::{ResponsesAttempt, ResponsesServiceConfig, ResponsesServiceResponse},
@@ -821,7 +861,9 @@ mod tests {
     fn fresh_instructions_include_the_default_append() {
         let disabled = SkillsConfig::from_roots(false, Vec::new());
         let default = reconcile_tact_instructions(
-            ResponsesServiceConfig::default().system_prompt.to_string(),
+            ResponsesServiceConfig::default()
+                .system_prompt()
+                .into_owned(),
         );
 
         assert_eq!(
@@ -850,10 +892,64 @@ mod tests {
     }
 
     #[test]
+    fn configured_instructions_follow_the_selected_model_and_preserve_overrides() {
+        let directory = tempdir().unwrap();
+        let config_path = directory.path().join("config.toml");
+        fs::write(&config_path, "").unwrap();
+        for custom in [None, Some("Custom instructions.")] {
+            let config = Config::load(ConfigOverrides {
+                path: Some(config_path.clone()),
+                workspace: Some(directory.path().to_path_buf()),
+                model: Some(Model::Astra),
+                instructions: custom.map(str::to_owned),
+                append_instructions: Some("Project instructions.".to_owned()),
+                ..ConfigOverrides::default()
+            })
+            .unwrap();
+            for model in [Model::Sol, Model::Terra, Model::Luna, Model::Astra] {
+                let session = SessionInstructions::from_config(&config, model, None, true);
+                let defaults = ResponsesServiceConfig {
+                    model,
+                    ..ResponsesServiceConfig::default()
+                };
+                let expected = reconcile_tact_instructions(
+                    custom.unwrap_or(&defaults.system_prompt()).to_owned(),
+                );
+                assert!(session.text.starts_with(&expected), "{model:?}");
+                assert!(!session.text.contains("You are Nanocodex"));
+                assert!(!session.text.contains("As Nanocodex,"));
+                assert!(!session.text.contains("You are Codex"));
+                for section in [
+                    TACT_INSTRUCTIONS,
+                    "Project instructions.",
+                    MEMORY_INSTRUCTIONS,
+                ] {
+                    assert_eq!(session.text.matches(section).count(), 1, "{model:?}");
+                }
+                if custom.is_none() {
+                    assert_eq!(session.text.contains("GPT-6 Astra"), model == Model::Astra);
+                }
+
+                let stored = "You are Codex.\n\nStored instructions.\n";
+                let resumed = SessionInstructions::from_config(
+                    &config,
+                    model,
+                    Some((stored.to_owned(), Some(false))),
+                    true,
+                );
+                assert_eq!(resumed.text.as_ref(), stored);
+                assert!(resumed.skills.is_empty());
+            }
+        }
+    }
+
+    #[test]
     fn appended_instructions_extend_the_default_or_replacement() {
         let disabled = SkillsConfig::from_roots(false, Vec::new());
         let default = reconcile_tact_instructions(
-            ResponsesServiceConfig::default().system_prompt.to_string(),
+            ResponsesServiceConfig::default()
+                .system_prompt()
+                .into_owned(),
         );
 
         let instructions = fresh_instructions(None, Some("Project instructions."), &disabled);
@@ -890,7 +986,9 @@ mod tests {
 
         let instructions = fresh_instructions(None, None, &enabled);
         let default = reconcile_tact_instructions(
-            ResponsesServiceConfig::default().system_prompt.to_string(),
+            ResponsesServiceConfig::default()
+                .system_prompt()
+                .into_owned(),
         );
 
         assert!(instructions.starts_with(&default));
@@ -1259,7 +1357,7 @@ mod tests {
         let configured = ConfiguredAgent {
             agent,
             events,
-            instructions: ResponsesServiceConfig::default().system_prompt,
+            instructions: ResponsesServiceConfig::default().system_prompt().into(),
             skills: Arc::from([]),
             memory_enabled: false,
             subagent_updates,

--- a/bin/tact/src/core/orchestration.rs
+++ b/bin/tact/src/core/orchestration.rs
@@ -428,7 +428,6 @@ mod tests {
             "websocket_reconnects": 0,
             "response_attempts": model_calls,
             "response_retries": 0,
-            "billing_uncertain_response_attempts": 0,
             "connection_duration_ns": 100,
             "retry_backoff_duration_ns": 0,
             "model_duration_ns": 900_000,

--- a/bin/tact/src/tui/components/app.rs
+++ b/bin/tact/src/tui/components/app.rs
@@ -274,11 +274,12 @@ impl AppNode {
                     let Some(root) = self.pane_mut(pane) else {
                         return ComponentUpdate::none();
                     };
+                    let preferred_reasoning_mode = root.component().preferred_reasoning_mode();
                     root.component_mut().reset_session(
                         &workspace,
                         effort,
                         reasoning_mode,
-                        reasoning_mode,
+                        preferred_reasoning_mode,
                         DraftReset::Clear,
                     );
                     root.component_mut().set_fast_mode(fast_mode);
@@ -333,11 +334,12 @@ impl AppNode {
                 let Some(root) = self.pane_mut(pane) else {
                     return ComponentUpdate::none();
                 };
+                let preferred_reasoning_mode = root.component().preferred_reasoning_mode();
                 root.component_mut().reset_session(
                     &workspace,
                     effort,
                     reasoning_mode,
-                    reasoning_mode,
+                    preferred_reasoning_mode,
                     draft_reset,
                 );
                 root.component_mut().set_fast_mode(fast_mode);
@@ -866,6 +868,26 @@ mod tests {
         let root = app.root(PaneId::Main).unwrap();
         assert_eq!(root.composer().draft(), "send with luna");
         assert_eq!(root.composer().model(), Model::Luna);
+    }
+
+    #[test]
+    fn model_session_replacement_preserves_the_preferred_reasoning_mode() {
+        let mut app = app();
+        app.set_preferred_reasoning_mode(ReasoningMode::Pro);
+
+        app.update(AppEvent::NewSessionReady {
+            pane: PaneId::Main,
+            effort: ReasoningEffort::High,
+            reasoning_mode: ReasoningMode::Standard,
+            fast_mode: false,
+            model: Model::Astra,
+            draft_reset: DraftReset::Preserve,
+            skills: Arc::from([]),
+        });
+
+        let root = app.root(PaneId::Main).unwrap();
+        assert_eq!(root.composer().reasoning_mode(), ReasoningMode::Standard);
+        assert_eq!(root.preferred_reasoning_mode(), ReasoningMode::Pro);
     }
 
     fn memory_record(id: i64, content: &str) -> MemoryRecord {

--- a/bin/tact/src/tui/components/composer.rs
+++ b/bin/tact/src/tui/components/composer.rs
@@ -1670,6 +1670,7 @@ mod tests {
             (Model::Luna, Color::White),
             (Model::Terra, Color::Green),
             (Model::Sol, Color::Yellow),
+            (Model::Astra, Color::LightMagenta),
         ] {
             let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
             composer.update(ComposerEvent::SetModel(model));

--- a/bin/tact/src/tui/components/model_selector.rs
+++ b/bin/tact/src/tui/components/model_selector.rs
@@ -16,7 +16,7 @@ use ratatui::{
 };
 use std::time::{Duration, Instant};
 
-const MODELS: [Model; 3] = [Model::Luna, Model::Terra, Model::Sol];
+const MODELS: [Model; 4] = [Model::Luna, Model::Terra, Model::Sol, Model::Astra];
 const ANIMATION_DURATION: Duration = Duration::from_millis(280);
 const ANIMATION_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 const KEY_BINDINGS: [(&str, &str); 3] = [("←/→", "model"), ("enter", "apply"), ("esc", "cancel")];
@@ -163,6 +163,7 @@ impl ModelSelector {
             (model_column(left, width, 0), Model::Luna, "Luna"),
             (model_column(left, width, 1), Model::Terra, "Terra"),
             (model_column(left, width, 2), Model::Sol, "Sol"),
+            (model_column(left, width, 3), Model::Astra, "Astra"),
         ];
         for (column, model, label) in labels {
             let label_width = u16::try_from(label.len()).unwrap_or(u16::MAX);
@@ -244,7 +245,7 @@ fn model_index(model: Model) -> usize {
     MODELS
         .iter()
         .position(|candidate| *candidate == model)
-        .unwrap_or(2)
+        .unwrap_or_else(|| unreachable!("closed Model roster must have a selector entry"))
 }
 
 fn model_name(model: Model) -> &'static str {
@@ -252,7 +253,8 @@ fn model_name(model: Model) -> &'static str {
         Model::Luna => "Luna",
         Model::Terra => "Terra",
         Model::Sol => "Sol",
-        _ => "Sol",
+        Model::Astra => "Astra",
+        _ => model.as_str(),
     }
 }
 
@@ -304,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn terra_label_is_centered_under_the_middle_stop() {
+    fn terra_label_is_centered_under_its_stop() {
         let terminal = render(&mut ModelSelector::new(Model::Terra));
         let buffer = terminal.backend().buffer();
         let stop = buffer
@@ -328,9 +330,10 @@ mod tests {
         let mut selector = ModelSelector::new(Model::Sol);
 
         selector.update_key(key(KeyCode::Right), now);
+        assert_eq!(selector.selected, 3);
+        selector.update_key(key(KeyCode::Left), now);
         assert_eq!(selector.selected, 2);
         selector.update_key(key(KeyCode::Left), now);
-        assert_eq!(selector.selected, 1);
         selector.update_key(key(KeyCode::Left), now);
         selector.update_key(key(KeyCode::Left), now);
         assert_eq!(selector.selected, 0);
@@ -343,11 +346,15 @@ mod tests {
         assert_eq!(rendered_label_color(&mut selector, "Luna"), Color::White);
         assert_eq!(rendered_label_color(&mut selector, "Terra"), Color::Green);
         assert_eq!(rendered_label_color(&mut selector, "Sol"), Color::Yellow);
+        assert_eq!(
+            rendered_label_color(&mut selector, "Astra"),
+            Color::LightMagenta
+        );
     }
 
     #[test]
     fn filled_bar_uses_the_selected_model_color() {
-        let mut selector = ModelSelector::new(Model::Sol);
+        let mut selector = ModelSelector::new(Model::Astra);
         let terminal = render(&mut selector);
         let rail = terminal
             .backend()
@@ -358,22 +365,30 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(!rail.is_empty());
-        assert!(rail.iter().all(|cell| cell.fg == Color::Yellow));
+        assert!(rail.iter().all(|cell| cell.fg == Color::LightMagenta));
     }
 
     #[test]
     fn stops_use_the_filled_bar_color_only_when_covered() {
         assert_eq!(
             rendered_stop_colors(&mut ModelSelector::new(Model::Luna)),
-            [Color::DarkGray, Color::DarkGray]
+            [Color::DarkGray, Color::DarkGray, Color::DarkGray]
         );
         assert_eq!(
             rendered_stop_colors(&mut ModelSelector::new(Model::Terra)),
-            [Color::Green, Color::DarkGray]
+            [Color::Green, Color::DarkGray, Color::DarkGray]
         );
         assert_eq!(
             rendered_stop_colors(&mut ModelSelector::new(Model::Sol)),
-            [Color::Yellow, Color::Yellow]
+            [Color::Yellow, Color::Yellow, Color::DarkGray]
+        );
+        assert_eq!(
+            rendered_stop_colors(&mut ModelSelector::new(Model::Astra)),
+            [
+                Color::LightMagenta,
+                Color::LightMagenta,
+                Color::LightMagenta
+            ]
         );
     }
 
@@ -425,6 +440,17 @@ mod tests {
         let update = selector.update_key(key(KeyCode::Enter), now);
 
         assert_eq!(update.effects, [ModelSelectorEffect::Apply(Model::Terra)]);
+    }
+
+    #[test]
+    fn astra_initialization_and_apply_preserve_astra() {
+        let now = Instant::now();
+        let mut selector = ModelSelector::new(Model::Astra);
+
+        assert_eq!(selector.selected, 3);
+        let update = selector.update_key(key(KeyCode::Enter), now);
+
+        assert_eq!(update.effects, [ModelSelectorEffect::Apply(Model::Astra)]);
     }
 
     #[test]

--- a/bin/tact/src/tui/components/root.rs
+++ b/bin/tact/src/tui/components/root.rs
@@ -477,7 +477,6 @@ impl RootNode {
         self.preferred_reasoning_mode = mode;
     }
 
-    #[cfg(test)]
     pub(crate) const fn preferred_reasoning_mode(&self) -> ReasoningMode {
         self.preferred_reasoning_mode
     }
@@ -2958,7 +2957,8 @@ fn model_name(model: Model) -> &'static str {
         Model::Luna => "Luna",
         Model::Terra => "Terra",
         Model::Sol => "Sol",
-        _ => "Sol",
+        Model::Astra => "Astra",
+        _ => model.as_str(),
     }
 }
 

--- a/bin/tact/src/tui/components/subagents.rs
+++ b/bin/tact/src/tui/components/subagents.rs
@@ -1095,7 +1095,8 @@ fn model_name(model: Model) -> &'static str {
         Model::Luna => "Luna",
         Model::Terra => "Terra",
         Model::Sol => "Sol",
-        _ => "Sol",
+        Model::Astra => "Astra",
+        _ => model.as_str(),
     }
 }
 

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         error::{Result, RuntimeError},
         herdr, hook,
     },
-    core::{ConfiguredAgent, extensions::Skill},
+    core::{ConfiguredAgent, extensions::Skill, supported_reasoning_mode},
     tui::{
         agent_events::ForwardedAgentEvent,
         components::{
@@ -489,15 +489,16 @@ pub(crate) async fn run(
             .map_err(RuntimeError::SessionTask)??
         } else {
             let model = fresh_model.expect("a fresh TUI startup must select a model");
+            let reasoning_mode = supported_reasoning_mode(model, preferred_reasoning_mode);
             (
                 ConfiguredAgent::from_config_with_model(
                     &config,
                     initial_effort,
-                    preferred_reasoning_mode,
+                    reasoning_mode,
                     model,
                 )?,
                 None,
-                preferred_reasoning_mode,
+                reasoning_mode,
                 model,
                 1,
             )
@@ -2080,17 +2081,9 @@ fn apply_pane_effect(
         }
         components::RootEffect::SetModel(model) => {
             *context.input = None;
-            let effort = context
-                .app
-                .root(pane)
-                .expect("model pane must exist")
-                .composer()
-                .effort();
-            let reasoning_mode = context
-                .panes
-                .get(&pane)
-                .expect("model pane must have a runtime")
-                .reasoning_mode;
+            let root = context.app.root(pane).expect("model pane must exist");
+            let effort = root.composer().effort();
+            let reasoning_mode = supported_reasoning_mode(model, root.preferred_reasoning_mode());
             let fast_mode = context
                 .panes
                 .get(&pane)
@@ -2220,7 +2213,8 @@ fn apply_pane_effect(
         components::RootEffect::NewSession(model) => {
             *context.input = None;
             let effort = context.config.agent().thinking();
-            let reasoning_mode = context.config.agent().reasoning_mode();
+            let reasoning_mode =
+                supported_reasoning_mode(model, context.config.agent().reasoning_mode());
             let config = context.config.clone();
             *context.new_session_task = Some(tokio::task::spawn_blocking(move || {
                 let fast_mode = config.agent().fast_mode();
@@ -2627,7 +2621,7 @@ async fn prepare_handoff(
     }
 
     let effort = config.agent().thinking();
-    let reasoning_mode = config.agent().reasoning_mode();
+    let reasoning_mode = supported_reasoning_mode(model, config.agent().reasoning_mode());
     let fast_mode = config.agent().fast_mode();
     let task = tokio::task::spawn_blocking(move || {
         ConfiguredAgent::from_config_with_session(
@@ -2823,7 +2817,8 @@ mod tests {
         MemoryCompletion, MemoryOperation, PaneGeneration, PaneSession, PaneSettings,
         PendingSubmission, close_pane_journal, copy_selection_with, invalidate_memory_generations,
         is_image_paste, local_link_path, merge_recent_prompts, next_memory_generation, open_pane,
-        run_memory_operation, send_submission, subagent_pane, validate_interactive,
+        run_memory_operation, send_submission, subagent_pane, supported_reasoning_mode,
+        validate_interactive,
     };
     use crate::{
         app::{
@@ -2845,6 +2840,18 @@ mod tests {
     use tact_memory::{MemoryStore, SelectedMemoryStore};
     use tact_subagents::{AgentId, AgentStatus, AgentUpdate};
     use tempfile::tempdir;
+
+    #[test]
+    fn astra_uses_standard_reasoning_without_changing_other_models() {
+        assert_eq!(
+            supported_reasoning_mode(Model::Astra, ReasoningMode::Pro),
+            ReasoningMode::Standard
+        );
+        assert_eq!(
+            supported_reasoning_mode(Model::Sol, ReasoningMode::Pro),
+            ReasoningMode::Pro
+        );
+    }
 
     #[test]
     fn control_or_super_v_requests_an_image_paste() {

--- a/bin/tact/src/tui/mod.rs
+++ b/bin/tact/src/tui/mod.rs
@@ -914,6 +914,7 @@ pub(crate) async fn run(
                         pane,
                         id,
                         error,
+                        terminal_stop,
                         snapshot,
                         terminal_expected,
                     } => {
@@ -937,13 +938,17 @@ pub(crate) async fn run(
                                 )
                             })
                             .transpose()?;
-                        let event = LocalEvent::WorkerTurnFinished { id, error };
+                        let event = LocalEvent::WorkerTurnFinished { id, error, terminal_stop };
                         let record = match resume_state {
                             Some(resume_state) => runtime
                                 .journal_mut()?
                                 .append_local_with_resume_state(event, resume_state)?,
                             None => runtime.journal_mut()?.append_local(event)?,
                         };
+                        if terminal_stop.is_some() {
+                            // Resume reads must observe the stop before the pane admits another command.
+                            runtime.journal_mut()?.flush().await?;
+                        }
                         schedule(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
                         if let Some(command) = config.agent().completion_hook() {
                             let command = command.to_owned();

--- a/bin/tact/src/tui/session.rs
+++ b/bin/tact/src/tui/session.rs
@@ -4,7 +4,7 @@ use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
     tui::{
         storage::{SessionStorage, StorageError},
-        transcript::{SessionStarted, TranscriptRecord},
+        transcript::{SessionStarted, TerminalStopReason, TranscriptRecord},
     },
 };
 use nanocodex::{Model, agent::session::SessionSnapshot};
@@ -77,6 +77,11 @@ pub(crate) enum SessionError {
     Storage(#[from] StorageError),
     #[error("no resumable state exists for session {session_id}")]
     MissingCheckpoint { session_id: String },
+    #[error("session {session_id} cannot be resumed: {reason}")]
+    TerminalStop {
+        session_id: String,
+        reason: TerminalStopReason,
+    },
     #[error(
         "session {session_id} uses resume-state format {found}; expected {RESUME_STATE_FORMAT_VERSION}"
     )]
@@ -127,14 +132,23 @@ pub(crate) fn load_checkpoint(
     config_path: &Path,
     session_id: &str,
 ) -> Result<ResumeState, SessionError> {
-    let encoded = SessionStorage::open_read_only(config_path)?
-        .ok_or_else(|| SessionError::MissingCheckpoint {
+    let storage = SessionStorage::open_read_only(config_path)?.ok_or_else(|| {
+        SessionError::MissingCheckpoint {
             session_id: session_id.to_owned(),
-        })?
-        .load_resume_state(session_id)?
-        .ok_or_else(|| SessionError::MissingCheckpoint {
+        }
+    })?;
+    if let Some(reason) = storage.terminal_stop(session_id)? {
+        return Err(SessionError::TerminalStop {
             session_id: session_id.to_owned(),
-        })?;
+            reason,
+        });
+    }
+    let encoded =
+        storage
+            .load_resume_state(session_id)?
+            .ok_or_else(|| SessionError::MissingCheckpoint {
+                session_id: session_id.to_owned(),
+            })?;
     let stored =
         serde_json::from_slice::<StoredResumeState>(&encoded).map_err(StorageError::from)?;
     if stored.format_version != RESUME_STATE_FORMAT_VERSION {
@@ -370,7 +384,10 @@ pub(crate) fn format_age(started_at_unix_ms: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{encode_checkpoint, load_checkpoint, load_transcript, model, save_checkpoint};
+    use super::{
+        SessionError, TerminalStopReason, encode_checkpoint, load_checkpoint, load_transcript,
+        model, save_checkpoint,
+    };
     use crate::{
         app::config::{ReasoningEffort, ReasoningMode},
         tui::{
@@ -738,6 +755,7 @@ mod tests {
             .append_local(LocalEvent::WorkerTurnFinished {
                 id: TurnId::new(2),
                 error: Some("API failed".to_owned()),
+                terminal_stop: None,
             })
             .unwrap();
         drop(journal);
@@ -751,6 +769,136 @@ mod tests {
         );
         let records = super::load_transcript(&config, "session").unwrap();
         assert_eq!(records.last().unwrap().kind(), "worker.turn_finished");
+    }
+
+    #[test]
+    fn terminal_provider_stop_blocks_the_last_successful_checkpoint() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let expected = snapshot("successful");
+        save_checkpoint(&config, "session", &expected, "instructions", true).unwrap();
+
+        let terminal_stop = serde_json::from_str::<TranscriptRecord>(
+            &json!({
+                "schema_version": 2,
+                "sequence": 2,
+                "recorded_at_unix_ms": 2,
+                "source": "tact",
+                "type": "worker.turn_finished",
+                "payload": {
+                    "id": 2,
+                    "error": "provider stopped conversation",
+                    "terminal_stop": "misalignment_policy_violation"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let later_failure = TranscriptRecord::from_local(
+            3,
+            3,
+            LocalEvent::WorkerTurnFinished {
+                id: TurnId::new(3),
+                error: Some("agent stopped".to_owned()),
+                terminal_stop: None,
+            },
+        )
+        .unwrap();
+        SessionStorage::open(&config)
+            .unwrap()
+            .append_records(
+                "session",
+                &[
+                    started(1, "session", None, None),
+                    Arc::new(terminal_stop),
+                    Arc::new(later_failure),
+                ],
+            )
+            .unwrap();
+
+        assert!(
+            load_checkpoint(&config, "session").is_err(),
+            "a terminal provider stop must block the retained checkpoint even after a later failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_stop_round_trips_through_the_journal_without_a_checkpoint() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        let (mut journal, writer) = TranscriptJournal::open(&config, "session").unwrap();
+        let start = started(1, "session", None, None);
+        journal.defer_start(start.decode_payload::<SessionStarted>().unwrap());
+        let reason = TerminalStopReason::MisalignmentPolicyViolation;
+        journal
+            .append_local(LocalEvent::WorkerTurnFinished {
+                id: TurnId::new(2),
+                error: Some("provider stopped conversation".to_owned()),
+                terminal_stop: Some(reason),
+            })
+            .unwrap();
+        journal.flush().await.unwrap();
+
+        assert!(matches!(load_checkpoint(&config, "session"),
+            Err(SessionError::TerminalStop { reason: actual, .. }) if actual == reason));
+        let records = load_transcript(&config, "session").unwrap();
+        let payload = records.last().unwrap().decode_payload::<Value>().unwrap();
+        assert_eq!(payload["terminal_stop"], "misalignment_policy_violation");
+        assert_eq!(
+            serde_json::from_value::<TerminalStopReason>(payload["terminal_stop"].clone()).unwrap(),
+            reason
+        );
+        drop(journal);
+        writer.into_task().await.unwrap().unwrap();
+    }
+
+    #[test]
+    fn unknown_terminal_stop_classification_fails_closed() {
+        let directory = tempdir().unwrap();
+        let config = directory.path().join("config.toml");
+        save_checkpoint(
+            &config,
+            "session",
+            &snapshot("successful"),
+            "instructions",
+            true,
+        )
+        .unwrap();
+        let record = TranscriptRecord::from_local(
+            2,
+            2,
+            LocalEvent::WorkerTurnFinished {
+                id: TurnId::new(2),
+                error: Some("provider stopped conversation".to_owned()),
+                terminal_stop: Some(TerminalStopReason::MisalignmentPolicyViolation),
+            },
+        )
+        .unwrap();
+        let mut encoded = serde_json::to_value(record).unwrap();
+        encoded["payload"]["terminal_stop"] = json!("future_provider_stop");
+        let record = serde_json::from_str(&encoded.to_string()).unwrap();
+        let mut storage = SessionStorage::open(&config).unwrap();
+        let expected = storage.load_resume_state("session").unwrap();
+        storage
+            .append_records(
+                "session",
+                &[started(1, "session", None, None), Arc::new(record)],
+            )
+            .unwrap();
+        drop(storage);
+
+        assert!(matches!(
+            load_checkpoint(&config, "session"),
+            Err(SessionError::Storage(_))
+        ));
+        assert_eq!(
+            SessionStorage::open_read_only(&config)
+                .unwrap()
+                .unwrap()
+                .load_resume_state("session")
+                .unwrap(),
+            expected
+        );
     }
 
     #[tokio::test]
@@ -776,6 +924,7 @@ mod tests {
                 LocalEvent::WorkerTurnFinished {
                     id: TurnId::new(1),
                     error: None,
+                    terminal_stop: None,
                 },
                 resume_state,
             )

--- a/bin/tact/src/tui/storage.rs
+++ b/bin/tact/src/tui/storage.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     app::config::{ReasoningEffort, ReasoningMode},
-    tui::transcript::{SCHEMA_VERSION, SessionStarted, TranscriptRecord},
+    tui::transcript::{SCHEMA_VERSION, SessionStarted, TerminalStopReason, TranscriptRecord},
 };
 use rusqlite::{
     Connection, OpenFlags, OptionalExtension, Transaction, ffi::ErrorCode, params,
@@ -424,6 +424,25 @@ impl SessionStorage {
             )
             .map_err(|source| query(&self.path, source))?;
         Ok(())
+    }
+
+    pub(crate) fn terminal_stop(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<TerminalStopReason>, StorageError> {
+        let reason = self.connection.query_row(
+            "SELECT json_quote(json_extract(CAST(record_json AS TEXT), '$.payload.terminal_stop'))
+             FROM events WHERE session_id = ?1
+             AND json_extract(CAST(record_json AS TEXT), '$.source') = 'tact'
+             AND json_extract(CAST(record_json AS TEXT), '$.type') = 'worker.turn_finished'
+             AND json_type(CAST(record_json AS TEXT), '$.payload.terminal_stop') != 'null'
+             ORDER BY event_id LIMIT 1",
+            [session_id],
+            |row| row.get::<_, String>(0),
+        ).optional().map_err(|source| query(&self.path, source))?;
+        reason
+            .map(|reason| serde_json::from_str(&reason).map_err(Into::into))
+            .transpose()
     }
 
     pub(crate) fn load_resume_state(

--- a/bin/tact/src/tui/theme.rs
+++ b/bin/tact/src/tui/theme.rs
@@ -175,7 +175,8 @@ impl Theme {
             Model::Luna => Color::White,
             Model::Terra => Color::Green,
             Model::Sol => Color::Yellow,
-            _ => Color::Yellow,
+            Model::Astra => Color::LightMagenta,
+            _ => Color::White,
         }
     }
 
@@ -393,6 +394,7 @@ mod tests {
         assert_eq!(theme.model(Model::Luna), Color::White);
         assert_eq!(theme.model(Model::Terra), Color::Green);
         assert_eq!(theme.model(Model::Sol), Color::Yellow);
+        assert_eq!(theme.model(Model::Astra), Color::LightMagenta);
     }
 
     #[test]

--- a/bin/tact/src/tui/transcript/journal.rs
+++ b/bin/tact/src/tui/transcript/journal.rs
@@ -572,6 +572,7 @@ mod tests {
             .append_local(LocalEvent::WorkerTurnFinished {
                 id: TurnId::new(1),
                 error: Some("failed".to_owned()),
+                terminal_stop: None,
             })
             .unwrap();
         journal

--- a/bin/tact/src/tui/transcript/mod.rs
+++ b/bin/tact/src/tui/transcript/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use journal::TranscriptJournal;
 pub(crate) use model::TranscriptModel;
 pub(crate) use record::{
     LocalEvent, SCHEMA_VERSION, SessionEnded, SessionOutcome, SessionStarted, ShellId,
-    TranscriptRecord, TurnId,
+    TerminalStopReason, TranscriptRecord, TurnId,
 };
 use std::path::PathBuf;
 use thiserror::Error;

--- a/bin/tact/src/tui/transcript/record.rs
+++ b/bin/tact/src/tui/transcript/record.rs
@@ -51,6 +51,13 @@ pub(crate) enum SessionOutcome {
     Failed,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TerminalStopReason {
+    #[error("provider misalignment policy violation")]
+    MisalignmentPolicyViolation,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct SessionEnded {
     pub(crate) outcome: SessionOutcome,
@@ -102,6 +109,7 @@ pub(crate) enum LocalEvent {
     WorkerTurnFinished {
         id: TurnId,
         error: Option<String>,
+        terminal_stop: Option<TerminalStopReason>,
     },
     WorkerTurnsInterrupted {
         count: usize,
@@ -220,9 +228,17 @@ impl TranscriptRecord {
             LocalEvent::WorkerTurnAccepted { id } => {
                 ("worker.turn_accepted", to_raw_value(&WorkerTurn { id })?)
             }
-            LocalEvent::WorkerTurnFinished { id, error } => (
+            LocalEvent::WorkerTurnFinished {
+                id,
+                error,
+                terminal_stop,
+            } => (
                 "worker.turn_finished",
-                to_raw_value(&WorkerTurnFinished { id, error })?,
+                to_raw_value(&WorkerTurnFinished {
+                    id,
+                    error,
+                    terminal_stop,
+                })?,
             ),
             LocalEvent::WorkerTurnsInterrupted { count, error } => (
                 "worker.turns_interrupted",
@@ -349,6 +365,8 @@ struct WorkerTurnFinished {
     id: TurnId,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    terminal_stop: Option<TerminalStopReason>,
 }
 
 #[derive(Serialize)]

--- a/bin/tact/src/tui/worker.rs
+++ b/bin/tact/src/tui/worker.rs
@@ -759,7 +759,11 @@ async fn start_turn(
         };
         let result = result.map(|result| CompletedTurn {
             final_message: result.final_message().to_owned(),
-            snapshot: (!auxiliary).then(|| Box::new(result.snapshot())),
+            snapshot: if auxiliary {
+                None
+            } else {
+                result.snapshot().map(Box::new)
+            },
         });
         if let Some(agent) = isolated_agent {
             drop(agent.shutdown().await);
@@ -843,7 +847,7 @@ async fn steer_turn(
             turns.spawn(async move {
                 let result = turn.await.map(|result| CompletedTurn {
                     final_message: result.final_message().to_owned(),
-                    snapshot: Some(Box::new(result.snapshot())),
+                    snapshot: result.snapshot().map(Box::new),
                 });
                 (key, TurnPurpose::Conversation, false, result)
             });

--- a/bin/tact/src/tui/worker.rs
+++ b/bin/tact/src/tui/worker.rs
@@ -3,7 +3,12 @@
 use crate::{
     app::config::ReasoningEffort,
     core::{IMAGE_RENDERING_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT},
-    tui::{components::QueueId, pane::PaneId, prompt::Submission, transcript::TurnId},
+    tui::{
+        components::QueueId,
+        pane::PaneId,
+        prompt::Submission,
+        transcript::{TerminalStopReason, TurnId},
+    },
 };
 use nanocodex::{
     AgentEvents, Nanocodex, NanocodexError, TurnControl,
@@ -112,6 +117,7 @@ pub(crate) enum WorkerEvent {
         pane: PaneId,
         id: TurnId,
         error: Option<String>,
+        terminal_stop: Option<TerminalStopReason>,
         snapshot: Option<Box<SessionSnapshot>>,
         terminal_expected: bool,
     },
@@ -785,6 +791,7 @@ fn reject_turn(request: TurnRequest, error: String, updates: &mpsc::UnboundedSen
             pane: request.pane,
             id: request.id,
             error: Some(error),
+            terminal_stop: None,
             snapshot: None,
             terminal_expected: false,
         })),
@@ -914,6 +921,7 @@ fn finish_turn(
                 pane: PaneId::Main,
                 id: TurnId::new(0),
                 error: Some(format!("turn task stopped unexpectedly: {error}")),
+                terminal_stop: None,
                 snapshot: None,
                 terminal_expected: false,
             }));
@@ -924,20 +932,27 @@ fn finish_turn(
     let was_cancelled = cancelled.remove(&key);
     match purpose {
         TurnPurpose::Conversation => {
-            let (error, snapshot) = match result {
-                Ok(completed) => (None, completed.snapshot),
+            let (error, snapshot, terminal_stop) = match result {
+                Ok(completed) => (None, completed.snapshot, None),
                 Err(NanocodexError::TurnCancelled)
                     if shutting_down || was_cancelled || cancelled_by_scope =>
                 {
-                    (None, None)
+                    (None, None, None)
                 }
-                Err(error) => (Some(error.to_string()), None),
+                Err(error) => {
+                    let terminal_stop = error
+                        .responses_error()
+                        .is_some_and(|source| source.is_misalignment_policy_violation())
+                        .then_some(TerminalStopReason::MisalignmentPolicyViolation);
+                    (Some(error.to_string()), None, terminal_stop)
+                }
             };
             drop(updates.send(WorkerEvent::TurnFinished {
                 pane: key.pane,
                 id: key.id,
                 error,
                 snapshot,
+                terminal_stop,
                 terminal_expected: true,
             }));
         }
@@ -1006,22 +1021,30 @@ async fn shutdown_agent(agent: Option<Nanocodex>) -> Result<(), NanocodexError> 
 #[cfg(test)]
 mod tests {
     use super::{
-        MemoryReviewState, ReflectionContext, WorkerCommand, WorkerEvent, reflection_prompt, spawn,
+        MemoryReviewState, ReflectionContext, TurnKey, TurnPurpose, WorkerCommand, WorkerEvent,
+        finish_turn, reflection_prompt, spawn,
     };
     use crate::{
         app::config::ReasoningEffort,
         core::{IMAGE_RENDERING_INSTRUCTIONS, MEMORY_REVIEW_CHECKPOINT},
-        tui::{components::QueueId, pane::PaneId, prompt::Submission, transcript::TurnId},
+        tui::{
+            components::QueueId,
+            pane::PaneId,
+            prompt::Submission,
+            transcript::{TerminalStopReason, TurnId},
+        },
     };
     use nanocodex::{
-        AgentEvents, Nanocodex, OpenAi,
+        AgentEvents, Nanocodex, NanocodexError, OpenAi,
         agent::input::{Prompt, PromptInput, UserInput},
         oai::{
             ResponseError,
-            tower::{ResponsesAttempt, ResponsesServiceResponse},
+            tower::{ResponsesAttempt, ResponsesServiceError, ResponsesServiceResponse},
+            transport::ResponsesError,
         },
     };
     use std::{
+        collections::{HashMap, HashSet},
         future::{Pending, pending},
         path::Path,
         result::Result as StdResult,
@@ -1033,11 +1056,76 @@ mod tests {
         time::Duration,
     };
     use tokio::{
-        sync::{Notify, oneshot},
+        sync::{Notify, mpsc, oneshot},
         time::timeout,
     };
     use tokio_util::sync::CancellationToken;
     use tower::Service;
+
+    #[test]
+    fn terminal_stop_classification_uses_the_typed_provider_code() {
+        let violation = r#"{"error":{"code":"misalignment_policy_violation","message":"conversation stopped"}}"#;
+        let ordinary =
+            r#"{"error":{"code":"server_error","message":"misalignment_policy_violation"}}"#;
+        let cases = [
+            (
+                ResponsesError::Api {
+                    event: violation.to_owned(),
+                },
+                true,
+            ),
+            (
+                ResponsesError::HttpRejected {
+                    status: 403,
+                    body: violation.to_owned(),
+                    retry_after: None,
+                },
+                true,
+            ),
+            (
+                ResponsesError::Api {
+                    event: ordinary.to_owned(),
+                },
+                false,
+            ),
+            (ResponsesError::UnexpectedEnd, false),
+        ];
+        for (source, stopped) in cases {
+            let error =
+                NanocodexError::Response(ResponseError::from(ResponsesServiceError::from(source)));
+            let (updates, mut received) = mpsc::unbounded_channel();
+            finish_turn(
+                Some(Ok((
+                    TurnKey {
+                        pane: PaneId::Main,
+                        id: TurnId::new(1),
+                    },
+                    TurnPurpose::Conversation,
+                    false,
+                    Err(error),
+                ))),
+                false,
+                &mut HashMap::new(),
+                &mut HashSet::new(),
+                &updates,
+            );
+            let WorkerEvent::TurnFinished {
+                error,
+                terminal_stop,
+                snapshot,
+                ..
+            } = received.try_recv().unwrap()
+            else {
+                panic!("expected terminal worker event");
+            };
+            assert!(error.is_some());
+            assert!(snapshot.is_none());
+            assert_eq!(
+                terminal_stop,
+                stopped.then_some(TerminalStopReason::MisalignmentPolicyViolation)
+            );
+        }
+    }
 
     #[derive(Clone)]
     struct PendingService {

--- a/crates/subagents/src/harness.rs
+++ b/crates/subagents/src/harness.rs
@@ -95,7 +95,7 @@ enum HarnessEvent {
     Deferred(Option<DeliveryCommand>),
     Urgent(Option<DeliveryCommand>),
     CapacityChanged,
-    TurnFinished(Result<nanocodex::agent::Result<nanocodex::TurnResult>, JoinError>),
+    TurnFinished(Box<Result<nanocodex::agent::Result<nanocodex::TurnResult>, JoinError>>),
 }
 
 impl HarnessHandle {
@@ -228,7 +228,7 @@ impl Harness {
                 }
                 HarnessEvent::Deferred(None) | HarnessEvent::Urgent(None) => {}
                 HarnessEvent::CapacityChanged => self.start_pending().await,
-                HarnessEvent::TurnFinished(result) => self.turn_finished(result).await,
+                HarnessEvent::TurnFinished(result) => self.turn_finished(*result).await,
             }
         }
     }
@@ -256,7 +256,7 @@ impl Harness {
             command = self.commands.recv() => HarnessEvent::Command(command),
             urgent = self.urgent.recv() => HarnessEvent::Urgent(urgent),
             deferred = self.deferred.recv() => HarnessEvent::Deferred(deferred),
-            result = &mut active.result => HarnessEvent::TurnFinished(result),
+            result = &mut active.result => HarnessEvent::TurnFinished(Box::new(result)),
         }
     }
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -19,9 +19,9 @@ Subagents are enabled by default. They can be disabled explicitly:
 enabled = false
 ```
 
-Disabling the feature removes all subagent tools and Tact's built-in delegation instructions from
-new and restored sessions. It does not disable memory, skills, MCP servers, or ordinary code-mode
-tools.
+Disabling the feature removes all subagent tools and omits Tact's built-in delegation instructions
+from fresh sessions. Resumed parents retain their saved instructions. The setting does not disable
+memory, skills, MCP servers, or ordinary code-mode tools.
 
 The setting applies when an agent runtime is created. Reloading configuration does not mutate the
 tool surface or instructions of an existing runtime. A later new or restored session uses the
@@ -76,8 +76,11 @@ therefore installed independently of the subagent tool group.
 
 ## Clean sessions and output contracts
 
-`spawn_agent` creates a new Nanocodex session through the calling agent's spawn handle. The child
-does not inherit the caller's conversation. Its initial prompt contains:
+`spawn_agent` creates a new Nanocodex session through Tact's configured child factory. The child
+does not inherit the caller's conversation. Each child model's instructions are composed from the
+configuration and skill catalog when the root runtime starts. This includes configured replacement
+and appended instructions. A resumed parent keeps its saved instructions; its new children use
+these freshly composed instructions. Their initial prompt contains:
 
 - the assigned role and task;
 - its agent ID and place in the task tree;
@@ -216,8 +219,8 @@ checked in code.
 
 The implementation preserves these invariants:
 
-- disabling subagents removes both their tools and their fixed delegation instructions;
-- disabling `subagents.allow_luna` removes the explicit Luna choice from the tool and instructions;
+- disabling subagents removes their tools and omits their fixed instructions from fresh sessions;
+- disabling `subagents.allow_luna` removes the explicit Luna choice from the tool and fresh instructions;
 - memory remains independent from the subagent enable switch;
 - every child starts with clean conversation context and a caller-supplied output contract;
 - task-tree scope prevents cross-root access;


### PR DESCRIPTION
## Summary

- Update Nanocodex to `371ed9adf40271f9efa477b6a8a27381d0e2d8e3`, including the Astra changes in [gakonst/nanocodex#275](https://github.com/gakonst/nanocodex/pull/275), and adapt Tact to the upstream APIs.
- Add Astra to the model selector and model-specific presentation. Support `astra` through `--model`, `TACT_MODEL`, and `[agent].model`.
- Default to Astra with low reasoning effort while preserving explicit configuration overrides.
- Compose fresh model-specific instructions for new root sessions and clean children, including Luna children spawned from resumed parents. Resumed roots retain their exact saved instructions; configured custom instructions remain replacements.
- Persist typed terminal provider policy stops and reject subsequent resume attempts, even when an earlier successful checkpoint exists. Keep the transcript readable and retain ordinary failed-turn resume behavior. Historical string-only errors are not retroactively classified.
- Update configuration, subagent, and resume documentation.

## Dependency

This PR remains blocked on a Nanocodex release containing `371ed9adf40271f9efa477b6a8a27381d0e2d8e3`. The dependency is pinned directly to that Git commit until the release is available; update it to the released crate version before marking this PR ready.

Upstream references: [revision comparison](https://github.com/gakonst/nanocodex/compare/4f3344400ee3d2a2446b96e342f8c9871aab9637...371ed9adf40271f9efa477b6a8a27381d0e2d8e3), [model-specific prompt contract](https://github.com/gakonst/nanocodex/blob/371ed9adf40271f9efa477b6a8a27381d0e2d8e3/crates/nanocodex-oai-api/src/openai/config.rs), [instruction tests](https://github.com/gakonst/nanocodex/blob/371ed9adf40271f9efa477b6a8a27381d0e2d8e3/crates/nanocodex-agent/tests/it/model/instructions.rs).

## Remaining Astra work

Per the [pinned Astra capability notes](https://github.com/gakonst/nanocodex/blob/371ed9adf40271f9efa477b6a8a27381d0e2d8e3/docs/GPT_6_ASTRA.md), these are follow-ups outside this PR:

- Nanocodex, then Tact integration: provider-native reasoning configuration updates coordinated with context and compaction policy. Compaction already works; configuration updates have history restrictions.
- Nanocodex, then Tact integration: the full asynchronous tool-call lifecycle, including pending calls, delayed results, cancellation, and recovery.
- Nanocodex, then Tact integration: native mid-response steering and its acknowledgement, interruption, and reconnect semantics. Current steering takes effect at model boundaries.
- Tact: expose the larger context-window setting already supported by the SDK.

## Testing

- `cargo test --workspace --all-features --quiet`: 972 tests passed.
- `cargo check --workspace --all-features`
- `just clippy`
- `just check-fmt`
- Both Tact fixes have regression tests verified to fail before the fix and pass afterward.
- No live provider validation was performed.
